### PR TITLE
Add links and references to missing terminology.

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
         wg:           "W3C Credentials Community Group",
 
         // URI of the public WG page
-        wgURI:        "http://www.w3.org/community/credentials/",
+        wgURI:        "https://www.w3.org/community/credentials/",
 
         // name (with the @w3c.org) of the public mailing to which comments are due
         wgPublicList: "public-credentials",
@@ -91,7 +91,18 @@
         inlineCSS: true
       };
 
-      var includeTerms = [ "identity profile", "entity", "entity credential", "subject", "claim" ];
+      var includeTerms = [
+        "issuer",
+        "inspector",
+        "holder",
+        "credential",
+        "verifiable claim",
+        "identity",
+        "identity profile",
+        "entity",
+        "entity credential",
+        "subject",
+        "claim" ];
     </script>
   </head>
   <body>
@@ -147,49 +158,57 @@ describes how to express that data model in JSON, JSON-LD, and WebIDL.
 <a>Entity credentials</a> refer to an architecture where:
           <ul>
             <li>
-<a>Entity credential</a> holders are positioned in the middle between issuers and inspectors.
+<a>Entity credential</a> holders are positioned in the middle between
+<a>issuers</a> and <a>inspectors</a>.
             </li>
             <li>
-<a>Entity credential</a> holders receive and store credentials from issuers through an
-agent that the issuer does not need to trust.
+<a>Entity credential</a> <a>holders</a> receive and store <a>credentials</a>
+from <a>issuers</a> through an <a>agent</a> that the issuer does not need to
+trust.
             </li>
             <li>
-<a>Entity credential</a> holders provide credentials to credential inspectors through
-an agent that inspectors needn't trust; they only need to trust issuers.
+<a>Entity credential</a> <a>holders</a> provide <a>credentials</a> to
+credential <a>inspectors</a> through an <a>agent</a> that inspectors needn't
+trust; they only need to trust <a>issuers</a>.
             </li>
             <li>
-<a>Entity credentials</a> are associated with identities, not particular services; credential
-holders can decide how to aggregate credentials and manage their own
-identities.
+<a>Entity credentials</a> are associated with <a>identities</a>, not
+particular services; <a>credential</a> <a>holders</a> can decide how to
+aggregate credentials and manage their own identities.
             </li>
             <li>
-<a>Entity credential</a> holders can control and own their own identifiers.
+<a>Entity credential</a> <a>holders</a> can control and own their own
+<a>identifiers</a>.
             </li>
             <li>
-<a>Entity credential</a> holders can control which credentials to use and when.
+<a>Entity credential</a> <a>holders</a> can control which
+<a>credentials</a> to use and when.
             </li>
             <li>
-<a>Entity credential</a> holders may freely choose and swap out the agents they employ to
-help them manage and share their credentials.
+<a>Entity credential</a> <a>holders</a> may freely choose and swap out the
+<a>agents</a> they employ to help them manage and share their
+<a>credentials</a>.
             </li>
             <li>
-<a>Entity credential</a> holders that share verifiable claims are not required to reveal the
-identity of the inspector to their agent or to issuers.
+<a>Entity credential</a> <a>holders</a> that share <a>verifiable claims</a>
+are not required to reveal the <a>identity</a> of the <a>inspector</a> to
+their <a>agent</a> or to <a>issuers</a>.
             </li>
           </ul>
         </li>
         <li>
-A standard, machine-readable data format for expressing <a>entity credentials</a>
-that can be extended with minimal coordination.
+A standard, machine-readable data format for expressing
+<a>entity credentials</a> that can be extended with minimal coordination.
         </li>
         <li>
-Independent issuance, storage, and cryptographic verification of <a>entity credentials</a>.
+Independent issuance, storage, and cryptographic verification of
+<a>entity credentials</a>.
         </li>
         <li>
 A standard mechanism for requesting <a>entity credentials</a>.
         </li>
         <li>
-The ability to revoke previously issued <a>entity credentials</a>.
+The ability to <a>revoke</a> previously issued <a>entity credentials</a>.
         </li>
         <li>
 Web Browser APIs for storing and consuming <a>entity credentials</a>.


### PR DESCRIPTION
The terminology section needs to be updated as it's fallen out of date. Don't merge yet, still a WIP.