### PR TITLE
Comment out WebIDL section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1088,6 +1088,11 @@ of verfiable claims about a particular <a>subject</a>.
 }</pre>
         </section>
       </section -->
+      <p class="issue" data-number="54" data-title="Should spec include WebIDL and XML expressions">
+The group is currently considering which expressions of the data model should
+be listed in the spec. WebIDL and XML are two of the expressions that are
+being considered.
+      </p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -805,7 +805,7 @@ of verifiable claims about a particular <a>subject</a>.
         </section>
       </section>
 
-      <section>
+      <!-- section>
         <h2>Expressing Identity Profiles, Entity Credentials, and
         Verifiable Claims in WebIDL</h2>
 
@@ -1087,7 +1087,7 @@ of verfiable claims about a particular <a>subject</a>.
   vc.signature = signature;
 }</pre>
         </section>
-      </section>
+      </section -->
     </section>
 
     <section>


### PR DESCRIPTION
I expect this PR to be somewhat controversial. Here's the reasoning behind it:

There has been a tendancy in the Web Payments WG to use the WebIDL in a spec to throw errors if the data doesn't EXACTLY match the WebIDL. This means that browser implementations will throw errors if new data is added or existing data is not there. This creates an extensibility problem as the browsers shouldn't be making the decision on whether or not to forward data, the end applications (issuer, holder, and inspector) should make that determination.

The WebIDL is also the source of MANY errors in the spec. While those errors can be cleaned up, I think the group should have a conversation about whether or not to include WebIDL as an expression format. We should talk about which formats we may work on. For example, the financial services and retail industry is still very heavily XML-based and will be for the forseeable future. The cost of upgrading is too high in that community, so should we have an XML representation?

For those reasons, I think we should push a more conservative spec out there, not include WebIDL or XML, until the group understands what it wants to include.

I also thought about pulling the JSON-LD stuff out to a separate spec, but we need to discuss that in more detail as well. 

This PR just does the easiest thing and comments out (does not delete) the WebIDL section.