### PR TITLE
Restructure spec to describe basic concepts and verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,12 @@
         inlineCSS: true
       };
     </script>
+    <style>
+pre .highlight {
+  font-weight: bold;
+  color: green;
+}
+</style>
   </head>
   <body>
     <section id='abstract'>
@@ -368,7 +374,7 @@ make grasping the basic concepts more difficult.
     </section>
 
     <section>
-      <h2>Data Model</h2>
+      <h2>Core Data Model</h2>
       <p>This section describes a data model for <a>entity
       profiles</a> and <a>entity credentials</a>, the latter covering
       both claims and verifiable claims, that is compatible with the
@@ -505,9 +511,24 @@ make grasping the basic concepts more difficult.
           a representation of the signing date.</dd>
         </dl>
       </section>
+    </section>
+
+    <section>
+      <h1>Basic Concepts</h1>
+      <section>
+        <h2>Issuer</h2>
+      </section>
 
       <section>
-        <h2>Revocation Model</h2>
+        <h2>Signature</h2>
+      </section>
+
+      <section>
+        <h2>Expiration</h2>
+      </section>
+
+      <section>
+        <h2>Revocation</h2>
         <p>Revocation information for the claims in the
         Verifiable Claims Model may be provided by adding the
         following <a>property</a>:
@@ -527,6 +548,72 @@ make grasping the basic concepts more difficult.
 The group is currently determining whether or not they should publish a
 very simple scheme for revocation as a part of this specification.
         </p>
+      </section>
+
+    </section>
+
+    <section>
+      <h1>Verification</h1>
+
+      <p>
+This section describes a number of checks required to verify a claim.
+Some checks are essential for all verifiable claims, while some are
+applicable to only some claims.
+      </p>
+      <section>
+        <h3>Structural Validity</h3>
+        <ul>
+          <li>Document is valid JSON-LD.</li>
+          <li>Required properties are present. For example, for a
+          Credential, <code>type</code> and <code>claim</code> are
+          required.</li>
+          <li>Property values match expectations described in the
+          specification. For example, the document type for a verifiable
+          claim must contain the class "Credential".</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Entity Validity</h3>
+        <p>
+A number of checks must be implemented to ensure a set of entities related
+to a Credential have mutually compatible properties and are trustworthy.
+        </p>
+        <ul>
+          <li>The <code>issuer</code> id must match expectations. Likely,
+          that means it is the id of a known and trusted <a>entity
+          profile</a>.</li>
+          <li>The claim subject identifier must match expectations.
+          Likely, that means it is the id of a known and trusted
+          <a>entity profile </a> for the subject of the claim. If the
+          entity that is subject of a claim has transmitted it to the
+          inspector-verifier, the subject may be able to prove ownership of key
+          identifying properties such as email address(es) and public
+          key(s).</li>
+          <li>The <code>issued</code> date must be in the expected range.
+          For example, an inspector-verifier may wish to ensure that the recorded
+          issued date of valid claims is not in the future.</li>
+          <li>The document signature is available in the form of a known
+          signature suite.</li>
+          <li>The public key associated with the signature is available
+          and a trustworthy link between this signing key and the
+          issuer's <a>entity profile</a> may be established.</li>
+          <li>If revocation instructions are present, the claim must not
+          have been revoked.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Fitness for Purpose</h3>
+        <ul>
+          <li>The custom properties in the <a>claim</a> should be
+          appropriate for the inspector-verifier's purpose. For example if an
+          inspector-verifier needs to determine that a subject is older than 21
+          years of age, they may accept claims of specific birthdate or
+          abstract properties such as <code>ageOver</code>.</li>
+          <li>The issuer is trusted by the inspector-verifier to make the claims
+          at hand. For example, Fast Food Resturant A will not be trusted
+          to make a claim that an individual may enjoy a lifetime 10%
+          discount to its competitor Fast Food Restaurant B.</li>
+        </ul>
       </section>
     </section>
 
@@ -1632,70 +1719,6 @@ Time periods should be shorter for highly dynamic information.
       </section>
     </section>
 
-    <section>
-      <h2>Verification</h2>
-
-      <p>
-This section describes a number of checks required to verify a claim.
-Some checks are essential for all verifiable claims, while some are
-applicable to only some claims.
-      </p>
-      <section>
-        <h3>Structural Validity</h3>
-        <ul>
-          <li>Document is valid JSON-LD.</li>
-          <li>Required properties are present. For example, for a
-          Credential, <code>type</code> and <code>claim</code> are
-          required.</li>
-          <li>Property values match expectations described in the
-          specification. For example, the document type for a verifiable
-          claim must contain the class "Credential".</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Entity Validity</h3>
-        <p>
-A number of checks must be implemented to ensure a set of entities related
-to a Credential have mutually compatible properties and are trustworthy.
-        </p>
-        <ul>
-          <li>The <code>issuer</code> id must match expectations. Likely,
-          that means it is the id of a known and trusted <a>entity
-          profile</a>.</li>
-          <li>The claim subject identifier must match expectations.
-          Likely, that means it is the id of a known and trusted
-          <a>entity profile </a> for the subject of the claim. If the
-          entity that is subject of a claim has transmitted it to the
-          inspector-verifier, the subject may be able to prove ownership of key
-          identifying properties such as email address(es) and public
-          key(s).</li>
-          <li>The <code>issued</code> date must be in the expected range.
-          For example, an inspector-verifier may wish to ensure that the recorded
-          issued date of valid claims is not in the future.</li>
-          <li>The document signature is available in the form of a known
-          signature suite.</li>
-          <li>The public key associated with the signature is available
-          and a trustworthy link between this signing key and the
-          issuer's <a>entity profile</a> may be established.</li>
-          <li>If revocation instructions are present, the claim must not
-          have been revoked.</li>
-        </ul>
-      </section>
-      <section>
-        <h3>Fitness for Purpose</h3>
-        <ul>
-          <li>The custom properties in the <a>claim</a> should be
-          appropriate for the inspector-verifier's purpose. For example if an
-          inspector-verifier needs to determine that a subject is older than 21
-          years of age, they may accept claims of specific birthdate or
-          abstract properties such as <code>ageOver</code>.</li>
-          <li>The issuer is trusted by the inspector-verifier to make the claims
-          at hand. For example, Fast Food Resturant A will not be trusted
-          to make a claim that an individual may enjoy a lifetime 10%
-          discount to its competitor Fast Food Restaurant B.</li>
-        </ul>
-      </section>
-    </section>
   </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -517,6 +517,39 @@ make grasping the basic concepts more difficult.
       <h1>Basic Concepts</h1>
       <section>
         <h2>Issuer</h2>
+        <p>
+Issuer information may be expressed via the following <a>properties</a>:
+        </p>
+        <dl>
+          <dt><var>issuer</var></dt>
+          <dd>
+The value of this property MUST be a URI. It is RECOMMENDED that dereferencing
+the URI results in a document containing machine-readable information about
+the issuer that may be used to verify the information expressed in the
+<a>credential</a>.
+          </dd>
+          <dt><var>issued</var></dt>
+          <dd>
+The value of this property MUST be a string value of an [ISO8601] combined
+date and time string and represents the date and time the <a>credential</a>
+was issued. Note that this date represents the earliest date when the
+information associated with the <var>claim</var> property became valid.
+          </dd>
+        </dl>
+        <pre class="example nohighlight" title="foo">
+{
+  "@context": "https://w3id.org/security/v1",
+  "id": "http://dmv.example.gov/credentials/3732",
+  "type": ["Credential", "ProofOfAgeCredential"],
+  <span class="highlight">"issuer": "https://dmv.example.gov/issuers/14"</span>,
+  <span class="highlight">"issued": "2010-01-01T19:73:24Z"</span>,
+  "claim": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "ageOver": 21
+  },
+  "signature": { ... }
+}
+        </pre>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -811,7 +811,6 @@ applicable to only some claims.
           the use of the <a>credential</a>, e.g. intended
           <a>inspector-verifiers</a>, restricted usage rights, etc., that this
           policy is adhered to.</li>
-          </li>
         </ul>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -536,7 +536,7 @@ was issued. Note that this date represents the earliest date when the
 information associated with the <var>claim</var> property became valid.
           </dd>
         </dl>
-        <pre class="example nohighlight" title="foo">
+        <pre class="example nohighlight" title="Usage of issuer properties">
 {
   "@context": "https://w3id.org/security/v1",
   "id": "http://dmv.example.gov/credentials/3732",
@@ -581,7 +581,27 @@ information associated with the <var>claim</var> property became valid.
 The group is currently determining whether or not they should publish a
 very simple scheme for revocation as a part of this specification.
         </p>
+
+        <pre class="example nohighlight" title="Usage of revocation property">
+{
+  "@context": "https://w3id.org/security/v1",
+  "id": "http://dmv.example.gov/credentials/3732",
+  "type": ["Credential", "ProofOfAgeCredential"],
+  "issuer": "https://dmv.example.gov/issuers/14",
+  "issued": "2010-01-01T19:73:24Z",
+  "claim": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "ageOver": 21
+  },
+  <span class="highlight">"revocation": {
+    "id": "https://dmv.example.gov/revocation/24,
+    "type": "RevocationList2017"
+  }</span>,
+  "signature": { ... }
+}
+        </pre>
       </section>
+
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@ the issuer that may be used to verify the information expressed in the
           </dd>
           <dt><var>issued</var></dt>
           <dd>
-The value of this property MUST be a string value of an [ISO8601] combined
+The value of this property MUST be a string value of an [[!ISO8601]] combined
 date and time string and represents the date and time the <a>credential</a>
 was issued. Note that this date represents the earliest date when the
 information associated with the <var>claim</var> property became valid.
@@ -558,6 +558,35 @@ information associated with the <var>claim</var> property became valid.
 
       <section>
         <h2>Expiration</h2>
+        <p>
+Expiration information for the <a>credential</a> MAY be provided by adding
+the following <a>property</a>:
+        </p>
+
+        <dl>
+          <dt><var>expires</var></dt>
+          <dd>
+The value of this property MUST be a string value of an [[!ISO8601]] combined
+date and time string and represents the date and time the <a>credential</a>
+will cease to be valid.
+          </dd>
+        </dl>
+
+        <pre class="example nohighlight" title="Usage of revocation property">
+{
+  "@context": "https://w3id.org/security/v1",
+  "id": "http://dmv.example.gov/credentials/3732",
+  "type": ["Credential", "ProofOfAgeCredential"],
+  "issuer": "https://dmv.example.gov/issuers/14",
+  "issued": "2010-01-01T19:73:24Z",
+  <span class="highlight">"expires": "2020-01-01T19:73:24Z"</span>,
+  "claim": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "ageOver": 21
+  },
+  "signature": { ... }
+}
+        </pre>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -661,6 +661,10 @@ very simple scheme for revocation as a part of this specification.
 }
         </pre>
       </section>
+    </section>
+
+    <section>
+      <h1>Advanced Concepts</h1>
 
       <section>
         <h2>Evidence</h2>

--- a/index.html
+++ b/index.html
@@ -722,9 +722,14 @@ Some checks are essential for all verifiable claims, while some are
 applicable to only some claims.
       </p>
       <section>
-        <h3>Structural Validity</h3>
+        <h3>Syntax</h3>
         <ul>
-          <li>Document is valid JSON-LD.</li>
+          <li>Document is syntactically valid (e.g. JSON, JSON-LD).</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Credential</h3>
+        <ul>
           <li>Required properties are present. For example, for a
           Credential, <code>type</code> and <code>claim</code> are
           required.</li>
@@ -734,17 +739,18 @@ applicable to only some claims.
         </ul>
       </section>
       <section>
-        <h3>Entity Validity</h3>
-        <p>
-A number of checks must be implemented to ensure a set of entities related
-to a Credential have mutually compatible properties and are trustworthy.
-        </p>
+        <h3>Issuer</h3>
         <ul>
           <li>The <code>issuer</code> id must match expectations. Likely,
           that means it is the id of a known and trusted <a>entity
           profile</a>.</li>
           <li>Recent metadata about the <code>issuer</code> which was published
           by the issuer MUST be available.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Subject</h3>
+        <ul>
           <li>The claim subject identifier must match expectations.
           Likely, that means it is the id of a known and trusted
           <a>entity profile </a> for the subject of the claim. If the
@@ -752,15 +758,35 @@ to a Credential have mutually compatible properties and are trustworthy.
           inspector-verifier, the subject may be able to prove ownership of key
           identifying properties such as email address(es) and public
           key(s).</li>
-          <li>The <code>issued</code> date must be in the expected range.
-          For example, an inspector-verifier may wish to ensure that the recorded
-          issued date of valid claims is not in the future.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Signature</h3>
+        <ul>
           <li>The document signature is available in the form of a known
           signature suite.</li>
+          <li>Required signature properties are present. For example, for a
+          Linked Data Signature, <code>type</code>, <code>created</code>,
+          <code>creator></code>, and <code>signatureValue</code> are present.
+          </li>
           <li>The public key associated with the signature is available
           and a trustworthy link between this signing key and the
           issuer's <a>entity profile</a> may be established. The key must
           not be revoked or expired.</li>
+          <li>The cryptographic signature is valid.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Expiration</h3>
+        <ul>
+          <li>The <code>issued</code> date must be in the expected range.
+          For example, an inspector-verifier may wish to ensure that the recorded
+          issued date of valid claims is not in the future.</li>
+        </ul>
+      </section>
+      <section>
+        <h3>Revocation</h3>
+        <ul>
           <li>If revocation instructions are present, the claim must not
           have been revoked.</li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -538,7 +538,6 @@ information associated with the <var>claim</var> property became valid.
         </dl>
         <pre class="example nohighlight" title="Usage of issuer properties">
 {
-  "@context": "https://w3id.org/security/v1",
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["Credential", "ProofOfAgeCredential"],
   <span class="highlight">"issuer": "https://dmv.example.gov/issuers/14"</span>,
@@ -554,6 +553,40 @@ information associated with the <var>claim</var> property became valid.
 
       <section>
         <h2>Signature</h2>
+        <p>
+A <a>credential</a> MAY be made verifiable by adding the following
+<a>property</a>:
+        </p>
+        <dl>
+          <dt><var>signature</var></dt>
+          <dd>
+The method used for a signature will vary byrepresentation language.  However,
+this property is expected to have a value that is a set of name-value pairs
+including at least a signature, a reference to the signing entity, and
+a representation of the signing date.</dd>
+        </dl>
+        <pre class="example nohighlight" title="Usage of signature property">
+{
+  "id": "http://example.gov/credentials/3732",
+  "type": ["Credential", "ProofOfAgeCredential"],
+  "issuer": "https://dmv.example.gov",
+  "issued": "2010-01-01",
+  "claim": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "ageOver": 21
+  },
+  <span class="highlight">"signature": {
+    "type": "LinkedDataSignature2017",
+    "created": "2017-06-18T21:19:10Z",
+    "creator": "https://example.com/jdoe/keys/1",
+    "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
+    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
+    PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
+    +W3JT24="
+  }</span>
+}
+        </pre>
       </section>
 
       <section>
@@ -572,9 +605,8 @@ will cease to be valid.
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of revocation property">
+        <pre class="example nohighlight" title="Usage of expires property">
 {
-  "@context": "https://w3id.org/security/v1",
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["Credential", "ProofOfAgeCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",
@@ -613,7 +645,6 @@ very simple scheme for revocation as a part of this specification.
 
         <pre class="example nohighlight" title="Usage of revocation property">
 {
-  "@context": "https://w3id.org/security/v1",
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["Credential", "ProofOfAgeCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",
@@ -654,7 +685,6 @@ very simple scheme for evidence as a part of this specification.
 
         <pre class="example nohighlight" title="Usage of evidence property">
 {
-  "@context": "https://w3id.org/security/v1",
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["Credential", "ProofOfAgeCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",

--- a/index.html
+++ b/index.html
@@ -743,6 +743,8 @@ to a Credential have mutually compatible properties and are trustworthy.
           <li>The <code>issuer</code> id must match expectations. Likely,
           that means it is the id of a known and trusted <a>entity
           profile</a>.</li>
+          <li>Recent metadata about the <code>issuer</code> which was published
+          by the issuer MUST be available.</li>
           <li>The claim subject identifier must match expectations.
           Likely, that means it is the id of a known and trusted
           <a>entity profile </a> for the subject of the claim. If the
@@ -757,7 +759,8 @@ to a Credential have mutually compatible properties and are trustworthy.
           signature suite.</li>
           <li>The public key associated with the signature is available
           and a trustworthy link between this signing key and the
-          issuer's <a>entity profile</a> may be established.</li>
+          issuer's <a>entity profile</a> may be established. The key must
+          not be revoked or expired.</li>
           <li>If revocation instructions are present, the claim must not
           have been revoked.</li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -602,6 +602,51 @@ very simple scheme for revocation as a part of this specification.
         </pre>
       </section>
 
+      <section>
+        <h2>Evidence</h2>
+        <p>Evidence information for the claims in the
+        Verifiable Claims Model may be provided by adding the
+        following <a>property</a>:
+        </p>
+
+        <dl>
+          <dt><var>evidence</var></dt>
+          <dd>The value of this property MUST be one or more evidence schemes
+            that provides enough information to a <a>inspector-verifier</a>
+            to determine whether or not the evidence gathered meets their
+            requirements.
+          </dd>
+        </dl>
+
+        <p class="issue" data-title="Define ONE concrete format for the evidence parameter ">
+The group is currently determining whether or not they should publish a
+very simple scheme for evidence as a part of this specification.
+        </p>
+
+        <pre class="example nohighlight" title="Usage of evidence property">
+{
+  "@context": "https://w3id.org/security/v1",
+  "id": "http://dmv.example.gov/credentials/3732",
+  "type": ["Credential", "ProofOfAgeCredential"],
+  "issuer": "https://dmv.example.gov/issuers/14",
+  "issued": "2010-01-01T19:73:24Z",
+  "claim": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "ageOver": 21
+  },
+  <span class="highlight">"evidence": {
+    "id": "https://dmv.example.gov/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
+    "type": "DocumentVerification",
+    "verifier": "https://dmv.example.gov/issuers/14",
+    "evidenceDocument": "DriversLicense",
+    "subjectPresence": "Physical",
+    "documentPresence": "Physical"
+  }</span>,
+  "signature": { ... }
+}
+        </pre>
+
+      </section>
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -803,6 +803,15 @@ applicable to only some claims.
           at hand. For example, Fast Food Resturant A will not be trusted
           to make a claim that an individual may enjoy a lifetime 10%
           discount to its competitor Fast Food Restaurant B.</li>
+          <li>If the <a>issuer</a> has placed any policy information about
+          the use of the <a>credential</a>, e.g. intended
+          <a>inspector-verifiers</a>, expiration date, etc., that this
+          policy is adhered to.</li>
+          <li>If the <a>holder</a> has placed any policy information about
+          the use of the <a>credential</a>, e.g. intended
+          <a>inspector-verifiers</a>, restricted usage rights, etc., that this
+          policy is adhered to.</li>
+          </li>
         </ul>
       </section>
     </section>


### PR DESCRIPTION
Per my action item from last week's call, I've restructured the spec to contain "basic concepts", "advanced concepts" and "verification" sections. Laying the specification out in this way enables us to neatly answer a number of the questions that @ChristopherA raised in #59.

This restructuring has also led to the ability to simplify the core data model section, which will be done in a separate PR. For the time being, ignore the Core Data Model section, and focus on the "Basic Concepts", "Advanced Concepts", and "Verification" sections in the spec. Don't worry about typos/prose for now, this PR is just to test out the new layout for the spec to see if it resonates with the group.

You can preview this PR here:

https://htmlpreview.github.io/?https://github.com/w3c/vc-data-model/blob/msporny-verification/index.html

/cc @ChristopherA @kimdhamilton