### PR TITLE
Add section on Verifiable Profiles to Basic Concepts

### DIFF
--- a/common.js
+++ b/common.js
@@ -36,6 +36,16 @@ var vcwg = {
       status: "CG-DRAFT",
       publisher: "Credentials Community Group"
     },
+    "LD-PROOFS": {
+      title: "Linked Data Proofs",
+      href: "https://w3c-ccg.github.io/ld-proofs/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley"
+      ],
+      status: "CG-DRAFT",
+      publisher: "Credentials Community Group"
+    },
     // aliases to known references
     "HTTP-SIGNATURES": {
       aliasOf: "http-signatures"

--- a/index.html
+++ b/index.html
@@ -658,6 +658,33 @@ of scope for this specification. A status scheme registry [[VC-STATUS-REGISTRY]]
 exists for implementers that would like to implement credential status checking.
         </p>
       </section>
+
+      <section>
+        <h2>Profiles</h2>
+        <p>
+Credentials MAY be composed by placing them into a data structure called a
+<a>profile</a>. A <a>verifiable profile</a> is a profile that contains
+<a>verifiable credentials</a> and one or more proofs that are appropriate
+for the profile. The basic structure of a <a>verifiable profile</a>
+is provided below:
+        </p>
+
+        <pre class="example nohighlight" title="Basic structure of a profile">
+{
+  "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+  "type": ["VerifiableProfile"],
+  <span class="highlight">"verifiableCredential": [{ ... }],
+  "proof": [{ ... }]</span>
+}
+        </pre>
+
+        <p>
+The contents of the <code>verifiableCredential</code> property are
+<a>verifiable credentials</a> as described by this specification. The contents
+of the <code>proof</code> property are proofs as described by the
+Linked Data Proofs [[LD-PROOFS]] specification.
+        </p>
+      </section>
     </section>
 
     <section>
@@ -845,11 +872,11 @@ applicable to only some credentials.
       <section>
         <h3>Signatures / Proofs</h3>
         <ul>
-          <li>The document signature is available in the form of a known
-          signature suite.</li>
-          <li>Required signature properties are present. For example, for a
+          <li>The document proof is available in the form of a known
+          proof suite.</li>
+          <li>Required proof properties are present. For example, for a
           Linked Data Signature, <code>type</code>, <code>created</code>,
-          <code>creator></code>, and <code>signatureValue</code> are present.
+          <code>creator></code>, and <code>proofValue</code> are present.
           </li>
           <li>The public key associated with the signature is available
           and a trustworthy link between this signing key and the
@@ -1715,12 +1742,12 @@ are replaced by short-lived, single use bearer tokens.
 
         <p>
 The contents of verifiable credentials are secured via the
-<code>credential.signature</code> field. The properties in this field
+<code>credential.proof</code> field. The properties in this field
 create a danger of correlation when the same values are used across more than
 one session or domain and the value does not change. Examples include the
 <code>creator</code>, <code>created</code>,
 <code>domain</code> (for very specific domains),
-<code>nonce</code>, and <code>signatureValue</code> fields.
+<code>nonce</code>, and <code>proofValue</code> fields.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@ signing entity, and a representation of the signing date.</dd>
     "created": "2017-06-18T21:19:10Z",
     "creator": "https://example.com/jdoe/keys/1",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
       MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
       PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
       +W3JT24="
@@ -1000,7 +1000,7 @@ applicable to only some credentials.
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "598c63d6",
-    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
     MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
     PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
     +W3JT24="
@@ -1108,7 +1108,7 @@ of <a>claims</a> about a particular <a>subject</a> as a
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "783b4dfa",
-    "proofValue": "Rxj7Kb/tDbGHFAs6ddHjVLsHDiNyYzxs2MPmNG8G47oS06N8i0Dis5mUePIzII4+p/ewcOTjvH7aJxnKEePCO9IrlqaHnO1TfmTut2rvXxE5JNzur0qoNq2yXl+TqUWmDXoHZF+jQ7gCsmYqTWhhsG5ufo9oyqDMzPoCb9ibsNk="
+    "signatureValue": "Rxj7Kb/tDbGHFAs6ddHjVLsHDiNyYzxs2MPmNG8G47oS06N8i0Dis5mUePIzII4+p/ewcOTjvH7aJxnKEePCO9IrlqaHnO1TfmTut2rvXxE5JNzur0qoNq2yXl+TqUWmDXoHZF+jQ7gCsmYqTWhhsG5ufo9oyqDMzPoCb9ibsNk="
   }
 }</pre>
         </section>
@@ -1149,7 +1149,7 @@ of <a>claims</a> about a particular <a>subject</a> as a
       "created": "2017-06-17T10:03:48Z",
       "creator": "https://dmv.example.gov/issuers/14/keys/234",
       "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-      "proofValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
+      "signatureValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
       ibcC1wpsMCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuF
       zvueMWmFPRdW+gGsutPTLhwYmfIFpbBu95t501+rSLHIEuujM/+PXr+W3JT24
       9Cky6Ed="
@@ -1160,7 +1160,7 @@ of <a>claims</a> about a particular <a>subject</a> as a
     "created": "2017-06-18T21:19:10Z",
     "creator": "did:example:ebfeb1f712ebc6f1c276e12ec21/keys/2",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
     MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
     PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
     +W3JT24="
@@ -1239,7 +1239,7 @@ of <a>claims</a> about a particular <a>subject</a> as a
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "6165d7e8",
-    "proofValue": "g4j9UrpHM4/uu32NlTw0HDaSaYF2sykskfuByD7UbuqEcJIKa+IoLJLrLjqDnMz0adwpBCHWaqqpnd47r0NKZbnJarGYrBFcRTwPQSeqGwac8E2SqjylTBbSGwKZkprEXTywyV7gILlC8a+naA7lBRi4y29FtcUJBTFQq4R5XzI="
+    "signatureValue": "g4j9UrpHM4/uu32NlTw0HDaSaYF2sykskfuByD7UbuqEcJIKa+IoLJLrLjqDnMz0adwpBCHWaqqpnd47r0NKZbnJarGYrBFcRTwPQSeqGwac8E2SqjylTBbSGwKZkprEXTywyV7gILlC8a+naA7lBRi4y29FtcUJBTFQq4R5XzI="
   }
 }</pre>
 
@@ -1289,7 +1289,7 @@ The following example demonstrates how to express a more complex
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "c168dfab",
-    "proofValue": "jz4bEW2FBMDkANyEjiPnrIctucHQCIwxrtzBXt+rVGmYMEflHrOwf7FYLH60E3Oz54VwSSQCi9J4tXQIhv4SofT5opbcIUj7ji6QrC6c+a3YLjg8l/+/uFjhzsLelAO4gh2k0FJxM04ljH0GZGuXTzhRnqTzJTnYSVo72PC92NA="
+    "signatureValue": "jz4bEW2FBMDkANyEjiPnrIctucHQCIwxrtzBXt+rVGmYMEflHrOwf7FYLH60E3Oz54VwSSQCi9J4tXQIhv4SofT5opbcIUj7ji6QrC6c+a3YLjg8l/+/uFjhzsLelAO4gh2k0FJxM04ljH0GZGuXTzhRnqTzJTnYSVo72PC92NA="
   }
 }</pre>
         </section>
@@ -1330,7 +1330,7 @@ The following example demonstrates how to express a more complex
       "created": "2017-06-17T10:03:48Z",
       "creator": "https://dmv.example.gov/issuers/14/keys/234",
       "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-      "proofValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
+      "signatureValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
       ibcC1wpsMCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuF
       zvueMWmFPRdW+gGsutPTLhwYmfIFpbBu95t501+rSLHIEuujM/+PXr+W3JT24
       9Cky6Ed="
@@ -1341,7 +1341,7 @@ The following example demonstrates how to express a more complex
     "created": "2017-06-18T21:19:10Z",
     "creator": "did:example:ebfeb1f712ebc6f1c276e12ec21/keys/2",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
     MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
     PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
     +W3JT24="

--- a/index.html
+++ b/index.html
@@ -876,7 +876,7 @@ applicable to only some credentials.
           proof suite.</li>
           <li>Required proof properties are present. For example, for a
           Linked Data Signature, <code>type</code>, <code>created</code>,
-          <code>creator</code>, and <code>proofValue</code> are present.
+          <code>creator</code>, and <code>signatureValue</code> are present.
           </li>
           <li>The public key associated with the signature is available
           and a trustworthy link between this signing key and the
@@ -1747,7 +1747,7 @@ create a danger of correlation when the same values are used across more than
 one session or domain and the value does not change. Examples include the
 <code>creator</code>, <code>created</code>,
 <code>domain</code> (for very specific domains),
-<code>nonce</code>, and <code>proofValue</code> fields.
+<code>nonce</code>, and <code>signatureValue</code> fields.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@ signing entity, and a representation of the signing date.</dd>
     "created": "2017-06-18T21:19:10Z",
     "creator": "https://example.com/jdoe/keys/1",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
       MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
       PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
       +W3JT24="
@@ -876,7 +876,7 @@ applicable to only some credentials.
           proof suite.</li>
           <li>Required proof properties are present. For example, for a
           Linked Data Signature, <code>type</code>, <code>created</code>,
-          <code>creator></code>, and <code>proofValue</code> are present.
+          <code>creator</code>, and <code>proofValue</code> are present.
           </li>
           <li>The public key associated with the signature is available
           and a trustworthy link between this signing key and the
@@ -995,12 +995,12 @@ applicable to only some credentials.
     "type": "SimpleRevocationList2017"
   },
   "proof": {
-    "type": "LinkedDataSignature2015",
+    "type": "RsaSignature2018",
     "created": "2016-06-18T21:19:10Z",
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "598c63d6",
-    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
     MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
     PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
     +W3JT24="
@@ -1103,12 +1103,12 @@ of <a>claims</a> about a particular <a>subject</a> as a
     }
   },
   "proof": {
-    "type": "LinkedDataSignature2015",
+    "type": "RsaSignature2018",
     "created": "2016-06-21T03:40:19Z",
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "783b4dfa",
-    "signatureValue": "Rxj7Kb/tDbGHFAs6ddHjVLsHDiNyYzxs2MPmNG8G47oS06N8i0Dis5mUePIzII4+p/ewcOTjvH7aJxnKEePCO9IrlqaHnO1TfmTut2rvXxE5JNzur0qoNq2yXl+TqUWmDXoHZF+jQ7gCsmYqTWhhsG5ufo9oyqDMzPoCb9ibsNk="
+    "proofValue": "Rxj7Kb/tDbGHFAs6ddHjVLsHDiNyYzxs2MPmNG8G47oS06N8i0Dis5mUePIzII4+p/ewcOTjvH7aJxnKEePCO9IrlqaHnO1TfmTut2rvXxE5JNzur0qoNq2yXl+TqUWmDXoHZF+jQ7gCsmYqTWhhsG5ufo9oyqDMzPoCb9ibsNk="
   }
 }</pre>
         </section>
@@ -1149,7 +1149,7 @@ of <a>claims</a> about a particular <a>subject</a> as a
       "created": "2017-06-17T10:03:48Z",
       "creator": "https://dmv.example.gov/issuers/14/keys/234",
       "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-      "signatureValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
+      "proofValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
       ibcC1wpsMCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuF
       zvueMWmFPRdW+gGsutPTLhwYmfIFpbBu95t501+rSLHIEuujM/+PXr+W3JT24
       9Cky6Ed="
@@ -1160,7 +1160,7 @@ of <a>claims</a> about a particular <a>subject</a> as a
     "created": "2017-06-18T21:19:10Z",
     "creator": "did:example:ebfeb1f712ebc6f1c276e12ec21/keys/2",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
     MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
     PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
     +W3JT24="
@@ -1234,12 +1234,12 @@ of <a>claims</a> about a particular <a>subject</a> as a
     "ageOver": 21
   },
   "proof": {
-    "type": "LinkedDataSignature2015",
+    "type": "RsaSignature2018",
     "created": "2016-06-18T21:10:38Z",
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "6165d7e8",
-    "signatureValue": "g4j9UrpHM4/uu32NlTw0HDaSaYF2sykskfuByD7UbuqEcJIKa+IoLJLrLjqDnMz0adwpBCHWaqqpnd47r0NKZbnJarGYrBFcRTwPQSeqGwac8E2SqjylTBbSGwKZkprEXTywyV7gILlC8a+naA7lBRi4y29FtcUJBTFQq4R5XzI="
+    "proofValue": "g4j9UrpHM4/uu32NlTw0HDaSaYF2sykskfuByD7UbuqEcJIKa+IoLJLrLjqDnMz0adwpBCHWaqqpnd47r0NKZbnJarGYrBFcRTwPQSeqGwac8E2SqjylTBbSGwKZkprEXTywyV7gILlC8a+naA7lBRi4y29FtcUJBTFQq4R5XzI="
   }
 }</pre>
 
@@ -1284,12 +1284,12 @@ The following example demonstrates how to express a more complex
     }
   },
   "proof": {
-    "type": "LinkedDataSignature2015",
+    "type": "RsaSignature2018",
     "created": "2016-06-21T03:43:29Z",
     "creator": "https://example.com/jdoe/keys/1",
     "domain": "json-ld.org",
     "nonce": "c168dfab",
-    "signatureValue": "jz4bEW2FBMDkANyEjiPnrIctucHQCIwxrtzBXt+rVGmYMEflHrOwf7FYLH60E3Oz54VwSSQCi9J4tXQIhv4SofT5opbcIUj7ji6QrC6c+a3YLjg8l/+/uFjhzsLelAO4gh2k0FJxM04ljH0GZGuXTzhRnqTzJTnYSVo72PC92NA="
+    "proofValue": "jz4bEW2FBMDkANyEjiPnrIctucHQCIwxrtzBXt+rVGmYMEflHrOwf7FYLH60E3Oz54VwSSQCi9J4tXQIhv4SofT5opbcIUj7ji6QrC6c+a3YLjg8l/+/uFjhzsLelAO4gh2k0FJxM04ljH0GZGuXTzhRnqTzJTnYSVo72PC92NA="
   }
 }</pre>
         </section>
@@ -1330,7 +1330,7 @@ The following example demonstrates how to express a more complex
       "created": "2017-06-17T10:03:48Z",
       "creator": "https://dmv.example.gov/issuers/14/keys/234",
       "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-      "signatureValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
+      "proofValue": "pYw8XNi1bgVg/sCneO4BavEll0/I1zJugez8RwDg/+
       ibcC1wpsMCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuF
       zvueMWmFPRdW+gGsutPTLhwYmfIFpbBu95t501+rSLHIEuujM/+PXr+W3JT24
       9Cky6Ed="
@@ -1341,7 +1341,7 @@ The following example demonstrates how to express a more complex
     "created": "2017-06-18T21:19:10Z",
     "creator": "did:example:ebfeb1f712ebc6f1c276e12ec21/keys/2",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "signatureValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
+    "proofValue": "BavEll0/I1zpYw8XNi1bgVg/sCneO4Jugez8RwDg/+
     MCRVpjOboDoe4SxxKjkCOvKiCHGDvc4krqi6Z1n0UfqzxGfmatCuFibcC1wps
     PRdW+gGsutPTLzvueMWmFhwYmfIFpbBu95t501+rSLHIEuujM/+PXr9Cky6Ed
     +W3JT24="
@@ -1519,7 +1519,7 @@ interface EntityProfile {
   claim.ageOver = 21;
 
   var signature = new Signature();
-  signature.type = "LinkedDataSignature2015";
+  signature.type = "RsaSignature2018";
   signature.created = "2016-06-18T21:10:38Z";
   signature.creator = "https://example.com/jdoe/keys/1";
   signature.domain = "json-ld.org";
@@ -1616,7 +1616,7 @@ of verfiable claims about a particular <a>subject</a>.
   claim.passport = passport;
 
   var signature = new Signature();
-  signature.type = "LinkedDataSignature2015";
+  signature.type = "RsaSignature2018";
   signature.created = "2016-06-21T03:43:29Z";
   signature.creator = "https://example.com/jdoe/keys/1";
   signature.domain = "json-ld.org";


### PR DESCRIPTION
Don't know why this went as long as it did undetected, but we didn't have a formal definition of what constitutes a Verifiable Profile in the spec. This is now fixed.

/cc @dlongley @burnburn @gkellogg @talltree