### PR TITLE
Add useful links to WG home and related repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ and Pull Requests in the GitHub repository, discussions often occur
 on the
 [public-vc-wg](http://lists.w3.org/Archives/Public/public-vc-wg/)
 mailing list as well.
+
+## Verifiable Claims Working Group
+* Group page: [https://www.w3.org/2017/vc/WG/](https://www.w3.org/2017/vc/WG/)
+* charter: [https://www.w3.org/2017/vc/WG/charter.html](https://www.w3.org/2017/vc/WG/charter.html)
+* Chairs
+** Matt Stone, Pearson @stonematt
+** Richard Varn, ETS @rvanr
+** Dan Burnet @burnburn
+
+### Verifiable Claims github repos
+* [Data Model](https://github.com/w3c/vc-data-model)
+* [Use Cases](https://github.com/w3c/vc-use-cases)
+
+### Other useful links
+* [Public group email archive](https://lists.w3.org/Archives/Public/public-vc-wg/)


### PR DESCRIPTION
Add links to WG home, charter, related repos, public mail archive and name the chairs.