### PR TITLE
Add section on Trust Model to the specification.

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,6 +513,56 @@ that are often, but not required to be, related.
     </section>
 
     <section>
+      <h1>Trust Model</h1>
+
+      <p>
+The Verifiable Credentials trust model is as follows:
+      </p>
+
+      <ol>
+        <li>
+The <a>verifier</a> trusts the <a>issuer</a> to issue the Verifiable Credential
+that it receives. This trust could be weakened depending upon the risk
+assessment of the verifier.
+        </li>
+        <li>
+All entities trust the <a>identifier registry</a> to be un-corruptible and
+to be a correct record of which identifiers belong to which <a>entities</a>.
+        </li>
+        <li>
+The <a>subject</a> trusts the <a>issuer</a> to issue true (i.e. not false)
+<a>credentials</a> about the subject, and to revoke them quickly when
+appropriate.
+        </li>
+        <li>
+The <a>holder</a> trusts the <a>repository</a> to store the
+<a>credentials</a> securely, to not release them to anyone other than the
+<a>holder</a>, and to not corrupt or lose them whilst they are in its care.
+        </li>
+      </ol>
+
+      <p>
+This trust model differentiates itself from other trust models by ensuring that:
+      </p>
+
+      <ul>
+        <li>
+The <a>issuer</a> and the <a>verifier</a> do not need to trust the
+repository</a>, and
+        </li>
+        <li>
+the <a>issuer</a> does not need to trust the <a>verifier</a>.
+        </li>
+      </ul>
+
+      <p>
+By decoupling the trust between the <a>identity provider</a> and the
+<a>relying party</a>, a more flexible and dynamic trust model is created
+such that market competition and customer choice is increased.
+      </p>
+    </section>
+
+    <section>
       <h1>Basic Concepts</h1>
       <section>
         <h2>Issuer</h2>

--- a/terms.html
+++ b/terms.html
@@ -73,6 +73,16 @@ Registries typically mediate the creation and verification of <a>subject</a>
 identifiers. Some registries, such as ones for UUIDs and public keys, act
 merely as namespaces for identifiers.
   </dd>
+  <dt><dfn data-lt="identity providers|idp">identity provider</dfn></dt>
+  <dd>
+An identity provider, sometimes abbreviated as <em>IdP</em> is a system
+that creates, maintains, and manages identity information for <a>holders</a>
+while providing authentication services to <a>relying party</a> applications
+within a federation or distributed network. This specification does not use
+this term unless comparing or mapping the concepts in this document to
+other specifications. This specification decouples the identity provider
+concept into two distinct concepts: the <a>issuer</a>, and the <a>holder</a>.
+  </dd>
   <dt><dfn data-lt="issuers|issuer's">issuer</dfn></dt>
   <dd>
 An <a>entity</a> that creates a <a>verifiable credential</a>, associates it
@@ -106,6 +116,7 @@ communication between <a>holders</a>, <a>issuers</a> and
   <dt><dfn data-lt="verifier|verifiers|verifier's|credential verifiers|credential verifier's">verifier</dfn></dt>
   <dd>
 An <a>entity</a> that receives one or more <a>profiles</a> for
-processing.
+processing. Other specifications may refer to this concept as a
+<dfn data-lt="relying parties">relying party</dfn>.
   </dd>
 </dl>

--- a/terms.html
+++ b/terms.html
@@ -78,10 +78,14 @@ merely as namespaces for identifiers.
 An identity provider, sometimes abbreviated as <em>IdP</em> is a system
 that creates, maintains, and manages identity information for <a>holders</a>
 while providing authentication services to <a>relying party</a> applications
-within a federation or distributed network. This specification does not use
-this term unless comparing or mapping the concepts in this document to
-other specifications. This specification decouples the identity provider
-concept into two distinct concepts: the <a>issuer</a>, and the <a>holder</a>.
+within a federation or distributed network. In this case the
+<a>holder</a> is always the <a>subject</a>. Even if the credentials are bearer
+credentials the assumption is that they will remain with the subject,
+and if they are not, then they have been stolen by an attacker. This
+specification does not use this term unless comparing or mapping the concepts
+in this document to other specifications. This specification decouples the
+identity provider concept into two distinct concepts: the <a>issuer</a>,
+and the <a>holder</a>.
   </dd>
   <dt><dfn data-lt="issuers|issuer's">issuer</dfn></dt>
   <dd>


### PR DESCRIPTION
This PR adds a section on the Trust Model to the specification, which uses a modified version of @David-Chadwick's text. Fixes #110.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/131.html" title="Last updated on Apr 18, 2018, 10:15 PM GMT (95d30d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/131/bdb0974...95d30d1.html" title="Last updated on Apr 18, 2018, 10:15 PM GMT (95d30d1)">Diff</a>