### PR TITLE
Update vocabulary based on changes to data model document.

### DIFF
--- a/vocab/context.jsonld
+++ b/vocab/context.jsonld
@@ -1,99 +1,67 @@
 {
-  "@context": {
-    "id": "@id",
-    "type": "@type",
-    "cred": "https://w3id.org/credentials#",
-    "dc": "http://purl.org/dc/terms/",
-    "schema": "http://schema.org/",
-    "sec": "https://w3id.org/security#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "CryptographicKey": "sec:Key",
-    "GraphSignature2012": "sec:GraphSignature2012",
-    "Identity": "https://w3id.org/identity#Identity",
-    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
-    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
-    "created": {
-      "@id": "dc:created",
-      "@type": "xsd:dateTime"
+  "@context": [
+    {
+      "@version": 1.1
     },
-    "creator": {
-      "@id": "dc:creator",
-      "@type": "@id"
-    },
-    "domain": "sec:domain",
-    "expires": {
-      "@id": "sec:expiration",
-      "@type": "xsd:dateTime"
-    },
-    "nonce": "sec:nonce",
-    "owner": {
-      "@id": "sec:owner",
-      "@type": "@id"
-    },
-    "privateKey": {
-      "@id": "sec:privateKey",
-      "@type": "@id"
-    },
-    "privateKeyPem": "sec:privateKeyPem",
-    "proof": "sec:proof",
-    "publicKey": {
-      "@id": "sec:publicKey",
-      "@container": "@graph",
-      "@type": "@id"
-    },
-    "publicKeyPem": "sec:publicKeyPem",
-    "publicKeyService": {
-      "@id": "sec:publicKeyService",
-      "@type": "@id"
-    },
-    "revoked": {
-      "@id": "sec:revoked",
-      "@type": "xsd:dateTime"
-    },
-    "signature": "sec:signature",
-    "signatureAlgorithm": "sec:signatureAlgorithm",
-    "signatureValue": "sec:signatureValue",
-    "Credential": "cred:Credential",
-    "Policy": "cred:Policy",
-    "VerifiableProfile": "cred:VerifiableProfile",
-    "claim": {
-      "@id": "cred:claim",
-      "@container": "@graph",
-      "@type": "@id"
-    },
-    "credential": {
-      "@id": "cred:credential",
-      "@type": "@id",
-      "@container": "@graph"
-    },
-    "credentialStatus": {
-      "@id": "cred:credentialStatus",
-      "@type": "@id"
-    },
-    "evidence": {
-      "@id": "cred:evidence",
-      "@type": "@id"
-    },
-    "issued": {
-      "@id": "cred:issued",
-      "@type": "xsd:dateTime"
-    },
-    "issuer": {
-      "@id": "cred:issuer",
-      "@type": "@id"
-    },
-    "revocation": {
-      "@id": "cred:revocation",
-      "@type": "@id"
-    },
-    "termsOfUse": {
-      "@id": "cred:termsOfUse",
-      "@type": "@id"
-    },
-    "verifiableCredential": {
-      "@id": "cred:verifiableCredential",
-      "@type": "@id",
-      "@container": "@graph"
+    "https://w3id.org/security/v1",
+    {
+      "id": "@id",
+      "type": "@type",
+      "cred": "https://w3id.org/credentials#",
+      "dc": "http://purl.org/dc/terms/",
+      "schema": "http://schema.org/",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "Identity": "https://w3id.org/identity#Identity",
+      "created": {
+        "@id": "dc:created",
+        "@type": "xsd:dateTime"
+      },
+      "creator": {
+        "@id": "dc:creator",
+        "@type": "@id"
+      },
+      "Credential": "cred:Credential",
+      "Policy": "cred:Policy",
+      "VerifiableProfile": "cred:VerifiableProfile",
+      "claim": {
+        "@id": "cred:claim",
+        "@container": "@graph",
+        "@type": "@id"
+      },
+      "credential": {
+        "@id": "cred:credential",
+        "@type": "@id",
+        "@container": "@graph"
+      },
+      "credentialStatus": {
+        "@id": "cred:credentialStatus",
+        "@type": "@id"
+      },
+      "evidence": {
+        "@id": "cred:evidence",
+        "@type": "@id"
+      },
+      "issued": {
+        "@id": "cred:issued",
+        "@type": "xsd:dateTime"
+      },
+      "issuer": {
+        "@id": "cred:issuer",
+        "@type": "@id"
+      },
+      "revocation": {
+        "@id": "cred:revocation",
+        "@type": "@id"
+      },
+      "termsOfUse": {
+        "@id": "cred:termsOfUse",
+        "@type": "@id"
+      },
+      "verifiableCredential": {
+        "@id": "cred:verifiableCredential",
+        "@type": "@id",
+        "@container": "@graph"
+      }
     }
-  }
+  ]
 }

--- a/vocab/context.jsonld
+++ b/vocab/context.jsonld
@@ -22,8 +22,8 @@
     },
     "domain": "sec:domain",
     "expires": {
-      "@id": "sec:expiration",
-      "@type": "xsd:dateTime"
+      "@id": "cred:expires",
+      "@type": "@id"
     },
     "nonce": "sec:nonce",
     "owner": {
@@ -52,9 +52,8 @@
     "signatureAlgorithm": "sec:signatureAlgorithm",
     "signatureValue": "sec:signatureValue",
     "Credential": "cred:Credential",
-    "CryptographicKeyCredential": "cred:CryptographicKeyCredential",
-    "Profile": "cred:Profile",
-    "RevocationList2017": "cred:RevocationList2017",
+    "Policy": "cred:Policy",
+    "VerifiableProfile": "cred:VerifiableProfile",
     "claim": {
       "@id": "cred:claim",
       "@container": "@graph"
@@ -63,6 +62,13 @@
       "@id": "cred:credential",
       "@type": "@id",
       "@container": "@graph"
+    },
+    "credentialStatus": {
+      "@id": "cred:credentialStatus",
+      "@type": "@id"
+    },
+    "entity": {
+      "@id": "cred:entity"
     },
     "evidence": {
       "@id": "cred:evidence",
@@ -76,15 +82,20 @@
       "@id": "cred:issuer",
       "@type": "@id"
     },
-    "recipient": {
-      "@id": "cred:recipient",
+    "proof": {
+      "@id": "cred:proof",
       "@type": "@id"
-    },
-    "referenceId": {
-      "@id": "cred:referenceId"
     },
     "revocation": {
       "@id": "cred:revocation",
+      "@type": "@id"
+    },
+    "termsOfUse": {
+      "@id": "cred:termsOfUse",
+      "@type": "@id"
+    },
+    "verifiableCredential": {
+      "@id": "cred:verifiableCredential",
       "@type": "@id"
     }
   }

--- a/vocab/context.jsonld
+++ b/vocab/context.jsonld
@@ -22,8 +22,8 @@
     },
     "domain": "sec:domain",
     "expires": {
-      "@id": "cred:expires",
-      "@type": "@id"
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
     },
     "nonce": "sec:nonce",
     "owner": {
@@ -35,8 +35,10 @@
       "@type": "@id"
     },
     "privateKeyPem": "sec:privateKeyPem",
+    "proof": "sec:proof",
     "publicKey": {
       "@id": "sec:publicKey",
+      "@container": "@graph",
       "@type": "@id"
     },
     "publicKeyPem": "sec:publicKeyPem",
@@ -56,7 +58,8 @@
     "VerifiableProfile": "cred:VerifiableProfile",
     "claim": {
       "@id": "cred:claim",
-      "@container": "@graph"
+      "@container": "@graph",
+      "@type": "@id"
     },
     "credential": {
       "@id": "cred:credential",
@@ -66,9 +69,6 @@
     "credentialStatus": {
       "@id": "cred:credentialStatus",
       "@type": "@id"
-    },
-    "entity": {
-      "@id": "cred:entity"
     },
     "evidence": {
       "@id": "cred:evidence",
@@ -82,10 +82,6 @@
       "@id": "cred:issuer",
       "@type": "@id"
     },
-    "proof": {
-      "@id": "cred:proof",
-      "@type": "@id"
-    },
     "revocation": {
       "@id": "cred:revocation",
       "@type": "@id"
@@ -96,7 +92,8 @@
     },
     "verifiableCredential": {
       "@id": "cred:verifiableCredential",
-      "@type": "@id"
+      "@type": "@id",
+      "@container": "@graph"
     }
   }
 }

--- a/vocab/credentials.html
+++ b/vocab/credentials.html
@@ -9,7 +9,7 @@ var respecConfig = {
     localBiblio: opencreds.localBiblio,
     specStatus:  "base",
     shortName:   "vc-vocab",
-    publishDate: "2018-03-22",
+    publishDate: "2018-03-23",
     thisVersion: "http://w3id.org/credentials",
     doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
@@ -86,7 +86,7 @@ var respecConfig = {
         <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2018-03-22</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2018-03-23</time></dd>
         <dt>Imports:</dt>
           <dd><a href="http://purl.org/dc/terms/" property="owl:imports">http://purl.org/dc/terms/</a></dd>
           <dd><a href="https://w3id.org/security" property="owl:imports">https://w3id.org/security</a></dd>
@@ -182,13 +182,6 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">entity</td>
-          <td resource="cred:entity" typeof="rdf:Property">
-            <em property="rdfs:label">entity</em>
-            <p property="rdfs:comment">A thing with distinct and independent existence such as a person, organization, concept, or device.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-          </td>
-        </tr>
         <tr><td class="bold">evidence</td>
           <td resource="cred:evidence" typeof="rdf:Property">
             <em property="rdfs:label">evidence</em>
@@ -197,19 +190,6 @@ var respecConfig = {
               <dl class="terms">
                   <dt>rdfs:range</dt>
                       <dd property="rdfs:range" resource="cred:DocumentationVerifier">cred:DocumentationVerifier</dd>
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">expires</td>
-          <td resource="cred:expires" typeof="rdf:Property">
-            <em property="rdfs:label">expires</em>
-            <p property="rdfs:comment">The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="xsd:dateTime">xsd:dateTime</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
               </dl>
@@ -236,21 +216,6 @@ var respecConfig = {
               <dl class="terms">
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
-              </dl>
-          </td>
-        </tr>
-        <tr><td class="bold">proof</td>
-          <td resource="cred:proof" typeof="rdf:Property">
-            <em property="rdfs:label">proof</em>
-            <p property="rdfs:comment">The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date.</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="_:">
-                        Union of
-                        <span property="owl:unionOf" inlist=true resource="cred:Credential">cred:Credential</span>
-                        <span property="owl:unionOf" inlist=true resource="cred:VerifiableProfile">cred:VerifiableProfile</span>
-                      </dd>
               </dl>
           </td>
         </tr>
@@ -331,6 +296,7 @@ var respecConfig = {
         <dt>claim</dt>
         <dd>
             cred:claim
+            with string values interpreted as @id
               with array values interpreted as @graph
         </dd>
         <dt>created</dt>
@@ -366,10 +332,6 @@ var respecConfig = {
         <dd>
             sec:domain
         </dd>
-        <dt>entity</dt>
-        <dd>
-            cred:entity
-        </dd>
         <dt>evidence</dt>
         <dd>
             cred:evidence
@@ -377,8 +339,8 @@ var respecConfig = {
         </dd>
         <dt>expires</dt>
         <dd>
-            cred:expires
-            with string values interpreted as @id
+            sec:expiration
+            with string values interpreted as xsd:dateTime
         </dd>
         <dt>id</dt>
         <dd>
@@ -414,13 +376,13 @@ var respecConfig = {
         </dd>
         <dt>proof</dt>
         <dd>
-            cred:proof
-            with string values interpreted as @id
+            sec:proof
         </dd>
         <dt>publicKey</dt>
         <dd>
             sec:publicKey
             with string values interpreted as @id
+              with array values interpreted as @graph
         </dd>
         <dt>publicKeyPem</dt>
         <dd>
@@ -474,6 +436,7 @@ var respecConfig = {
         <dd>
             cred:verifiableCredential
             with string values interpreted as @id
+              with array values interpreted as @graph
         </dd>
         <dt>xsd</dt>
         <dd>

--- a/vocab/credentials.html
+++ b/vocab/credentials.html
@@ -9,7 +9,7 @@ var respecConfig = {
     localBiblio: opencreds.localBiblio,
     specStatus:  "base",
     shortName:   "vc-vocab",
-    publishDate: "2018-03-23",
+    publishDate: "2018-04-01",
     thisVersion: "http://w3id.org/credentials",
     doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
@@ -86,7 +86,7 @@ var respecConfig = {
         <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2018-03-23</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2018-04-01</time></dd>
         <dt>Imports:</dt>
           <dd><a href="http://purl.org/dc/terms/" property="owl:imports">http://purl.org/dc/terms/</a></dd>
           <dd><a href="https://w3id.org/security" property="owl:imports">https://w3id.org/security</a></dd>
@@ -265,21 +265,9 @@ var respecConfig = {
         <dd>
             cred:Credential
         </dd>
-        <dt>CryptographicKey</dt>
-        <dd>
-            sec:Key
-        </dd>
-        <dt>GraphSignature2012</dt>
-        <dd>
-            sec:GraphSignature2012
-        </dd>
         <dt>Identity</dt>
         <dd>
             https://w3id.org/identity#Identity
-        </dd>
-        <dt>LinkedDataSignature2015</dt>
-        <dd>
-            sec:LinkedDataSignature2015
         </dd>
         <dt>Policy</dt>
         <dd>
@@ -288,10 +276,6 @@ var respecConfig = {
         <dt>VerifiableProfile</dt>
         <dd>
             cred:VerifiableProfile
-        </dd>
-        <dt>canonicalizationAlgorithm</dt>
-        <dd>
-            sec:canonicalizationAlgorithm
         </dd>
         <dt>claim</dt>
         <dd>
@@ -328,19 +312,10 @@ var respecConfig = {
         <dd>
             http://purl.org/dc/terms/
         </dd>
-        <dt>domain</dt>
-        <dd>
-            sec:domain
-        </dd>
         <dt>evidence</dt>
         <dd>
             cred:evidence
             with string values interpreted as @id
-        </dd>
-        <dt>expires</dt>
-        <dd>
-            sec:expiration
-            with string values interpreted as xsd:dateTime
         </dd>
         <dt>id</dt>
         <dd>
@@ -356,72 +331,14 @@ var respecConfig = {
             cred:issuer
             with string values interpreted as @id
         </dd>
-        <dt>nonce</dt>
-        <dd>
-            sec:nonce
-        </dd>
-        <dt>owner</dt>
-        <dd>
-            sec:owner
-            with string values interpreted as @id
-        </dd>
-        <dt>privateKey</dt>
-        <dd>
-            sec:privateKey
-            with string values interpreted as @id
-        </dd>
-        <dt>privateKeyPem</dt>
-        <dd>
-            sec:privateKeyPem
-        </dd>
-        <dt>proof</dt>
-        <dd>
-            sec:proof
-        </dd>
-        <dt>publicKey</dt>
-        <dd>
-            sec:publicKey
-            with string values interpreted as @id
-              with array values interpreted as @graph
-        </dd>
-        <dt>publicKeyPem</dt>
-        <dd>
-            sec:publicKeyPem
-        </dd>
-        <dt>publicKeyService</dt>
-        <dd>
-            sec:publicKeyService
-            with string values interpreted as @id
-        </dd>
         <dt>revocation</dt>
         <dd>
             cred:revocation
             with string values interpreted as @id
         </dd>
-        <dt>revoked</dt>
-        <dd>
-            sec:revoked
-            with string values interpreted as xsd:dateTime
-        </dd>
         <dt>schema</dt>
         <dd>
             http://schema.org/
-        </dd>
-        <dt>sec</dt>
-        <dd>
-            https://w3id.org/security#
-        </dd>
-        <dt>signature</dt>
-        <dd>
-            sec:signature
-        </dd>
-        <dt>signatureAlgorithm</dt>
-        <dd>
-            sec:signatureAlgorithm
-        </dd>
-        <dt>signatureValue</dt>
-        <dd>
-            sec:signatureValue
         </dd>
         <dt>termsOfUse</dt>
         <dd>

--- a/vocab/credentials.html
+++ b/vocab/credentials.html
@@ -7,10 +7,11 @@
     <script class="remove">
 var respecConfig = {
     localBiblio: opencreds.localBiblio,
-    specStatus: "base",
-    shortName: "vc-vocab",
-    publishDate:  "2017-12-01",
-    thisVersion:    "http://w3id.org/credentials",
+    specStatus:  "base",
+    shortName:   "vc-vocab",
+    publishDate: "2018-03-22",
+    thisVersion: "http://w3id.org/credentials",
+    doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
     // lcEnd: "3000-01-01",
     // crEnd: "3000-01-01",
@@ -85,7 +86,7 @@ var respecConfig = {
         <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2017-12-01</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2018-03-22</time></dd>
         <dt>Imports:</dt>
           <dd><a href="http://purl.org/dc/terms/" property="owl:imports">http://purl.org/dc/terms/</a></dd>
           <dd><a href="https://w3id.org/security" property="owl:imports">https://w3id.org/security</a></dd>
@@ -126,33 +127,18 @@ var respecConfig = {
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
           </td>
         </tr>
-        <tr><td class="bold">CryptographicKeyCredential</td>
-          <td resource="cred:CryptographicKeyCredential" typeof="rdfs:Class">
-            <em property="rdfs:label">Cryptographic Key Credential</em>
-            <p property="rdfs:comment">FIXME</p>
+        <tr><td class="bold">Policy</td>
+          <td resource="cred:Policy" typeof="rdfs:Class">
+            <em property="rdfs:label">Policy</em>
+            <p property="rdfs:comment">Issue: The group is currently exploring a variety of ways of expressing the terms of use associated with a Verifiable Credential, namely, the Open Digital Rights Language.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subClassOf</dt>
-                      <dd property="rdfs:subClassOf" resource="cred:Credential">cred:Credential</dd>
-              </dl>
           </td>
         </tr>
-        <tr><td class="bold">Profile</td>
-          <td resource="cred:Profile" typeof="rdfs:Class">
+        <tr><td class="bold">VerifiableProfile</td>
+          <td resource="cred:VerifiableProfile" typeof="rdfs:Class">
             <em property="rdfs:label">Verifiable Profile</em>
-            <p property="rdfs:comment">A set of one or more `credentials` typically related to the same `subject`. An entity may have multiple `profiles` and each `profile` may contain `verifiable credentials` issued by multiple issuers. A `verifiable profile` is a `profile` that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`.</p>
+            <p property="rdfs:comment">A `verifiable profile` is a profile that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
-          </td>
-        </tr>
-        <tr><td class="bold">RevocationList2017</td>
-          <td resource="cred:RevocationList2017" typeof="rdfs:Class">
-            <em property="rdfs:label">Revocation List 2017</em>
-            <p property="rdfs:comment">FIXME</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
-              <dl class="terms">
-                  <dt>rdfs:subClassOf</dt>
-                      <dd property="rdfs:subClassOf" resource="cred:RevocationList2017">cred:RevocationList2017</dd>
-              </dl>
           </td>
         </tr>
       </table>
@@ -164,7 +150,7 @@ var respecConfig = {
         <tr><td class="bold">claim</td>
           <td resource="cred:claim" typeof="rdf:Property">
             <em property="rdfs:label">claim</em>
-            <p property="rdfs:comment">A statement made about a `subject`. A **verifiable claim** is a claim that is tamper-resistant and whose authorship can be cryptographically verified.</p>
+            <p property="rdfs:comment">A statement made about a `subject`.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:domain</dt>
@@ -181,8 +167,26 @@ var respecConfig = {
                   <dt>rdfs:range</dt>
                       <dd property="rdfs:range" resource="cred:Credential">cred:Credential</dd>
                   <dt>rdfs:domain</dt>
-                      <dd property="rdfs:domain" resource="cred:Profile">cred:Profile</dd>
+                      <dd property="rdfs:domain" resource="cred:VerifiableProfile">cred:VerifiableProfile</dd>
               </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">credentialStatus</td>
+          <td resource="cred:credentialStatus" typeof="rdf:Property">
+            <em property="rdfs:label">credential status</em>
+            <p property="rdfs:comment">The value of this property MUST be a status scheme that provides enough information to determine the current status of the credential (e.g. suspended, revoked, etc.). The status scheme will vary depending on a variety of factors, such as whether it is simple to implement or privacy-enhancing.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">entity</td>
+          <td resource="cred:entity" typeof="rdf:Property">
+            <em property="rdfs:label">entity</em>
+            <p property="rdfs:comment">A thing with distinct and independent existence such as a person, organization, concept, or device.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
           </td>
         </tr>
         <tr><td class="bold">evidence</td>
@@ -193,6 +197,19 @@ var respecConfig = {
               <dl class="terms">
                   <dt>rdfs:range</dt>
                       <dd property="rdfs:range" resource="cred:DocumentationVerifier">cred:DocumentationVerifier</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">expires</td>
+          <td resource="cred:expires" typeof="rdf:Property">
+            <em property="rdfs:label">expires</em>
+            <p property="rdfs:comment">The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="xsd:dateTime">xsd:dateTime</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
               </dl>
@@ -214,7 +231,7 @@ var respecConfig = {
         <tr><td class="bold">issuer</td>
           <td resource="cred:issuer" typeof="rdf:Property">
             <em property="rdfs:label">issuer</em>
-            <p property="rdfs:comment">An `entit`y that creates a `verifiable claim`, associates it with a particular `subject`, and transmits it to a `holder`.</p>
+            <p property="rdfs:comment">The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
                   <dt>rdfs:domain</dt>
@@ -222,18 +239,19 @@ var respecConfig = {
               </dl>
           </td>
         </tr>
-        <tr><td class="bold">recipient</td>
-          <td resource="cred:recipient" typeof="rdf:Property">
-            <em property="rdfs:label">recipient</em>
-            <p property="rdfs:comment">FIXME</p>
+        <tr><td class="bold">proof</td>
+          <td resource="cred:proof" typeof="rdf:Property">
+            <em property="rdfs:label">proof</em>
+            <p property="rdfs:comment">The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date.</p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
-          </td>
-        </tr>
-        <tr><td class="bold">referenceId</td>
-          <td resource="cred:referenceId" typeof="rdf:Property">
-            <em property="rdfs:label">referenceId</em>
-            <p property="rdfs:comment">FIXME</p>
-            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="_:">
+                        Union of
+                        <span property="owl:unionOf" inlist=true resource="cred:Credential">cred:Credential</span>
+                        <span property="owl:unionOf" inlist=true resource="cred:VerifiableProfile">cred:VerifiableProfile</span>
+                      </dd>
+              </dl>
           </td>
         </tr>
         <tr><td class="bold">revocation</td>
@@ -242,10 +260,34 @@ var respecConfig = {
             <p property="rdfs:comment"></p>
             <span property="rdfs:isDefinedBy" resource="shex:"></span>
               <dl class="terms">
-                  <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="cred:RevocationList2017">cred:RevocationList2017</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">termsOfUse</td>
+          <td resource="cred:termsOfUse" typeof="rdf:Property">
+            <em property="rdfs:label">terms of use</em>
+            <p property="rdfs:comment">The value of this property MUST be one or more terms of use descriptions that provide enough information to a verifier to determine how they may utilize the given information.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="cred:Policy">cred:Policy</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="cred:Credential">cred:Credential</dd>
+              </dl>
+          </td>
+        </tr>
+        <tr><td class="bold">verifiableCredential</td>
+          <td resource="cred:verifiableCredential" typeof="rdf:Property">
+            <em property="rdfs:label">verifiable credential</em>
+            <p property="rdfs:comment">The contents of the `verifiableCredential` property are `verifiable credentials` as described by this specification.</p>
+            <span property="rdfs:isDefinedBy" resource="shex:"></span>
+              <dl class="terms">
+                  <dt>rdfs:range</dt>
+                      <dd property="rdfs:range" resource="cred:Credential">cred:Credential</dd>
+                  <dt>rdfs:domain</dt>
+                      <dd property="rdfs:domain" resource="cred:VerifiableProfile">cred:VerifiableProfile</dd>
               </dl>
           </td>
         </tr>
@@ -262,10 +304,6 @@ var respecConfig = {
         <dd>
             sec:Key
         </dd>
-        <dt>CryptographicKeyCredential</dt>
-        <dd>
-            cred:CryptographicKeyCredential
-        </dd>
         <dt>GraphSignature2012</dt>
         <dd>
             sec:GraphSignature2012
@@ -278,13 +316,13 @@ var respecConfig = {
         <dd>
             sec:LinkedDataSignature2015
         </dd>
-        <dt>Profile</dt>
+        <dt>Policy</dt>
         <dd>
-            cred:Profile
+            cred:Policy
         </dd>
-        <dt>RevocationList2017</dt>
+        <dt>VerifiableProfile</dt>
         <dd>
-            cred:RevocationList2017
+            cred:VerifiableProfile
         </dd>
         <dt>canonicalizationAlgorithm</dt>
         <dd>
@@ -315,6 +353,11 @@ var respecConfig = {
             with string values interpreted as @id
               with array values interpreted as @graph
         </dd>
+        <dt>credentialStatus</dt>
+        <dd>
+            cred:credentialStatus
+            with string values interpreted as @id
+        </dd>
         <dt>dc</dt>
         <dd>
             http://purl.org/dc/terms/
@@ -323,6 +366,10 @@ var respecConfig = {
         <dd>
             sec:domain
         </dd>
+        <dt>entity</dt>
+        <dd>
+            cred:entity
+        </dd>
         <dt>evidence</dt>
         <dd>
             cred:evidence
@@ -330,8 +377,8 @@ var respecConfig = {
         </dd>
         <dt>expires</dt>
         <dd>
-            sec:expiration
-            with string values interpreted as xsd:dateTime
+            cred:expires
+            with string values interpreted as @id
         </dd>
         <dt>id</dt>
         <dd>
@@ -365,6 +412,11 @@ var respecConfig = {
         <dd>
             sec:privateKeyPem
         </dd>
+        <dt>proof</dt>
+        <dd>
+            cred:proof
+            with string values interpreted as @id
+        </dd>
         <dt>publicKey</dt>
         <dd>
             sec:publicKey
@@ -378,15 +430,6 @@ var respecConfig = {
         <dd>
             sec:publicKeyService
             with string values interpreted as @id
-        </dd>
-        <dt>recipient</dt>
-        <dd>
-            cred:recipient
-            with string values interpreted as @id
-        </dd>
-        <dt>referenceId</dt>
-        <dd>
-            cred:referenceId
         </dd>
         <dt>revocation</dt>
         <dd>
@@ -418,9 +461,19 @@ var respecConfig = {
         <dd>
             sec:signatureValue
         </dd>
+        <dt>termsOfUse</dt>
+        <dd>
+            cred:termsOfUse
+            with string values interpreted as @id
+        </dd>
         <dt>type</dt>
         <dd>
             @type
+        </dd>
+        <dt>verifiableCredential</dt>
+        <dd>
+            cred:verifiableCredential
+            with string values interpreted as @id
         </dd>
         <dt>xsd</dt>
         <dd>

--- a/vocab/credentials.jsonld
+++ b/vocab/credentials.jsonld
@@ -22,8 +22,8 @@
     },
     "domain": "sec:domain",
     "expires": {
-      "@id": "sec:expiration",
-      "@type": "xsd:dateTime"
+      "@id": "cred:expires",
+      "@type": "@id"
     },
     "nonce": "sec:nonce",
     "owner": {
@@ -52,9 +52,8 @@
     "signatureAlgorithm": "sec:signatureAlgorithm",
     "signatureValue": "sec:signatureValue",
     "Credential": "cred:Credential",
-    "CryptographicKeyCredential": "cred:CryptographicKeyCredential",
-    "Profile": "cred:Profile",
-    "RevocationList2017": "cred:RevocationList2017",
+    "Policy": "cred:Policy",
+    "VerifiableProfile": "cred:VerifiableProfile",
     "claim": {
       "@id": "cred:claim",
       "@container": "@graph"
@@ -63,6 +62,13 @@
       "@id": "cred:credential",
       "@type": "@id",
       "@container": "@graph"
+    },
+    "credentialStatus": {
+      "@id": "cred:credentialStatus",
+      "@type": "@id"
+    },
+    "entity": {
+      "@id": "cred:entity"
     },
     "evidence": {
       "@id": "cred:evidence",
@@ -76,15 +82,20 @@
       "@id": "cred:issuer",
       "@type": "@id"
     },
-    "recipient": {
-      "@id": "cred:recipient",
+    "proof": {
+      "@id": "cred:proof",
       "@type": "@id"
-    },
-    "referenceId": {
-      "@id": "cred:referenceId"
     },
     "revocation": {
       "@id": "cred:revocation",
+      "@type": "@id"
+    },
+    "termsOfUse": {
+      "@id": "cred:termsOfUse",
+      "@type": "@id"
+    },
+    "verifiableCredential": {
+      "@id": "cred:verifiableCredential",
       "@type": "@id"
     }
   },
@@ -174,7 +185,7 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used for Verifiable Claims [[verifiable-claims-data-model]] along with the default JSON-LD Context."
     },
-    "dc:date": "2017-12-01",
+    "dc:date": "2018-03-22",
     "owl:imports": [
       "http://purl.org/dc/terms/",
       "https://w3id.org/security"
@@ -194,36 +205,24 @@
         }
       },
       {
-        "@id": "cred:CryptographicKeyCredential",
+        "@id": "cred:Policy",
         "@type": "rdfs:Class",
         "rdfs:label": {
-          "en": "Cryptographic Key Credential"
+          "en": "Policy"
         },
         "rdfs:comment": {
-          "en": "FIXME"
-        },
-        "rdfs:subClassOf": "cred:Credential"
+          "en": "Issue: The group is currently exploring a variety of ways of expressing the terms of use associated with a Verifiable Credential, namely, the Open Digital Rights Language."
+        }
       },
       {
-        "@id": "cred:Profile",
+        "@id": "cred:VerifiableProfile",
         "@type": "rdfs:Class",
         "rdfs:label": {
           "en": "Verifiable Profile"
         },
         "rdfs:comment": {
-          "en": "A set of one or more `credentials` typically related to the same `subject`. An entity may have multiple `profiles` and each `profile` may contain `verifiable credentials` issued by multiple issuers. A `verifiable profile` is a `profile` that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`."
+          "en": "A `verifiable profile` is a profile that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`."
         }
-      },
-      {
-        "@id": "cred:RevocationList2017",
-        "@type": "rdfs:Class",
-        "rdfs:label": {
-          "en": "Revocation List 2017"
-        },
-        "rdfs:comment": {
-          "en": "FIXME"
-        },
-        "rdfs:subClassOf": "cred:RevocationList2017"
       }
     ],
     "rdfs_properties": [
@@ -234,7 +233,7 @@
           "en": "claim"
         },
         "rdfs:comment": {
-          "en": "A statement made about a `subject`. A **verifiable claim** is a claim that is tamper-resistant and whose authorship can be cryptographically verified."
+          "en": "A statement made about a `subject`."
         },
         "rdfs:domain": "cred:Credential"
       },
@@ -247,8 +246,29 @@
         "rdfs:comment": {
           "en": "A set of one or more claims made by the same `entity` about a `subject`. A **verifiable credential** is a credential that is tamper-resistant and whose authorship can be cryptographically verified."
         },
-        "rdfs:domain": "cred:Profile",
+        "rdfs:domain": "cred:VerifiableProfile",
         "rdfs:range": "cred:Credential"
+      },
+      {
+        "@id": "cred:credentialStatus",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "credential status"
+        },
+        "rdfs:comment": {
+          "en": "The value of this property MUST be a status scheme that provides enough information to determine the current status of the credential (e.g. suspended, revoked, etc.). The status scheme will vary depending on a variety of factors, such as whether it is simple to implement or privacy-enhancing."
+        },
+        "rdfs:domain": "cred:Credential"
+      },
+      {
+        "@id": "cred:entity",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "entity"
+        },
+        "rdfs:comment": {
+          "en": "A thing with distinct and independent existence such as a person, organization, concept, or device."
+        }
       },
       {
         "@id": "cred:evidence",
@@ -261,6 +281,18 @@
         },
         "rdfs:domain": "cred:Credential",
         "rdfs:range": "cred:DocumentationVerifier"
+      },
+      {
+        "@id": "cred:expires",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "expires"
+        },
+        "rdfs:comment": {
+          "en": "The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid."
+        },
+        "rdfs:domain": "cred:Credential",
+        "rdfs:range": "xsd:dateTime"
       },
       {
         "@id": "cred:issued",
@@ -281,28 +313,24 @@
           "en": "issuer"
         },
         "rdfs:comment": {
-          "en": "An `entit`y that creates a `verifiable claim`, associates it with a particular `subject`, and transmits it to a `holder`."
+          "en": "The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`."
         },
         "rdfs:domain": "cred:Credential"
       },
       {
-        "@id": "cred:recipient",
+        "@id": "cred:proof",
         "@type": "rdf:Property",
         "rdfs:label": {
-          "en": "recipient"
+          "en": "proof"
         },
         "rdfs:comment": {
-          "en": "FIXME"
-        }
-      },
-      {
-        "@id": "cred:referenceId",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "referenceId"
+          "en": "The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."
         },
-        "rdfs:comment": {
-          "en": "FIXME"
+        "rdfs:domain": {
+          "owl:unionOf": [
+            "cred:Credential",
+            "cred:VerifiableProfile"
+          ]
         }
       },
       {
@@ -314,8 +342,31 @@
         "rdfs:comment": {
           "en": ""
         },
+        "rdfs:domain": "cred:Credential"
+      },
+      {
+        "@id": "cred:termsOfUse",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "terms of use"
+        },
+        "rdfs:comment": {
+          "en": "The value of this property MUST be one or more terms of use descriptions that provide enough information to a verifier to determine how they may utilize the given information."
+        },
         "rdfs:domain": "cred:Credential",
-        "rdfs:range": "cred:RevocationList2017"
+        "rdfs:range": "cred:Policy"
+      },
+      {
+        "@id": "cred:verifiableCredential",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "verifiable credential"
+        },
+        "rdfs:comment": {
+          "en": "The contents of the `verifiableCredential` property are `verifiable credentials` as described by this specification."
+        },
+        "rdfs:domain": "cred:VerifiableProfile",
+        "rdfs:range": "cred:Credential"
       }
     ]
   }

--- a/vocab/credentials.jsonld
+++ b/vocab/credentials.jsonld
@@ -1,101 +1,69 @@
 {
-  "@context": {
-    "id": "@id",
-    "type": "@type",
-    "cred": "https://w3id.org/credentials#",
-    "dc": "http://purl.org/dc/terms/",
-    "schema": "http://schema.org/",
-    "sec": "https://w3id.org/security#",
-    "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "CryptographicKey": "sec:Key",
-    "GraphSignature2012": "sec:GraphSignature2012",
-    "Identity": "https://w3id.org/identity#Identity",
-    "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
-    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
-    "created": {
-      "@id": "dc:created",
-      "@type": "xsd:dateTime"
+  "@context": [
+    {
+      "@version": 1.1
     },
-    "creator": {
-      "@id": "dc:creator",
-      "@type": "@id"
-    },
-    "domain": "sec:domain",
-    "expires": {
-      "@id": "sec:expiration",
-      "@type": "xsd:dateTime"
-    },
-    "nonce": "sec:nonce",
-    "owner": {
-      "@id": "sec:owner",
-      "@type": "@id"
-    },
-    "privateKey": {
-      "@id": "sec:privateKey",
-      "@type": "@id"
-    },
-    "privateKeyPem": "sec:privateKeyPem",
-    "proof": "sec:proof",
-    "publicKey": {
-      "@id": "sec:publicKey",
-      "@container": "@graph",
-      "@type": "@id"
-    },
-    "publicKeyPem": "sec:publicKeyPem",
-    "publicKeyService": {
-      "@id": "sec:publicKeyService",
-      "@type": "@id"
-    },
-    "revoked": {
-      "@id": "sec:revoked",
-      "@type": "xsd:dateTime"
-    },
-    "signature": "sec:signature",
-    "signatureAlgorithm": "sec:signatureAlgorithm",
-    "signatureValue": "sec:signatureValue",
-    "Credential": "cred:Credential",
-    "Policy": "cred:Policy",
-    "VerifiableProfile": "cred:VerifiableProfile",
-    "claim": {
-      "@id": "cred:claim",
-      "@container": "@graph",
-      "@type": "@id"
-    },
-    "credential": {
-      "@id": "cred:credential",
-      "@type": "@id",
-      "@container": "@graph"
-    },
-    "credentialStatus": {
-      "@id": "cred:credentialStatus",
-      "@type": "@id"
-    },
-    "evidence": {
-      "@id": "cred:evidence",
-      "@type": "@id"
-    },
-    "issued": {
-      "@id": "cred:issued",
-      "@type": "xsd:dateTime"
-    },
-    "issuer": {
-      "@id": "cred:issuer",
-      "@type": "@id"
-    },
-    "revocation": {
-      "@id": "cred:revocation",
-      "@type": "@id"
-    },
-    "termsOfUse": {
-      "@id": "cred:termsOfUse",
-      "@type": "@id"
-    },
-    "verifiableCredential": {
-      "@id": "cred:verifiableCredential",
-      "@type": "@id",
-      "@container": "@graph"
+    "https://w3id.org/security/v1",
+    {
+      "id": "@id",
+      "type": "@type",
+      "cred": "https://w3id.org/credentials#",
+      "dc": "http://purl.org/dc/terms/",
+      "schema": "http://schema.org/",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "Identity": "https://w3id.org/identity#Identity",
+      "created": {
+        "@id": "dc:created",
+        "@type": "xsd:dateTime"
+      },
+      "creator": {
+        "@id": "dc:creator",
+        "@type": "@id"
+      },
+      "Credential": "cred:Credential",
+      "Policy": "cred:Policy",
+      "VerifiableProfile": "cred:VerifiableProfile",
+      "claim": {
+        "@id": "cred:claim",
+        "@container": "@graph",
+        "@type": "@id"
+      },
+      "credential": {
+        "@id": "cred:credential",
+        "@type": "@id",
+        "@container": "@graph"
+      },
+      "credentialStatus": {
+        "@id": "cred:credentialStatus",
+        "@type": "@id"
+      },
+      "evidence": {
+        "@id": "cred:evidence",
+        "@type": "@id"
+      },
+      "issued": {
+        "@id": "cred:issued",
+        "@type": "xsd:dateTime"
+      },
+      "issuer": {
+        "@id": "cred:issuer",
+        "@type": "@id"
+      },
+      "revocation": {
+        "@id": "cred:revocation",
+        "@type": "@id"
+      },
+      "termsOfUse": {
+        "@id": "cred:termsOfUse",
+        "@type": "@id"
+      },
+      "verifiableCredential": {
+        "@id": "cred:verifiableCredential",
+        "@type": "@id",
+        "@container": "@graph"
+      }
     }
-  },
+  ],
   "@graph": {
     "@context": {
       "id": "@id",
@@ -182,7 +150,7 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used for Verifiable Claims [[verifiable-claims-data-model]] along with the default JSON-LD Context."
     },
-    "dc:date": "2018-03-23",
+    "dc:date": "2018-04-01",
     "owl:imports": [
       "http://purl.org/dc/terms/",
       "https://w3id.org/security"

--- a/vocab/credentials.jsonld
+++ b/vocab/credentials.jsonld
@@ -22,8 +22,8 @@
     },
     "domain": "sec:domain",
     "expires": {
-      "@id": "cred:expires",
-      "@type": "@id"
+      "@id": "sec:expiration",
+      "@type": "xsd:dateTime"
     },
     "nonce": "sec:nonce",
     "owner": {
@@ -35,8 +35,10 @@
       "@type": "@id"
     },
     "privateKeyPem": "sec:privateKeyPem",
+    "proof": "sec:proof",
     "publicKey": {
       "@id": "sec:publicKey",
+      "@container": "@graph",
       "@type": "@id"
     },
     "publicKeyPem": "sec:publicKeyPem",
@@ -56,7 +58,8 @@
     "VerifiableProfile": "cred:VerifiableProfile",
     "claim": {
       "@id": "cred:claim",
-      "@container": "@graph"
+      "@container": "@graph",
+      "@type": "@id"
     },
     "credential": {
       "@id": "cred:credential",
@@ -66,9 +69,6 @@
     "credentialStatus": {
       "@id": "cred:credentialStatus",
       "@type": "@id"
-    },
-    "entity": {
-      "@id": "cred:entity"
     },
     "evidence": {
       "@id": "cred:evidence",
@@ -82,10 +82,6 @@
       "@id": "cred:issuer",
       "@type": "@id"
     },
-    "proof": {
-      "@id": "cred:proof",
-      "@type": "@id"
-    },
     "revocation": {
       "@id": "cred:revocation",
       "@type": "@id"
@@ -96,7 +92,8 @@
     },
     "verifiableCredential": {
       "@id": "cred:verifiableCredential",
-      "@type": "@id"
+      "@type": "@id",
+      "@container": "@graph"
     }
   },
   "@graph": {
@@ -185,7 +182,7 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used for Verifiable Claims [[verifiable-claims-data-model]] along with the default JSON-LD Context."
     },
-    "dc:date": "2018-03-22",
+    "dc:date": "2018-03-23",
     "owl:imports": [
       "http://purl.org/dc/terms/",
       "https://w3id.org/security"
@@ -261,16 +258,6 @@
         "rdfs:domain": "cred:Credential"
       },
       {
-        "@id": "cred:entity",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "entity"
-        },
-        "rdfs:comment": {
-          "en": "A thing with distinct and independent existence such as a person, organization, concept, or device."
-        }
-      },
-      {
         "@id": "cred:evidence",
         "@type": "rdf:Property",
         "rdfs:label": {
@@ -281,18 +268,6 @@
         },
         "rdfs:domain": "cred:Credential",
         "rdfs:range": "cred:DocumentationVerifier"
-      },
-      {
-        "@id": "cred:expires",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "expires"
-        },
-        "rdfs:comment": {
-          "en": "The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid."
-        },
-        "rdfs:domain": "cred:Credential",
-        "rdfs:range": "xsd:dateTime"
       },
       {
         "@id": "cred:issued",
@@ -316,22 +291,6 @@
           "en": "The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`."
         },
         "rdfs:domain": "cred:Credential"
-      },
-      {
-        "@id": "cred:proof",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "proof"
-        },
-        "rdfs:comment": {
-          "en": "The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."
-        },
-        "rdfs:domain": {
-          "owl:unionOf": [
-            "cred:Credential",
-            "cred:VerifiableProfile"
-          ]
-        }
       },
       {
         "@id": "cred:revocation",

--- a/vocab/credentials.ttl
+++ b/vocab/credentials.ttl
@@ -11,7 +11,7 @@
 cred: a owl:Ontology;
   dc:title "Verifiable Claims Vocabulary"@en;
   dc:description """This document describes the RDFS vocabulary description used for Verifiable Claims [[verifiable-claims-data-model]] along with the default JSON-LD Context."""@en;
-  dc:date "2018-03-22"^^xsd:date;
+  dc:date "2018-03-23"^^xsd:date;
   dc:imports <http://purl.org/dc/terms/>, <https://w3id.org/security>;
   rdfs:seeAlso <https://www.w3.org/TR/verifiable-claims-data-model/>;
 
@@ -46,21 +46,11 @@ cred:credentialStatus a rdf:Property;
   rdfs:comment """The value of this property MUST be a status scheme that provides enough information to determine the current status of the credential (e.g. suspended, revoked, etc.). The status scheme will vary depending on a variety of factors, such as whether it is simple to implement or privacy-enhancing."""@en;
   rdfs:domain cred:Credential;
   rdfs:isDefinedBy cred: .
-cred:entity a rdf:Property;
-  rdfs:label "entity"@en;
-  rdfs:comment """A thing with distinct and independent existence such as a person, organization, concept, or device."""@en;
-  rdfs:isDefinedBy cred: .
 cred:evidence a rdf:Property;
   rdfs:label "evidence"@en;
   rdfs:comment """The value of this property MUST be one or more evidence schemes that provides enough information to a verifier to determine whether or not the evidence gathered meets their requirements."""@en;
   rdfs:domain cred:Credential;
   rdfs:range cred:DocumentationVerifier;
-  rdfs:isDefinedBy cred: .
-cred:expires a rdf:Property;
-  rdfs:label "expires"@en;
-  rdfs:comment """The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid."""@en;
-  rdfs:domain cred:Credential;
-  rdfs:range xsd:dateTime;
   rdfs:isDefinedBy cred: .
 cred:issued a rdf:Property;
   rdfs:label "issued"@en;
@@ -72,11 +62,6 @@ cred:issuer a rdf:Property;
   rdfs:label "issuer"@en;
   rdfs:comment """The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`."""@en;
   rdfs:domain cred:Credential;
-  rdfs:isDefinedBy cred: .
-cred:proof a rdf:Property;
-  rdfs:label "proof"@en;
-  rdfs:comment """The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."""@en;
-  rdfs:domain [ owl:unionOf (cred:Credential cred:VerifiableProfile)];
   rdfs:isDefinedBy cred: .
 cred:revocation a rdf:Property;
   rdfs:label "revocation"@en;

--- a/vocab/credentials.ttl
+++ b/vocab/credentials.ttl
@@ -11,7 +11,7 @@
 cred: a owl:Ontology;
   dc:title "Verifiable Claims Vocabulary"@en;
   dc:description """This document describes the RDFS vocabulary description used for Verifiable Claims [[verifiable-claims-data-model]] along with the default JSON-LD Context."""@en;
-  dc:date "2017-12-01"^^xsd:date;
+  dc:date "2018-03-22"^^xsd:date;
   dc:imports <http://purl.org/dc/terms/>, <https://w3id.org/security>;
   rdfs:seeAlso <https://www.w3.org/TR/verifiable-claims-data-model/>;
 
@@ -20,38 +20,47 @@ cred:Credential a rdfs:Class;
   rdfs:label "Credential"@en;
   rdfs:comment """FIXME"""@en;
   rdfs:isDefinedBy cred: .
-cred:CryptographicKeyCredential a rdfs:Class;
-  rdfs:label "Cryptographic Key Credential"@en;
-  rdfs:comment """FIXME"""@en;
-  rdfs:subClassOf cred:Credential;
+cred:Policy a rdfs:Class;
+  rdfs:label "Policy"@en;
+  rdfs:comment """Issue: The group is currently exploring a variety of ways of expressing the terms of use associated with a Verifiable Credential, namely, the Open Digital Rights Language."""@en;
   rdfs:isDefinedBy cred: .
-cred:Profile a rdfs:Class;
+cred:VerifiableProfile a rdfs:Class;
   rdfs:label "Verifiable Profile"@en;
-  rdfs:comment """A set of one or more `credentials` typically related to the same `subject`. An entity may have multiple `profiles` and each `profile` may contain `verifiable credentials` issued by multiple issuers. A `verifiable profile` is a `profile` that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`."""@en;
-  rdfs:isDefinedBy cred: .
-cred:RevocationList2017 a rdfs:Class;
-  rdfs:label "Revocation List 2017"@en;
-  rdfs:comment """FIXME"""@en;
-  rdfs:subClassOf cred:RevocationList2017;
+  rdfs:comment """A `verifiable profile` is a profile that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`."""@en;
   rdfs:isDefinedBy cred: .
 
 # Property definitions
 cred:claim a rdf:Property;
   rdfs:label "claim"@en;
-  rdfs:comment """A statement made about a `subject`. A **verifiable claim** is a claim that is tamper-resistant and whose authorship can be cryptographically verified."""@en;
+  rdfs:comment """A statement made about a `subject`."""@en;
   rdfs:domain cred:Credential;
   rdfs:isDefinedBy cred: .
 cred:credential a rdf:Property;
   rdfs:label "credential"@en;
   rdfs:comment """A set of one or more claims made by the same `entity` about a `subject`. A **verifiable credential** is a credential that is tamper-resistant and whose authorship can be cryptographically verified."""@en;
-  rdfs:domain cred:Profile;
+  rdfs:domain cred:VerifiableProfile;
   rdfs:range cred:Credential;
+  rdfs:isDefinedBy cred: .
+cred:credentialStatus a rdf:Property;
+  rdfs:label "credential status"@en;
+  rdfs:comment """The value of this property MUST be a status scheme that provides enough information to determine the current status of the credential (e.g. suspended, revoked, etc.). The status scheme will vary depending on a variety of factors, such as whether it is simple to implement or privacy-enhancing."""@en;
+  rdfs:domain cred:Credential;
+  rdfs:isDefinedBy cred: .
+cred:entity a rdf:Property;
+  rdfs:label "entity"@en;
+  rdfs:comment """A thing with distinct and independent existence such as a person, organization, concept, or device."""@en;
   rdfs:isDefinedBy cred: .
 cred:evidence a rdf:Property;
   rdfs:label "evidence"@en;
   rdfs:comment """The value of this property MUST be one or more evidence schemes that provides enough information to a verifier to determine whether or not the evidence gathered meets their requirements."""@en;
   rdfs:domain cred:Credential;
   rdfs:range cred:DocumentationVerifier;
+  rdfs:isDefinedBy cred: .
+cred:expires a rdf:Property;
+  rdfs:label "expires"@en;
+  rdfs:comment """The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid."""@en;
+  rdfs:domain cred:Credential;
+  rdfs:range xsd:dateTime;
   rdfs:isDefinedBy cred: .
 cred:issued a rdf:Property;
   rdfs:label "issued"@en;
@@ -61,20 +70,28 @@ cred:issued a rdf:Property;
   rdfs:isDefinedBy cred: .
 cred:issuer a rdf:Property;
   rdfs:label "issuer"@en;
-  rdfs:comment """An `entit`y that creates a `verifiable claim`, associates it with a particular `subject`, and transmits it to a `holder`."""@en;
+  rdfs:comment """The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`."""@en;
   rdfs:domain cred:Credential;
   rdfs:isDefinedBy cred: .
-cred:recipient a rdf:Property;
-  rdfs:label "recipient"@en;
-  rdfs:comment """FIXME"""@en;
-  rdfs:isDefinedBy cred: .
-cred:referenceId a rdf:Property;
-  rdfs:label "referenceId"@en;
-  rdfs:comment """FIXME"""@en;
+cred:proof a rdf:Property;
+  rdfs:label "proof"@en;
+  rdfs:comment """The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."""@en;
+  rdfs:domain [ owl:unionOf (cred:Credential cred:VerifiableProfile)];
   rdfs:isDefinedBy cred: .
 cred:revocation a rdf:Property;
   rdfs:label "revocation"@en;
   rdfs:comment """"""@en;
   rdfs:domain cred:Credential;
-  rdfs:range cred:RevocationList2017;
+  rdfs:isDefinedBy cred: .
+cred:termsOfUse a rdf:Property;
+  rdfs:label "terms of use"@en;
+  rdfs:comment """The value of this property MUST be one or more terms of use descriptions that provide enough information to a verifier to determine how they may utilize the given information."""@en;
+  rdfs:domain cred:Credential;
+  rdfs:range cred:Policy;
+  rdfs:isDefinedBy cred: .
+cred:verifiableCredential a rdf:Property;
+  rdfs:label "verifiable credential"@en;
+  rdfs:comment """The contents of the `verifiableCredential` property are `verifiable credentials` as described by this specification."""@en;
+  rdfs:domain cred:VerifiableProfile;
+  rdfs:range cred:Credential;
   rdfs:isDefinedBy cred: .

--- a/vocab/credentials.ttl
+++ b/vocab/credentials.ttl
@@ -4,14 +4,13 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix cred: <https://w3id.org/credentials#> .
 @prefix schema: <http://schema.org/> .
-@prefix sec: <https://w3id.org/security#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 # CSVM Ontology definition
 cred: a owl:Ontology;
   dc:title "Verifiable Claims Vocabulary"@en;
   dc:description """This document describes the RDFS vocabulary description used for Verifiable Claims [[verifiable-claims-data-model]] along with the default JSON-LD Context."""@en;
-  dc:date "2018-03-23"^^xsd:date;
+  dc:date "2018-04-01"^^xsd:date;
   dc:imports <http://purl.org/dc/terms/>, <https://w3id.org/security>;
   rdfs:seeAlso <https://www.w3.org/TR/verifiable-claims-data-model/>;
 

--- a/vocab/template.html
+++ b/vocab/template.html
@@ -7,10 +7,11 @@
     <script class="remove">
 var respecConfig = {
     localBiblio: opencreds.localBiblio,
-    specStatus: "base",
-    shortName: "vc-vocab",
-    publishDate:  "<%=ont["dc:date"]%>",
-    thisVersion:    "http://w3id.org/credentials",
+    specStatus:  "base",
+    shortName:   "vc-vocab",
+    publishDate: "<%=ont["dc:date"]%>",
+    thisVersion: "http://w3id.org/credentials",
+    doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
     // lcEnd: "3000-01-01",
     // crEnd: "3000-01-01",

--- a/vocab/vocab.csv
+++ b/vocab/vocab.csv
@@ -7,18 +7,21 @@ xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,
 ,owl:imports,,http://purl.org/dc/terms/,,,,,
 ,owl:imports,,https://w3id.org/security,,,,,
 ,rdfs:seeAlso,,https://www.w3.org/TR/verifiable-claims-data-model/,,,,,
-claim,rdf:Property,claim,,Credential,,,@graph,A statement made about a `subject`. A **verifiable claim** is a claim that is tamper-resistant and whose authorship can be cryptographically verified.
-credential,rdf:Property,credential,,Profile,Credential,,@graph,A set of one or more claims made by the same `entity` about a `subject`. A **verifiable credential** is a credential that is tamper-resistant and whose authorship can be cryptographically verified.
-evidence,rdf:Property,evidence,,Credential,DocumentationVerifier,,,The value of this property MUST be one or more evidence schemes that provides enough information to a verifier to determine whether or not the evidence gathered meets their requirements.
+claim,rdf:Property,claim,,Credential,,,@graph,A statement made about a `subject`.
+credential,rdf:Property,credential,,VerifiableProfile,Credential,,@graph,A set of one or more claims made by the same `entity` about a `subject`. A **verifiable credential** is a credential that is tamper-resistant and whose authorship can be cryptographically verified.
+entity,rdf:Property,entity,,,,,,"A thing with distinct and independent existence such as a person, organization, concept, or device."
 issued,rdf:Property,issued,,Credential,xsd:dateTime,,,The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` was issued. Note that this date represents the earliest date when the information associated with the _claim property became valid.
-issuer,rdf:Property,issuer,,Credential,,@id,,"An `entit`y that creates a `verifiable claim`, associates it with a particular `subject`, and transmits it to a `holder`."
-recipient,rdf:Property,recipient,,,,@id,,FIXME
-referenceId,rdf:Property,referenceId,,,,,,FIXME
-revocation,rdf:Property,revocation,,Credential,RevocationList2017,@id,,
+issuer,rdf:Property,issuer,,Credential,,@id,,The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`.
+proof,rdf:Property,proof,,"Credential,VerifiableProfile",,@id,,"The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."
+evidence,rdf:Property,evidence,,Credential,DocumentationVerifier,,,The value of this property MUST be one or more evidence schemes that provides enough information to a verifier to determine whether or not the evidence gathered meets their requirements.
+expires,rdf:Property,expires,,Credential,xsd:dateTime,@id,,The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid.
+credentialStatus,rdf:Property,credential status,,Credential,,@id,,"The value of this property MUST be a status scheme that provides enough information to determine the current status of the credential (e.g. suspended, revoked, etc.). The status scheme will vary depending on a variety of factors, such as whether it is simple to implement or privacy-enhancing."
+verifiableCredential,rdf:Property,verifiable credential,,VerifiableProfile,Credential,@id,,The contents of the `verifiableCredential` property are `verifiable credentials` as described by this specification.
+termsOfUse,rdf:Property,terms of use,,Credential,Policy,@id,,The value of this property MUST be one or more terms of use descriptions that provide enough information to a verifier to determine how they may utilize the given information.
+revocation,rdf:Property,revocation,,Credential,,@id,,
 Credential,rdfs:Class,Credential,,,,,,FIXME
-CryptographicKeyCredential,rdfs:Class,Cryptographic Key Credential,Credential,,,,,FIXME
-Profile,rdfs:Class,Verifiable Profile,,,,,,A set of one or more `credentials` typically related to the same `subject`. An entity may have multiple `profiles` and each `profile` may contain `verifiable credentials` issued by multiple issuers. A `verifiable profile` is a `profile` that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`.
-RevocationList2017,rdfs:Class,Revocation List 2017,cred:RevocationList2017,,,,,FIXME
+Policy,rdfs:Class,Policy,,,,,,"Issue: The group is currently exploring a variety of ways of expressing the terms of use associated with a Verifiable Credential, namely, the Open Digital Rights Language."
+VerifiableProfile,rdfs:Class,Verifiable Profile,,,,,,A `verifiable profile` is a profile that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`.
 Identity,term,,https://w3id.org/identity#Identity,,,,,FIXME
 canonicalizationAlgorithm,term,,sec:canonicalizationAlgorithm,,,,,FIXME
 created,term,,dc:created,,,xsd:dateTime,,FIXME

--- a/vocab/vocab.csv
+++ b/vocab/vocab.csv
@@ -1,7 +1,7 @@
 id,type,label,subClassOf,domain,range,@type,@container,comment
+,@context,,https://w3id.org/security/v1,,,,,
 cred,prefix,,https://w3id.org/credentials#,,,,,
 dc,prefix,,http://purl.org/dc/terms/,,,,,
-sec,prefix,,https://w3id.org/security#,,,,,
 schema,prefix,,http://schema.org/,,,,,
 xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,
 ,owl:imports,,http://purl.org/dc/terms/,,,,,
@@ -20,23 +20,5 @@ Credential,rdfs:Class,Credential,,,,,,FIXME
 Policy,rdfs:Class,Policy,,,,,,"Issue: The group is currently exploring a variety of ways of expressing the terms of use associated with a Verifiable Credential, namely, the Open Digital Rights Language."
 VerifiableProfile,rdfs:Class,Verifiable Profile,,,,,,A `verifiable profile` is a profile that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`.
 Identity,term,,https://w3id.org/identity#Identity,,,,,FIXME
-canonicalizationAlgorithm,term,,sec:canonicalizationAlgorithm,,,,,The canonicalization algorithm is used to transform the input data into a form that can be passed to a cryptographic digest method. The digest is then digitally signed using a digital signature algorithm. Canonicalization ensures that a piece of software that is generating a digital signature is able to do so on the same set of information in a deterministic manner.
 created,term,,dc:created,,,xsd:dateTime,,Date of creation of the resource.
 creator,term,,dc:creator,,,@id,,An entity primarily responsible for making the resource.
-domain,term,,sec:domain,,,,,FIXME
-expires,term,,sec:expiration,,,xsd:dateTime,,The expiration time is typically associated with a Key and specifies when the validity of the key will expire. It is considered a best practice to only create keys that have very definite expiration periods. This period is typically set to between six months and two years. An digital signature created using an expired key must be marked as invalid by any software attempting to verify the signature.
-nonce,term,,sec:nonce,,,,,"This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request."
-owner,term,,sec:owner,,,@id,,"This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request."
-privateKey,term,,sec:privateKey,,,@id,,A public key property is used to specify a URL that contains information about a public key.
-privateKeyPem,term,,sec:privateKeyPem,,,,,A private key PEM property is used to specify the PEM-encoded version of the private key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing private keys.
-proof,term,,sec:proof,,,,,"The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."
-publicKey,term,,sec:publicKey,,,@id,@graph,A public key property is used to specify a URL that contains information about a public key.
-publicKeyPem,term,,sec:publicKeyPem,,,,,A public key PEM property is used to specify the PEM-encoded version of the public key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing public keys.
-publicKeyService,term,,sec:publicKeyService,,,@id,,The publicKeyService property is used to express the REST URL that provides public key management services as defined by the Web Key [SECURE-MESSAGING] specification.
-revoked,term,,sec:revoked,,,xsd:dateTime,,"The revocation time is typically associated with a Key that has been marked as invalid as of the date and time associated with the property. Key revocations are often used when a key is compromised, such as the theft of the private key, or during the course of best-practice key rotation schedules."
-signature,term,,sec:signature,,,,,"The signature property is used to associate a signature with a graph of information. The signature property is typically not included in the canonicalized graph that is then digested, and digitally signed."
-signatureAlgorithm,term,,sec:signatureAlgorithm,,,,,"The signature algorithm is used to specify the cryptographic signature function to use when digitally signing the digest data. Typically, text to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step #3. A signature class typically specifies a default signature algorithm, so this property rarely needs to be used in practice when specifying digital signatures."
-signatureValue,term,,sec:signatureValue,,,,,The signature value is used to express the output of the signature algorithm expressed in base-64 format.
-CryptographicKey,term,,sec:Key,,,,,"This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data."
-GraphSignature2012,term,,sec:GraphSignature2012,,,,,"A graph signature is used for digital signatures on RDF graphs. The default canonicalization mechanism is specified in the RDF Graph normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature."
-LinkedDataSignature2015,term,,sec:LinkedDataSignature2015,,,,,"A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature. This signature uses a algorithm for producing the data that it signs and verifies that is different from other Linked Data signatures."

--- a/vocab/vocab.csv
+++ b/vocab/vocab.csv
@@ -7,38 +7,36 @@ xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,
 ,owl:imports,,http://purl.org/dc/terms/,,,,,
 ,owl:imports,,https://w3id.org/security,,,,,
 ,rdfs:seeAlso,,https://www.w3.org/TR/verifiable-claims-data-model/,,,,,
-claim,rdf:Property,claim,,Credential,,,@graph,A statement made about a `subject`.
+claim,rdf:Property,claim,,Credential,,@id,@graph,A statement made about a `subject`.
 credential,rdf:Property,credential,,VerifiableProfile,Credential,,@graph,A set of one or more claims made by the same `entity` about a `subject`. A **verifiable credential** is a credential that is tamper-resistant and whose authorship can be cryptographically verified.
-entity,rdf:Property,entity,,,,,,"A thing with distinct and independent existence such as a person, organization, concept, or device."
 issued,rdf:Property,issued,,Credential,xsd:dateTime,,,The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` was issued. Note that this date represents the earliest date when the information associated with the _claim property became valid.
 issuer,rdf:Property,issuer,,Credential,,@id,,The value of this property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that may be used to verify the information expressed in the `credential`.
-proof,rdf:Property,proof,,"Credential,VerifiableProfile",,@id,,"The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."
 evidence,rdf:Property,evidence,,Credential,DocumentationVerifier,,,The value of this property MUST be one or more evidence schemes that provides enough information to a verifier to determine whether or not the evidence gathered meets their requirements.
-expires,rdf:Property,expires,,Credential,xsd:dateTime,@id,,The value of this property MUST be a string value of an [[ISO8601]] combined date and time string and represents the date and time the `credential` will cease to be valid.
 credentialStatus,rdf:Property,credential status,,Credential,,@id,,"The value of this property MUST be a status scheme that provides enough information to determine the current status of the credential (e.g. suspended, revoked, etc.). The status scheme will vary depending on a variety of factors, such as whether it is simple to implement or privacy-enhancing."
-verifiableCredential,rdf:Property,verifiable credential,,VerifiableProfile,Credential,@id,,The contents of the `verifiableCredential` property are `verifiable credentials` as described by this specification.
+verifiableCredential,rdf:Property,verifiable credential,,VerifiableProfile,Credential,@id,@graph,The contents of the `verifiableCredential` property are `verifiable credentials` as described by this specification.
 termsOfUse,rdf:Property,terms of use,,Credential,Policy,@id,,The value of this property MUST be one or more terms of use descriptions that provide enough information to a verifier to determine how they may utilize the given information.
 revocation,rdf:Property,revocation,,Credential,,@id,,
 Credential,rdfs:Class,Credential,,,,,,FIXME
 Policy,rdfs:Class,Policy,,,,,,"Issue: The group is currently exploring a variety of ways of expressing the terms of use associated with a Verifiable Credential, namely, the Open Digital Rights Language."
 VerifiableProfile,rdfs:Class,Verifiable Profile,,,,,,A `verifiable profile` is a profile that is tamper-resistant and whose contents are typically counter-signed by the `holder` or `subject`.
 Identity,term,,https://w3id.org/identity#Identity,,,,,FIXME
-canonicalizationAlgorithm,term,,sec:canonicalizationAlgorithm,,,,,FIXME
-created,term,,dc:created,,,xsd:dateTime,,FIXME
-creator,term,,dc:creator,,,@id,,FIXME
+canonicalizationAlgorithm,term,,sec:canonicalizationAlgorithm,,,,,The canonicalization algorithm is used to transform the input data into a form that can be passed to a cryptographic digest method. The digest is then digitally signed using a digital signature algorithm. Canonicalization ensures that a piece of software that is generating a digital signature is able to do so on the same set of information in a deterministic manner.
+created,term,,dc:created,,,xsd:dateTime,,Date of creation of the resource.
+creator,term,,dc:creator,,,@id,,An entity primarily responsible for making the resource.
 domain,term,,sec:domain,,,,,FIXME
-expires,term,,sec:expiration,,,xsd:dateTime,,FIXME
-nonce,term,,sec:nonce,,,,,FIXME
-owner,term,,sec:owner,,,@id,,FIXME
-privateKey,term,,sec:privateKey,,,@id,,FIXME
-privateKeyPem,term,,sec:privateKeyPem,,,,,FIXME
-publicKey,term,,sec:publicKey,,,@id,,FIXME
-publicKeyPem,term,,sec:publicKeyPem,,,,,FIXME
-publicKeyService,term,,sec:publicKeyService,,,@id,,FIXME
-revoked,term,,sec:revoked,,,xsd:dateTime,,FIXME
-signature,term,,sec:signature,,,,,FIXME
-signatureAlgorithm,term,,sec:signatureAlgorithm,,,,,FIXME
-signatureValue,term,,sec:signatureValue,,,,,FIXME
-CryptographicKey,term,,sec:Key,,,,,FIXME
-GraphSignature2012,term,,sec:GraphSignature2012,,,,,FIXME
-LinkedDataSignature2015,term,,sec:LinkedDataSignature2015,,,,,FIXME
+expires,term,,sec:expiration,,,xsd:dateTime,,The expiration time is typically associated with a Key and specifies when the validity of the key will expire. It is considered a best practice to only create keys that have very definite expiration periods. This period is typically set to between six months and two years. An digital signature created using an expired key must be marked as invalid by any software attempting to verify the signature.
+nonce,term,,sec:nonce,,,,,"This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request."
+owner,term,,sec:owner,,,@id,,"This property is used in conjunction with the input to the signature hashing function in order to protect against replay attacks. Typically, receivers need to track all nonce values used within a certain time period in order to ensure that an attacker cannot merely re-send a compromised packet in order to execute a privileged request."
+privateKey,term,,sec:privateKey,,,@id,,A public key property is used to specify a URL that contains information about a public key.
+privateKeyPem,term,,sec:privateKeyPem,,,,,A private key PEM property is used to specify the PEM-encoded version of the private key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing private keys.
+proof,term,,sec:proof,,,,,"The method used for a mathematical proof will vary by representation language and the technology used. For example, if digital signatures are used for the proof mechanism, this property is expected to have a value that is a set of name-value pairs including at least a signature, a reference to the signing entity, and a representation of the signing date."
+publicKey,term,,sec:publicKey,,,@id,@graph,A public key property is used to specify a URL that contains information about a public key.
+publicKeyPem,term,,sec:publicKeyPem,,,,,A public key PEM property is used to specify the PEM-encoded version of the public key. This encoding is compatible with almost every Secure Sockets Layer library implementation and typically plugs directly into functions intializing public keys.
+publicKeyService,term,,sec:publicKeyService,,,@id,,The publicKeyService property is used to express the REST URL that provides public key management services as defined by the Web Key [SECURE-MESSAGING] specification.
+revoked,term,,sec:revoked,,,xsd:dateTime,,"The revocation time is typically associated with a Key that has been marked as invalid as of the date and time associated with the property. Key revocations are often used when a key is compromised, such as the theft of the private key, or during the course of best-practice key rotation schedules."
+signature,term,,sec:signature,,,,,"The signature property is used to associate a signature with a graph of information. The signature property is typically not included in the canonicalized graph that is then digested, and digitally signed."
+signatureAlgorithm,term,,sec:signatureAlgorithm,,,,,"The signature algorithm is used to specify the cryptographic signature function to use when digitally signing the digest data. Typically, text to be signed goes through three steps: 1) canonicalization, 2) digest, and 3) signature. This property is used to specify the algorithm that should be used for step #3. A signature class typically specifies a default signature algorithm, so this property rarely needs to be used in practice when specifying digital signatures."
+signatureValue,term,,sec:signatureValue,,,,,The signature value is used to express the output of the signature algorithm expressed in base-64 format.
+CryptographicKey,term,,sec:Key,,,,,"This class represents a cryptographic key that may be used for encryption, decryption, or digitally signing data."
+GraphSignature2012,term,,sec:GraphSignature2012,,,,,"A graph signature is used for digital signatures on RDF graphs. The default canonicalization mechanism is specified in the RDF Graph normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature."
+LinkedDataSignature2015,term,,sec:LinkedDataSignature2015,,,,,"A Linked Data signature is used for digital signatures on RDF Datasets. The default canonicalization mechanism is specified in the RDF Dataset Normalization specification, which effectively deterministically names all unnamed nodes. The default signature mechanism uses a SHA-256 digest and RSA to perform the digital signature. This signature uses a algorithm for producing the data that it signs and verifies that is different from other Linked Data signatures."


### PR DESCRIPTION
Fixes #127.

There's probably some cruft left in here, so identifying extra terms, properties and classes that can be removed would be useful. Ideally, if we had a set of maintained examples we could use to run by the generated context and do some RDFS entailment checking of the result of transforming to RDF would help make sure we haven't missed something.