### PR TITLE
Enable embedded JSON-LD for SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
 
         // extend the bibliography entries
         localBiblio: vcwg.localBiblio,
+        doJsonLd: true,
 
         github: "https://github.com/w3c/vc-data-model",
         includePermalinks: false,


### PR DESCRIPTION
This replaces the previous `doRDFa` flag, which is no longer supported, and ads schema.org markup for spec facts. See the [respec wiki](https://github.com/w3c/respec/wiki/doJsonLd).