### PR TITLE
Fixed Evidence

### DIFF
--- a/index.html
+++ b/index.html
@@ -787,7 +787,8 @@ using the information provided to correlate the <a>holder</a>.
           <dd>The value of this property MUST be one or more evidence schemes
             that provides enough information to a <a>verifier</a>
             to determine whether or not the evidence gathered meets their
-            requirements.
+            requirements. The contents of each evidence scheme is determined by the
+            particular scheme itself.
           </dd>
         </dl>
 
@@ -806,9 +807,10 @@ very simple scheme for evidence as a part of this specification.
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "ageOver": 21
   },
-  <span class="highlight">"evidence": {
+  <span class="highlight">"evidence": [{
+    "scheme": "< scheme id >",
     "id": "https://dmv.example.gov/evidence/f2aeec97-fc0d-42bf-8ca7-0548192d4231",
-    "type": "DocumentVerification",
+    "type": ["DocumentVerification"],
     "verifier": "https://dmv.example.gov/issuers/14",
     "evidenceDocument": "DriversLicense",
     "subjectPresence": "Physical",


### PR DESCRIPTION
This is item viii) from PR#141 i.e.

viii) turned evidence into a set, consistent with the existing text, with each element being identified by its unique scheme ID. The contents of the scheme properties are then determined by the scheme itself