### PR TITLE
Improve refrences to prof lic/cert bodies in Intro and Ecosystem

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,7 +185,7 @@ identification number),
         </li>
         <li>
 information related to the issuing authority (e.g. state department,
-federal agency, or employer),
+federal agency, or certification body),
         </li>
         <li>
 evidence related to how the credential was derived, and
@@ -199,7 +199,7 @@ information related to expiration dates.
 A verifiable credential is capable of containing the same information that a
 physical credential does and much more because it is not constrained by
 physical restrictions. The addition of technologies like digital signatures
-also make verifiable credentials more tamperproof and therefore trustworthy
+also make verifiable credentials more tamperproof and therefore more trustworthy
 than their physical counterparts. Exchanging verifiable credentials over long
 distances are also possible through the Internet, making them more convenient
 when needing to establish trust over long distances.
@@ -229,7 +229,8 @@ Examples of holders include students, employees, and customers.
         <dd>
 An <a>entity</a> that creates a <a>verifiable credential</a>, associates it
 with a particular <a>subject</a>, and transmits it to a <a>holder</a>.
-Examples of issuers include corporations, governments, and individuals.
+Examples of issuers include corporations, non-profits, trade associations, 
+governments, and individuals.
         </dd>
         <dt><a>verifier</a></dt>
         <dd>


### PR DESCRIPTION
Replace "employer" with "certification body" in describing issuing authority (more frequent use case), and add a couple more categories in the Ecosystem/issuer role to represent professional credentialing better.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/stonematt/vc-data-model/pull/166.html" title="Last updated on Apr 30, 2018, 6:02 PM GMT (d07ecac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/166/9ea3a8d...stonematt:d07ecac.html" title="Last updated on Apr 30, 2018, 6:02 PM GMT (d07ecac)">Diff</a>