### PR TITLE
Add a section on Conformance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1450,6 +1450,147 @@ property-value pairs (e.g. MUST NOT be revoked, MUST be in the expected range).
     </section>
 
     <section>
+      <h2>Syntaxes</h2>
+
+
+      <p>
+Many of the data model concepts in this document thus far have been introduced
+by example using the JSON syntax. This section formalizes how the data model
+(described in Sections <a href="#core-data-model"></a>,
+<a href="#basic-concepts"></a>, and <a href="#advanced-concepts"></a>
+) is realized in JSON and JSON-LD. Although syntactic mappings are only provided for these two syntaxes,
+applications and services may also use any other data representation syntax,
+such as XML, YAML, or CBOR, that is capable of expressing the data model.
+      </p>
+
+      <section>
+        <h2>JSON</h2>
+
+          <p>
+The data model as described in Section <a href="#core-data-model"></a> can be
+encoded in Javascript Object Notation (JSON) [[!RFC8259]] by mapping
+property values to the following JSON types:
+          </p>
+
+          <ul>
+            <li>Numeric values representable as IEEE754 SHOULD be represented
+            as a Number type.</li>
+            <li>Any boolean value SHOULD be represented as a Boolean type.</li>
+            <li>Any sequence value SHOULD be represented as an Array type.</li>
+            <li>Any unordered set of values SHOULD be represented as
+            an Array type.</li>
+            <li>Any set of <a>properties</a> SHOULD be represented as
+            an Object type.</li>
+            <li>Any empty value SHOULD be represented as a null value.</li>
+            <li>Any other value MUST be represented as a String type.</li>
+          </ul>
+
+        <section>
+          <h3>JSON Web Token</h3>
+
+          <p class="issue">
+This section will be moved into its own specification before this document
+enters the Candidate Recommendation stage.
+          </p>
+
+          <p>The following example demonstrates how one could
+          express this data model using a JSON Web Token.</p>
+
+  <pre class="example" title="A JOSE JWT verifiable credential">
+  eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2Rtdi
+  5leGFtcGxlLmdvdiIsImlhdCI6MTI2MjMwNDAwMCwiZXhwIjoxNDgzMjI4ODAwL
+  CJhdWQiOiJ3d3cuZXhhbXBsZS5jb20iLCJzdWIiOiJkaWQ6ZWJmZWIxZjcxMmVi
+  YzZmMWMyNzZlMTJlYzIxIiwiZW50aXR5Q3JlZGVudGlhbCI6eyJAY29udGV4dCI
+  6Imh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvdjEiLCJpZCI6Imh0dHA6Ly9leG
+  FtcGxlLmdvdi9jcmVkZW50aWFscy8zNzMyIiwidHlwZSI6WyJDcmVkZW50aWFsI
+  iwiUHJvb2ZPZkFnZUNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiaHR0cHM6Ly9kbXYu
+  ZXhhbXBsZS5nb3YiLCJpc3N1ZWQiOiIyMDEwLTAxLTAxIiwiY2xhaW0iOnsiaWQ
+  iOiJkaWQ6ZWJmZWIxZjcxMmViYzZmMWMyNzZlMTJlYzIxIiwiYWdlT3ZlciI6Mj
+  F9fX0.LwqH58NasGPeqtTxT632YznKDuxEeC59gMAe9uueb4pX_lDQd2_UyUcc6
+  NW1E3qxvYlps4hH_YzzTuXB_R1A9UHXq4zyiz2sMtZWyJkUL1FERclT2CypX5e1
+  fO4zVES_8uaNoinim6VtS76x_2VmOMQ_GcqXG3iaLGVJHCNlCu4
+  </pre>
+
+  <p>
+  The JWT above was produced using the inputs below:
+  </p>
+
+  <p class="issue">
+  A number of the concerns have been raised around security,
+  composability, reusability, and extensibility with respect
+  to the use of JWTs for Verifiable Credentials. These concerns
+  will be documented in time in at least the Verfiable Claims Model
+  and Security Considerations section of this document.
+  </p>
+
+  <pre>
+  // JWT Header
+  {
+    "alg": "RS256",
+    "typ": "JWT"
+  }
+  // JWT Payload
+  {
+    "iss": "https://dmv.example.gov",
+    "iat": 1262304000,
+    "exp": 1483228800,
+    "aud": "www.example.com",
+    "sub": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "verifiableCredential": {
+      "@context": "https://w3id.org/security/v1",
+      "id": "http://example.gov/credentials/3732",
+      "type": ["VerifiableCredential", "ProofOfAgeCredential"],
+      "issuer": "https://dmv.example.gov",
+      "issuanceDate": "2010-01-01",
+      "claim": {
+        "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+        "ageOver": 21
+      }
+    }
+  }
+  </pre>
+
+        </section>
+
+      </section>
+
+      <section>
+        <h2>JSON-LD</h2>
+
+        <p>
+[[!JSON-LD]] is a JSON-based format that is used to serialize
+<a href="http://www.w3.org/TR/ld-glossary/#linked-data">Linked Data</a>.
+The syntax is designed to easily integrate into deployed systems that
+already use JSON, and provides a smooth upgrade path from JSON to JSON-LD.
+It is primarily intended to be a way to use Linked Data in
+Web-based programming environments, to build interoperable Web services,
+and to store Linked Data in JSON-based storage engines.
+        </p>
+
+        <p>
+JSON-LD is useful when extending the data model described in this
+specification. Instances of the data model are encoded in JSON-LD in
+the same way that they are encoded in JSON (Section <a href="#json"></a>),
+with the addition of the <code>@context</code> property. The
+<a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD Context</a>
+is described in detail in the [[!JSON-LD]] specification and its use
+is elaborated upon in Section <a href="#extensibility"></a>.
+        </p>
+
+        <p>
+Multiple contexts MAY be used or combined to express any arbitrary
+information about credentials in idiomatic JSON. If an application is
+processing a <a>verifiable credential</a> or <a>verifiable presentation</a>,
+and a <code>@context</code> property is not present at the top-level of the
+JSON-LD document, then a <code>@context</code> property with a value of
+<code>https://w3id.org/credentials/v1</code> MUST be assumed.
+        </p>
+
+      </section>
+
+    </section>
+
+    <section>
       <h1>Verification</h1>
 
       <p>

--- a/index.html
+++ b/index.html
@@ -1420,6 +1420,33 @@ as the specific vocabulary terms for disputed claims.
 
       </section>
 
+      <section>
+        <h2>Conformance</h2>
+
+        <p>
+A concrete expression of the data model in this specification is a
+<em>conforming document</em> if it complies with the normative statements in
+this specification regarding syntax (e.g. the content in
+<a href="#basic-concepts">Basic Concepts</a>,
+<a href="#advanced-concepts">Advanced Concepts</a>, and
+<a href="#syntaxes">Syntaxes</a>).
+For convenience, normative statements for <em>conforming documents</em> are
+often phrased as statements on the syntax used in properties and their
+associated values in the document (e.g. MUST be a URI,
+MUST be a string value of an ISO8601 combined date and time string).
+        </p>
+
+        <p>
+A <em>conforming processor</em> is a software or hardware-based implementation
+of the normative statements in this specification regarding the expected
+contents of property-value pairs (e.g. the content in <a>Verification</a>).
+For convenience, normative statements for <em>conforming processors</em> are
+often phrased as behavioral statements regarding the contents of
+property-value pairs (e.g. MUST NOT be revoked, MUST be in the expected range).
+        </p>
+
+      </section>
+
     </section>
 
     <section>


### PR DESCRIPTION
Most W3C specs have a section on conformance. This just adds that section, which has been missing for a while.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/197.html" title="Last updated on Jul 10, 2018, 9:34 PM GMT (72a8ed0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/197/b41e408...72a8ed0.html" title="Last updated on Jul 10, 2018, 9:34 PM GMT (72a8ed0)">Diff</a>