### PR TITLE
Add section on caching credentials and refreshService. Fixes #164. Fixes #139.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1244,9 +1244,7 @@ the Cache-Control header in HTTP [[RFC7234]] Section
           <dt><var>cacheRefreshService</var></dt>
           <dd>
 The value of this property MUST be a URL. The URL MUST be constructed such that
-an HTTP GET with a query parameter of <code>id</code> and the value of the
-credential `id` property appended will result in an updated credential or an
-error.
+an HTTP GET on it will result in an updated credential or an error.
           </dd>
         </dl>
 
@@ -1258,7 +1256,7 @@ error.
   "issuer": "https://example.com/issuers/14",
   "issuanceDate": "2018-02-24T05:28:04Z",
   <span class="highlight">"cacheControl": "public, must-revalidate, max-age=5184000"</span>,
-  <span class="highlight">"cacheRefreshService": "https://example.org/credentials"</span>,
+  <span class="highlight">"cacheRefreshService": "https://example.org/credentials?id=3fgJ3k"</span>,
   "claim": {
     "id": "did:example:abcdef1234567",
     "name": "Jane Doe"
@@ -1268,7 +1266,7 @@ error.
         </pre>
 
         <p>
-It is strongly RECOMMENDED that the `cacheRefreshService` URL authenticates
+It is RECOMMENDED that the `cacheRefreshService` URL authenticates
 the caller and SHOULD only allow the holder of the original credential to
 retrieve a refreshed credential in order to mitigate privacy violations.
         </p>

--- a/index.html
+++ b/index.html
@@ -1279,6 +1279,12 @@ their operational needs.
         </p>
 
         <p>
+Any relative time value (e.g. <em>delta-seconds</em>), such as values associated
+with <code>max-age</code>, specified in the <code>cacheControl</code> field
+MUST be specified as being relative to the <code>issuanceDate</code>.
+        </p>
+
+        <p>
 If used, HTTP Cache-Control Header values MUST be at least as restrictive
 (i.e. cause the cached value to invalidate) as <code>cacheControl</code> values
 specified in an HTTP message (e.g. <a>presentation</a>). For example, the value

--- a/index.html
+++ b/index.html
@@ -1218,6 +1218,70 @@ new <code>favoriteFood</code> term so that it may only be used within the
 
       </section>
 
+
+      <section>
+        <h2>Caching</h2>
+
+        <p>
+<a>Issuers</a> may wish to signal information related to caching a
+<a>credential</a> to <a>holders</a> and <a>verifiers</a>. Some issuers may
+assert that they do not want a credential to be cached, while others may
+specify certain caching rules and refresh time periods that are acceptable.
+        </p>
+
+        <p>
+Caching information for the credential in the Verifiable Credentials Data
+Model is provided by adding the following <a>properties</a>:
+        </p>
+
+        <dl>
+          <dt><var>cacheControl</var></dt>
+          <dd>
+The value of this property MUST be one or more of the acceptable values for
+the Cache-Control header in HTTP [[RFC7234]] Section
+<a href="https://tools.ietf.org/html/rfc7234#section-5.2">5.2. Cache-Control</a>.
+          </dd>
+          <dt><var>cacheRefreshService</var></dt>
+          <dd>
+The value of this property MUST be a URL. The URL MUST be constructed such that
+an HTTP GET with a query parameter of <code>id</code> and the value of the
+credential `id` property appended will result in an updated credential or an
+error.
+          </dd>
+        </dl>
+
+        <pre class="example nohighlight" title="A simple credential with caching information">
+{
+  "@context": "https://w3id.org/credentials/v1",
+  "id": "http://example.com/credentials/4643",
+  "type": ["VerifiableCredential"],
+  "issuer": "https://example.com/issuers/14",
+  "issuanceDate": "2018-02-24T05:28:04Z",
+  <span class="highlight">"cacheControl": "public, must-revalidate, max-age=5184000"</span>,
+  <span class="highlight">"cacheRefreshService": "https://example.org/credentials"</span>,
+  "claim": {
+    "id": "did:example:abcdef1234567",
+    "name": "Jane Doe"
+  },
+  "proof": { ... }
+}
+        </pre>
+
+        <p>
+It is strongly RECOMMENDED that the `cacheRefreshService` URL authenticates
+the caller and SHOULD only allow the holder of the original credential to
+retrieve a refreshed credential in order to mitigate privacy violations.
+        </p>
+
+        <p>
+If a <code>cacheControl</code> value is not present, then a <a>verifier</a>
+MAY cache the data up to the <code>expirationDate</code>, while ensuring to
+process the credential <a href="#status">status</a> at an interval that meets
+their operational needs.
+        </p>
+
+      </section>
+
       <section>
         <h2>Terms of Use</h2>
 

--- a/index.html
+++ b/index.html
@@ -1266,9 +1266,12 @@ an HTTP GET on it will result in an updated credential or an error.
         </pre>
 
         <p>
-It is RECOMMENDED that the `refreshService` URL authenticates the caller and
-SHOULD only allow the holder of the original credential to retrieve a
-refreshed credential in order to mitigate privacy violations.
+It is RECOMMENDED that the <code>refreshService</code> URL authenticates the
+caller and SHOULD only allow the holder of the original credential to retrieve
+a refreshed credential in order to mitigate privacy violations. <a>Issuers</a>
+SHOULD ensure that the <code>refreshService</code> URL does not leak any
+more information than is provided in the credential itself (e.g. user account
+details that are not present in the credential).
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -1266,8 +1266,8 @@ an HTTP GET on it will result in an updated credential or an error.
         </pre>
 
         <p>
-It is RECOMMENDED that the `refreshService` URL authenticates the caller and 
-SHOULD only allow the holder of the original credential to retrieve a 
+It is RECOMMENDED that the `refreshService` URL authenticates the caller and
+SHOULD only allow the holder of the original credential to retrieve a
 refreshed credential in order to mitigate privacy violations.
         </p>
 
@@ -1276,6 +1276,17 @@ If a <code>cacheControl</code> value is not present, then a <a>verifier</a>
 MAY cache the data up to the <code>expirationDate</code>, while ensuring to
 process the credential <a href="#status">status</a> at an interval that meets
 their operational needs.
+        </p>
+
+        <p>
+If used, HTTP Cache-Control Header values MUST be at least as restrictive
+(i.e. cause the cached value to invalidate) as <code>cacheControl</code> values
+specified in an HTTP message (e.g. <a>presentation</a>). For example, the value
+for <code>max-age</code> specified in an HTTP Cache-Control Header MUST be
+equal to or less than the <code>max-age</code> value specified in the
+<a>credential</a>. In the event that there is a conflict between the
+<code>cacheControl</code> value and the HTTP Cache-Control Header, the value
+that causes the cache to invalidate the soonest MUST be used.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1241,7 +1241,7 @@ The value of this property MUST be one or more of the acceptable values for
 the Cache-Control header in HTTP [[RFC7234]] Section
 <a href="https://tools.ietf.org/html/rfc7234#section-5.2">5.2. Cache-Control</a>.
           </dd>
-          <dt><var>cacheRefreshService</var></dt>
+          <dt><var>refreshService</var></dt>
           <dd>
 The value of this property MUST be a URL. The URL MUST be constructed such that
 an HTTP GET on it will result in an updated credential or an error.
@@ -1256,7 +1256,7 @@ an HTTP GET on it will result in an updated credential or an error.
   "issuer": "https://example.com/issuers/14",
   "issuanceDate": "2018-02-24T05:28:04Z",
   <span class="highlight">"cacheControl": "public, must-revalidate, max-age=5184000"</span>,
-  <span class="highlight">"cacheRefreshService": "https://example.org/credentials?id=3fgJ3k"</span>,
+  <span class="highlight">"refreshService": "https://example.org/credentials?id=3fgJ3k"</span>,
   "claim": {
     "id": "did:example:abcdef1234567",
     "name": "Jane Doe"
@@ -1266,9 +1266,9 @@ an HTTP GET on it will result in an updated credential or an error.
         </pre>
 
         <p>
-It is RECOMMENDED that the `cacheRefreshService` URL authenticates
-the caller and SHOULD only allow the holder of the original credential to
-retrieve a refreshed credential in order to mitigate privacy violations.
+It is RECOMMENDED that the `refreshService` URL authenticates the caller and 
+SHOULD only allow the holder of the original credential to retrieve a 
+refreshed credential in order to mitigate privacy violations.
         </p>
 
         <p>


### PR DESCRIPTION
This is an attempt to propose how we do credential caching and credential refreshing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/199.html" title="Last updated on Jul 17, 2018, 2:29 PM GMT (fa18583)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/199/db4abd5...fa18583.html" title="Last updated on Jul 17, 2018, 2:29 PM GMT (fa18583)">Diff</a>