### PR TITLE
Tamper-evident, not tamper-resistant

### DIFF
--- a/index.html
+++ b/index.html
@@ -451,7 +451,7 @@ same <a>entity</a>. It may include an identifier to uniquely identify the
 credential, as well as metadata that describes properties of the credential
 itself such as: the <a>issuer</a>, the expiry time, a representative image,
 etc. A <a>verifiable credential</a> is a set of claims and meta data that are
-tamper-resistant and that cryptographically prove who issued it.
+tamper-evident and that cryptographically prove who issued it.
       </p>
 
       <figure>

--- a/terms.html
+++ b/terms.html
@@ -14,7 +14,7 @@ A statement made about a <a>subject</a>.
   <dd>
 A set of one or more <a>claims</a> made by the same <a>entity</a>.
 A <dfn data-lt="verifiable credentials">verifiable credential</dfn>
-is a credential that is tamper-resistant and whose authorship can be
+is a credential that is tamper-evident and whose authorship can be
 cryptographically verified.
   </dd>
   <dt><dfn data-lt="credential validation">validation</dfn></dt>
@@ -98,7 +98,7 @@ A set of one or more <a>credentials</a> typically related to the same
 <a>subject</a>. An <a>entity</a> may have multiple profiles and each profile
 may contain <a>verifiable credentials</a> issued by multiple <a>issuers</a>. A
 <dfn data-lt="verifiable profiles">verifiable profile</dfn> is
-a profile that is tamper-resistant and whose contents are typically
+a profile that is tamper-evident and whose contents are typically
 counter-signed by the <a>holder</a> or <a>subject</a>.
   </dd>
   <dt><dfn data-lt="credential repository|credential repositories|repositories">repository</dfn></dt>


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>

We were misusing terms. VCs are not tamper-resistant (designed to frustrate tampering). Anybody can get a VC and rewrite bytes in the file. They are tamper-evident (designed to provide clear evidence if somebody tampers). See the articles about these two terms on wikipedia.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/vc-data-model/pull/215.html" title="Last updated on Aug 15, 2018, 6:32 PM GMT (d67ffdb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/215/21f255f...dhh1128:d67ffdb.html" title="Last updated on Aug 15, 2018, 6:32 PM GMT (d67ffdb)">Diff</a>