### PR TITLE
Tamper-evident, not tamper-resistant

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,7 +491,7 @@ same <a>entity</a>. It may include an identifier to uniquely identify the
 credential, as well as metadata that describes properties of the credential
 itself such as: the <a>issuer</a>, the expiry time, a representative image,
 etc. A <a>verifiable credential</a> is a set of claims and meta data that are
-tamper-resistant and that cryptographically prove who issued it.
+tamper-evident and that cryptographically prove who issued it.
       </p>
 
       <figure>

--- a/terms.html
+++ b/terms.html
@@ -14,7 +14,7 @@ An assertion made about a <a>subject</a>.
   <dd>
 A set of one or more <a>claims</a> made by the issuer.
 A <dfn data-lt="verifiable credentials">verifiable credential</dfn>
-is a credential that is tamper-resistant and whose authorship can be
+is a credential that is tamper-evident and whose authorship can be
 cryptographically verified.
   </dd>
   <dd>
@@ -103,7 +103,7 @@ A set of one or more <a>verifiable credentials</a> transmitted by a holder.
 A <a>holder</a> may create multiple presentations and each presentation
 may contain <a>verifiable credentials</a> issued by multiple <a>issuers</a>. A
 <dfn data-lt="verifiable presentations">verifiable presentation</dfn> is
-a presentation that is made tamper-resistant by the <a>holder</a>.
+a presentation that is made tamper-evident by the <a>holder</a>.
   </dd>
   <dt><dfn data-lt="credential repository|credential repositories|repositories">repository</dfn></dt>
   <dd>


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>

VCs are not tamper-resistant; anybody can modify the bytes in a VC file. Rather, they are tamper-evident, meaning we can tell when such a modification happens. See the wikipedia articles about these two terms.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/vc-data-model/pull/218.html" title="Last updated on Aug 20, 2018, 4:35 PM GMT (2e56d54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/218/e70d984...dhh1128:2e56d54.html" title="Last updated on Aug 20, 2018, 4:35 PM GMT (2e56d54)">Diff</a>