### PR TITLE
Distinguish credentials from presentations

### DIFF
--- a/index.html
+++ b/index.html
@@ -980,51 +980,11 @@ exists for implementers that would like to implement credential status checking.
         <h2>Presentations</h2>
 
         <p>
-Credentials MAY be composed by placing them into a data structure called a
-<a>presentation</a>. A <a>verifiable presentation</a> is a presentation that contains
-<a>verifiable credentials</a> and one or more proofs that are appropriate
-for the presentation. The basic structure of a <a>verifiable presentation</a>
-is provided below:
+Credentials MAY be used to make a <a>verifiable presentation</a>. The presentation
+may be of a credential itself, or of a profile, or of data derived from credentials
+in a format that is cryptographically verifiable.
         </p>
 
-        <pre class="example nohighlight" title="Basic structure of a presentation">
-{
-  "@context": "https://w3id.org/credentials/v1",
-  "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
-  "type": ["VerifiablePresentation"],
-  <span class="highlight">"verifiableCredential": [{ ... }],
-  "proof": [{ ... }]</span>
-}
-        </pre>
-
-        <p class="issue" data-number=133>
-The group is currently discussing whether the "id" field is appropriately
-defined for Presentations.
-        </p>
-
-        <p class="issue" data-number=120>
-The group is currently discussing whether the "id" field is appropriately
-defined across all objects.
-        </p>
-
-        <p class="issue" data-number=106>
-The group is currently discussing how the data model expresses when the
-subject is not the holder of the credential/presentation.
-        </p>
-
-        <p class="issue" data-number=105>
-The group is currently discussing holders, subjects, and identifier
-control.
-        </p>
-
-        <p>
-The contents of the <code>verifiableCredential</code> property are
-<a>verifiable credentials</a> as described by this specification. The contents
-of the <code>proof</code> property are proofs as described by the
-Linked Data Proofs [[LD-PROOFS]] specification. The <code>id</code> property
-is optional and MAY be used to provide a unique identifier for the presentation.
-The value associated with the <code>id</code> property MUST be a URI.
-        </p>
       </section>
     </section>
 
@@ -1248,10 +1208,9 @@ new <code>favoriteFood</code> term so that it may only be used within the
         <p>Terms of use can be utilized by an <a>issuer</a>, <a>subject</a> or a
         <a>holder</a> to express limitations on the use of information
         expressed by the Verifiable Credentials Data Model. The <a>issuer</a> places
-        the terms of use inside the <a>credential</a> before it is converted into a
-        <a>verifiable credential</a>. The <a>holder</a> places the terms of use inside
-        the <a>presentation</a> before it is converted into a
-        <a>verifiable presentation</a>.</p>
+        their terms of use inside the <a>credential</a> before it is converted into a
+        <a>verifiable credential</a>. The <a>holder</a> places issuer terms
+        of use, if applicable, plus holder terms of use, inside a <a>presentation</a>.</p>
 
        <p class="note"> it is for further study how a subject who is not a
        holder places terms of
@@ -1282,6 +1241,7 @@ new <code>favoriteFood</code> term so that it may only be used within the
 The group is currently exploring a variety of ways of expressing the terms of
 use associated with a Verifiable Credential, namely, the
 <a href="http://w3c.github.io/poe/model/">Open Digital Rights Language</a>.
+A related initiative is the one at customercommons.org.
         </p>
 
         <pre class="example nohighlight" title="Usage of termsOfUse property by an Issuer">

--- a/index.html
+++ b/index.html
@@ -1522,14 +1522,16 @@ should treat this entire section as at-risk and currently under debate.
       <p>
 Normally verifiable credentials will be presented to verifiers by the
 subject. However in some cases, the subject may need to pass the whole or
-part of a verifiable credential to a holder. The data model allows for both
-cases as follows.
+part of a verifiable credential to another holder. The data model allows for
+both cases as follows.
       </p>
 
       <p>
 If only the subject is allowed to present the verifiable credential to a
 verifier, the issuer MUST insert the "subject only" Terms of Use into the
-verifiable credential, as defined below.
+verifiable credential, as defined below. <span class="issue">
+This feature is at risk and is likely to be removed due to lack of consensus.
+</span>
       </p>
 
       <p>
@@ -1538,12 +1540,21 @@ verifiable credential to a holder, for example, a patient may pass a
 prescription verifiable credential to a relative for the relative to present
 it to a pharmacist for dispensing, then the subject MUST issue a verifiable
 credential to the holder containing the claim properties that are being
-passed on, as described below.
+passed on, as described below. <span class="issue">
+This feature is at risk and is likely to be removed and replaced with
+another solution, possibly created by another Working Group, that focuses on
+delegation of authority instead of delegation of attributes.
+</span>
       </p>
 
    <section>
 
    <h3> 'Subject Only' Terms of Use </h3>
+
+      <p class="issue" data-number=204>
+The group is currently debating the best security model for delegation. Readers
+should treat this entire section as at-risk and currently under debate.
+      <p>
 
   <p>
 The Subject Only Terms of Use states that a verifiable credential MUST only be presented to a verifier by the subject. If a verifier is presented with a verifiable credential containing the Subject Only Terms of Use, by anyone other than the subject, it MUST refuse to accept it.</p>
@@ -1571,6 +1582,11 @@ The Subject Only Terms of Use states that a verifiable credential MUST only be p
   <section>
    <h3> Passing on a Verifiable Credential </h3>
 
+      <p class="issue" data-number=204>
+The group is currently debating the best security model for delegation. Readers
+should treat this entire section as at-risk and currently under debate.
+      <p>
+
    <p>
 
 When the subject passes a verifiable credential to a
@@ -1580,8 +1596,6 @@ the subject is the holder to whom the verifiable credential is being passed,
 and the claim contains the properties that are being passed on. In addition, the holder creates a verifiable presentation that contains these two
 verifiable credentials.
 </p>
-
-
 
         <pre class="example nohighlight" title="An example of a holder presenting verifiable
 credential properties that have been passed to it by the subject">
@@ -1635,32 +1649,48 @@ credential properties that have been passed to it by the subject">
    </section>
   </section>
 
-
-
    <section>
-      <h2>Holder Acts on Behalf of Subject</h2>
+      <h2>Holder Acts on Behalf of the Subject</h2>
 
       <p>
-When the holder wants to act on behalf of the subject, the issuer SHOULD indicate this by
-either including the relationship of the holder in the subject's <a>claim</a>,
-or by issuing a separate relationship credential to the holder.
-Either way, the relationship describes the relationship between the holder and the subject of the claim, and helps the verifier to decide whether to accept the verifiable credential or not. </p>
+The data model supports the <a>holder</a> acting on behalf of the
+<a>subject</a> in at least the following ways:
+      </p>
 
-<p class="issue"> It is outside
-the scope of this standard how the issuer verifies the subject, the holder and the
-relationship between them.
+      <ul>
+        <li>
+The issuer may include the relationship between the holder and the subject
+in the <code>claim</code> data.
+        </li>
+        <li>
+The issuer may express the relationship between the holder and the subject
+by issuing a new <a>verifiable credential</a> which the holder utilizes.
+        </li>
+        <li>
+The subject may express their relationship with the holder by issuing a
+new <a>verifiable credential</a> which the holder utilizes.
+        </li>
+      </ul>
 
-<p>
-Note: it is for further study which, if any, of these mechanisms is to be
+      <p>
+The mechanisms above describe the relationship between the holder and the
+subject and helps the verifier to decide whether the relationship is
+sufficiently expressed for the given use case.
+      </p>
+
+      <p class="note">
+The additional mechanisms that the issuer or the verifier uses to verify the
+relationship between the subject and the holder are outside of the scope of
+this specification.
+      </p>
+
+      <p class="issue">
+It is for further study which, if any, of these mechanisms is to be
 standardised by the working group.
+      </p>
 
-     </p>
-
-
-        <pre class="example nohighlight" title="An example of the relationship
-property in a child's credential, so that a parent can hold it">
-
-{
+      <pre class="example nohighlight" title="An example of the relationship
+property in a child's credential">{
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["Credential", "ProofOfAgeCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",
@@ -1669,24 +1699,22 @@ property in a child's credential, so that a parent can hold it">
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "ageUnder": 16,
     "parent": {
-      "type": "Mother",
-      "id": "did:example:ebfeb1c276e12ec211f712ebc6f"
+      "id": "did:example:ebfeb1c276e12ec211f712ebc6f",
+      "type": "Mother"
     }
   },
-  "proof": {
-    "type": "RsaSignature2018",
-    "created": "2017-06-17T10:03:48Z",
-    "creator": "https://dmv.example.gov/issuers/14/keys/234",
-    "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-    "signatureValue": "pY9...Cky6Ed = "
-  }
+  "proof": { ... } // the proof is generated by the DMV
 }
-     </pre>
+      </pre>
 
-<pre class="example nohighlight" title="An example of a relationship credential issued to
-a parent so that the parent can hold their child's verifiable credentials">
+      <p>
+In the example above, the issuer has expressed the relationship between the
+child and the parent such that a verifier would most likely accept the
+credential if it is provided by the child or the parent.
+      </p>
 
-{
+      <pre class="example nohighlight" title="An example of a relationship
+credential issued to a parent">{
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["Credential", "RelationshipCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",
@@ -1694,22 +1722,49 @@ a parent so that the parent can hold their child's verifiable credentials">
   "claim": {
     "id": "did:example:ebfeb1c276e12ec211f712ebc6f",
     "child": {
-      "type": ["Person", "Child"],
-      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21"
+      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+      "type": ["Person", "Child"]
     }
   },
-  "proof": {
-    "type": "RsaSignature2018",
-    "created": "2017-06-17T10:03:48Z",
-    "creator": "https://dmv.example.gov/issuers/14/keys/234",
-    "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-    "signatureValue": "pY9...Cky6Ed = "
-  }
+  "proof": { ... } // the proof is generated by the DMV
 }
-
 </pre>
 
-<p> It can easily be seen from the above example how an authoritative issuer could indicate that a person is the owner of a pet dog </p>
+     <p>
+In the example above, the issuer has expressed the relationship between the
+child and the parent in a separate credential such that a verifier would most
+likely accept any of the child's credentials if it is provided by the child or
+if the credential above is provided with any of the child's credentials.
+     </p>
+
+     <pre class="example nohighlight" title="An example of a relationship
+credential issued by a child">{
+  "id": "http://example.org/credentials/23894",
+  "type": ["Credential", "RelationshipCredential"],
+  "issuer": "http://example.org/credentials/23894",
+  "issued": "2010-01-01T19:73:24Z",
+  "claim": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "parent": {
+      "id": "did:example:ebfeb1c276e12ec211f712ebc6f",
+      "type": "Mother"
+    }
+  },
+  "proof": { ... } // the proof is generated by the child
+}
+</pre>
+
+      <p>
+In the example above, the child has expressed the relationship between the
+child and the parent in a separate credential such that a verifier would most
+likely accept any of the child's credentials if the credential above is
+provided.
+      </p>
+
+      <p>
+Similarly, these same strategies can be used for many other types of use cases
+such as power of attorney, pet ownership, and patient prescription pick up.
+      </p>
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -984,7 +984,7 @@ exists for implementers that would like to implement credential status checking.
 Credentials MAY be used to make a <a>verifiable presentation</a>. A
 verifiable presentation may be of a verifiable credential itself, or
 of data derived from verifiable credentials in a format that is
-cryptographically verifiable. In the first example below, we show a
+cryptographically verifiable. In the example below, we show a
 verifiable presentation that embeds verifiable credentials:
         </p>
 
@@ -1027,62 +1027,9 @@ verifiable presentation that embeds verifiable credentials:
           </p>
 
           <p>
-          The next example shows a ZKP-style verifiable presentation that contains
-          derived data instead. Here, the original credential contained a birthdate;
-          the presentation references that birthdate to assert an "over 65" <a>derived
-          predicate</a>, plus a "not expired" <a>derived predicate</a>. Notice that
-          claims are clustered by subject, with some claims about "this" (the credential
-          itself), and others about a subject named "person."
-      </p>
-          <pre class="example nohighlight"
-               title="Usage of proof property on a verifiable presentation">
-            {
-              "type": ["VerifiablePresentation"],
-              "claims": [       <i>// Each of the claims is created from a verifiable credential</i>
-                {
-                    "credDef": "sov:CRED_DEF:EID",
-                    "this": {
-                      "issuer": "https://eid.gov/issuers/1",
-                      "not expired": true,
-                      "holder": "person",
-                    },
-                    "person": {
-                      "> 65": "true",
-                    }
-                },
-                {
-                    "credDef": "sov:CRED_DEF:SUBSCRIPTION",
-                    "this": {
-                      "issuer": "https://moviestreaming.com/issuers/1",
-                      "not expired": true,
-                      "holder": "person",
-                    },
-                    "person": {
-                      "subscription type": "premium",
-                    }
-                }
-              ],
-              <span class="highlight">"proofs": [	<i>// the number of proofs is same as the number of claims</i>
-                {
-                    "type": "z-mix",
-                    "value": {
-                        <i>// meant to be parsed by a library supporting "z-mix"</i>
-                        ...
-                        ....
-                    }
-                },
-                {
-                    "type": "z-mix",
-                    "value": {
-                        <i>// meant to be parsed by a library supporting "z-mix"</i>
-                        ...
-                        ....
-                    }
-                }
-              ]
-            </span>
-            }
-            </pre>
+          We are currently working on an example of a ZKP-style verifiable presentation that contains
+          derived data instead of directly embedded verifiable credentials.
+          </p>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -209,15 +209,15 @@ information related to expiration dates.
       </ul>
 
       <p>
-A verifiable credential is capable of representing all of the same information
-that a physical credential is intended to represent. The addition of
-digital technologies, such as digital signatures, also make verifiable
-credentials more tamperproof and therefore more trustworthy
-than their physical counterparts. Verifiable credentials can also be
-rapidly exchanged through the Internet, making them more convenient than
-their physical counterparts when needing to establish trust at a distance.
+A verifiable credential can represent all of the same information that a
+physical credential represents. The addition of technologies such as
+digital signatures makes verifiable credentials more tamper-evident and
+therefore more trustworthy than their physical counterparts. Holders can
+generate presentations and share them with verifiers to prove they possess
+verifiable credentials with certain characteristics. Both credentials and
+presentations can be rapidly exchanged, making them more convenient than
+their physical counterparts when establishing trust at a distance.
       </p>
-
     </section>
 
     <section>
@@ -238,8 +238,8 @@ standardization. The following roles are introduced in this specification:
         <dt><a>holder</a></dt>
         <dd>
 A role an <a>entity</a> may perform by possessing one or more
-<a>verifiable credentials</a>. Examples of holders include students,
-employees, and customers.
+<a>verifiable credentials</a> and generationg <a>presentations</a> from them
+Examples of holders include students, employees, and customers.
         </dd>
         <dt><a>issuer</a></dt>
         <dd>
@@ -251,7 +251,7 @@ trade associations, governments, and individuals.
         <dt><a>verifier</a></dt>
         <dd>
 A role an <a>entity</a> may perform by receiving one or more
-<a>verifiable credentials</a> for processing.
+<a>verifiable presentations</a> for processing.
 Examples of verifiers include employers, security personnel, and websites.
         </dd>
         <dt><a>identifier registry</a></dt>
@@ -346,21 +346,24 @@ specification, namely:
       <ul>
         <li>
 <a>Holders</a> receive and store <a>verifiable credentials</a> from
-<a>issuers</a> through an agent that the issuer does not need to trust.
+<a>issuers</a>. <a>Holders</a> may interact with an issuer through an
+agent that the issuer needn't trust.
         </li>
         <li>
 <a>Holders</a> are positioned between <a>issuers</a> and <a>verifiers</a>
-and mediate the transmission of <a>verifiable credentials</a>.
+and use <a>verifiable credentials</a> to make <a>verifiable presentations</a>
+to <a>verifiers</a>.
         </li>
         <li>
-<a>Holders</a> provide <a>verifiable credentials</a> to <a>verifiers</a>
-through an agent that verifiers needn't trust; they only need to trust
+<a>Holders</a> may interact with <a>verifiers</a> through an agent that
+verifiers needn't trust; verifiers only need to trust
 <a>issuers</a>.
         </li>
         <li>
 <a>Verifiable credentials</a> are associated with <a>subjects</a>, not
 particular services; <a>holders</a> decide how to aggregate and manage
-<a>verifiable credentials</a>.
+<a>verifiable credentials</a> and the <a>verifiable presentations</a>
+associated with them.
         </li>
         <li>
 <a>Holders</a> are able to easily control and own their own identifiers.
@@ -373,17 +376,22 @@ particular services; <a>holders</a> decide how to aggregate and manage
 to help them manage and share their <a>verifiable credentials</a>.
         </li>
         <li>
-<a>Holders</a> that share <a>verifiable credentials</a> are not required to
+<a>Holders</a> that share <a>verifiable presentations</a> are not required to
 reveal the identity of the <a>verifier</a> to <a>issuers</a>.
         </li>
         <li>
-A <a>verifiable credential</a> is expressed in one or more standard,
-machine-readable data formats which can also be extended with minimal
-coordination.
+<a>Holders</a> in <a>presentations</a> can either disclose the attributes or satisfy <a>predicates</a>
+requested by the <a>verifier</a>. <a>Predicates</a> are boolean conditions like greater/less than or
+equal to, is in set, etc.
         </li>
         <li>
-<a>Verifiable credentials</a> are independently issued, stored,
-and verified.
+<a>Verifiable credentials</a> and <a>verifiable presentations</a> are expressed in one or more standard,
+machine-readable data formats which can also be extended with minimal coordination.
+        </li>
+        <li>
+Issuers independently issue <a>verifiable credentials</a>, and holders store them.
+Holders independently offer <a>verifiable presentations</a>, and verifiers
+independently verify them.
         </li>
         <li>
 <a>Verifiable Credentials</a> can be revoked by the <a>issuer</a>.
@@ -459,6 +467,12 @@ An example of a basic claim that expresses that Pat is over the age of 21.
       </figure>
 
       <p>
+If a presentation supports predicates, a claim about birthdate (not true or false, but tied to
+a specific date value) can become the basis of proof that at an arbitrary point in time, the
+age of a subject did or will lie within an arbitrary interval.
+      </p>
+
+      <p>
 These claims may be merged together to express a graph of
 information about a particular subject. The example below extends the
 data model above by adding claims that state that Pat knows Sam and that
@@ -531,8 +545,15 @@ subset of one's persona is called a <a>verifiable presentation</a>.
       </p>
 
       <p>
-A <a>verifiable presentation</a> is a collection of one or more
-<a>verifiable credentials</a> that are often about the same <a>subject</a> that
+A <a>verifiable presentation</a> is data from one or more <a>verifiable
+credentials</a>, packaged in such a way that the authorship of the data
+is verifiable. If credentials are directly presented, they become a
+presentation. Profiles are presentations. Data formats derived from
+credentials that are cryptographically verifiable but that do not, of
+themselves, contain credentials, may also be presentations.
+      </p>
+      <p>
+      The data in a presentation are often about the same <a>subject</a> that
 have been issued by multiple <a>issuers</a>. The aggregation of this
 information typically expresses an aspect of a person, organization, or entity.
       </p>
@@ -552,7 +573,7 @@ gaming persona, or home life persona.
 
       <p class="note">
 It is possible to have a <a>presentation</a>, such as a business persona,
-that contains multiple <a>credentials</a> about different <a>subjects</a>
+that draws upon multiple <a>credentials</a> about different <a>subjects</a>
 that are often, but not required to be, related.
       </p>
 
@@ -584,7 +605,7 @@ All entities trust the <a>identifier registry</a> to be un-corruptible and
 to be a correct record of which identifiers belong to which <a>entities</a>.
         </li>
         <li>
-The <a>subject</a> trusts the <a>issuer</a> to issue true (i.e. not false)
+The <a>subject</a> trusts the <a>issuer</a> to issue true
 <a>credentials</a> about the subject, and to revoke them quickly when
 appropriate.
         </li>
@@ -605,7 +626,7 @@ The <a>issuer</a> and the <a>verifier</a> do not need to trust the
 repository</a>, and
         </li>
         <li>
-the <a>issuer</a> does not need to trust the <a>verifier</a>.
+the <a>issuer</a> does not need to trust (or even know) the <a>verifier</a>.
         </li>
       </ul>
 

--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@ standardization. The following roles are introduced in this specification:
         <dt><a>holder</a></dt>
         <dd>
 A role an <a>entity</a> may perform by possessing one or more
-<a>verifiable credentials</a> and generationg <a>presentations</a> from them
+<a>verifiable credentials</a> and generating <a>presentations</a> from them.
 Examples of holders include students, employees, and customers.
         </dd>
         <dt><a>issuer</a></dt>
@@ -389,9 +389,10 @@ equal to, is in set, etc.
 machine-readable data formats which can also be extended with minimal coordination.
         </li>
         <li>
-Issuers independently issue <a>verifiable credentials</a>, and holders store them.
-Holders independently offer <a>verifiable presentations</a>, and verifiers
-independently verify them.
+Issuers issue <a>verifiable credentials</a>, and holders store them.
+Holders offer <a>verifiable presentations</a>, and verifiers verify them.
+Issuance of credentials, storage of credentials, the generation and sharing
+of presentations, and the verification of them are each independent processes.
         </li>
         <li>
 <a>Verifiable Credentials</a> can be revoked by the <a>issuer</a>.
@@ -467,9 +468,9 @@ An example of a basic claim that expresses that Pat is over the age of 21.
       </figure>
 
       <p>
-If a presentation supports predicates, a claim about birthdate (not true or false, but tied to
-a specific date value) can become the basis of proof that at an arbitrary point in time, the
-age of a subject did or will lie within an arbitrary interval.
+If a presentation supports <a>derived predicates<a>, a claim about birthdate in a
+credential can become the basis of proof that at an arbitrary point in time, the
+age of a subject did or will fall within an arbitrary interval.
       </p>
 
       <p>
@@ -545,12 +546,12 @@ subset of one's persona is called a <a>verifiable presentation</a>.
       </p>
 
       <p>
-A <a>verifiable presentation</a> is data from one or more <a>verifiable
-credentials</a>, packaged in such a way that the authorship of the data
+A <a>verifiable presentation</a> expresses data from one or more <a>verifiable
+credentials</a>, and is packaged in such a way that the authorship of the data
 is verifiable. If credentials are directly presented, they become a
-presentation. Profiles are presentations. Data formats derived from
-credentials that are cryptographically verifiable but that do not, of
-themselves, contain credentials, may also be presentations.
+presentation. Data formats derived from credentials that are cryptographically
+verifiable but that do not, of themselves, contain credentials, may also be
+presentations.
       </p>
       <p>
       The data in a presentation are often about the same <a>subject</a> that
@@ -626,7 +627,7 @@ The <a>issuer</a> and the <a>verifier</a> do not need to trust the
 repository</a>, and
         </li>
         <li>
-the <a>issuer</a> does not need to trust (or even know) the <a>verifier</a>.
+the <a>issuer</a> does not need to know or trust the <a>verifier</a>.
         </li>
       </ul>
 
@@ -980,11 +981,108 @@ exists for implementers that would like to implement credential status checking.
         <h2>Presentations</h2>
 
         <p>
-Credentials MAY be used to make a <a>verifiable presentation</a>. The presentation
-may be of a credential itself, or of a profile, or of data derived from credentials
-in a format that is cryptographically verifiable.
+Credentials MAY be used to make a <a>verifiable presentation</a>. A
+verifiable presentation may be of a verifiable credential itself, or
+of data derived from verifiable credentials in a format that is
+cryptographically verifiable. In the first example below, we show a
+verifiable presentation that embeds verifiable credentials:
         </p>
 
+          <pre class="example nohighlight" title="Basic structure of a presentation">
+          {
+          "@context": "https://w3id.org/credentials/v1",
+          "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
+          "type": ["VerifiablePresentation"],
+          <span class="highlight">"verifiableCredential": [{ ... }],
+  "proof": [{ ... }]</span>
+          }
+          </pre>
+          <p class="issue" data-number=133>
+              The group is currently discussing whether the "id" field is appropriately
+              defined for Presentations.
+          </p>
+
+          <p class="issue" data-number=120>
+              The group is currently discussing whether the "id" field is appropriately
+              defined across all objects.
+          </p>
+
+          <p class="issue" data-number=106>
+              The group is currently discussing how the data model expresses when the
+              subject is not the holder of the credential/presentation.
+          </p>
+
+          <p class="issue" data-number=105>
+              The group is currently discussing holders, subjects, and identifier
+              control.
+          </p>
+
+          <p>
+              The contents of the <code>verifiableCredential</code> property shown above are
+              <a>verifiable credentials</a> as described by this specification. The contents
+              of the <code>proof</code> property are proofs as described by the
+              Linked Data Proofs [[LD-PROOFS]] specification. The <code>id</code> property
+              is optional and MAY be used to provide a unique identifier for the presentation.
+              The value associated with the <code>id</code> property MUST be a URI.
+          </p>
+
+          <p>
+          The next example shows a ZKP-style verifiable presentation that contains
+          derived data instead. Here, the original credential contained a birthdate;
+          the presentation references that birthdate to assert an "over 65" <a>derived
+          predicate</a>, plus a "not expired" <a>derived predicate</a>. Notice that
+          claims are clustered by subject, with some claims about "this" (the credential
+          itself), and others about a subject named "person."
+      </p>
+          <pre class="example nohighlight"
+               title="Usage of proof property on a verifiable presentation">
+            {
+              "type": ["VerifiablePresentation"],
+              "claims": [       <i>// Each of the claims is created from a verifiable credential</i>
+                {
+                    "credDef": "sov:CRED_DEF:EID",
+                    "this": {
+                      "issuer": "https://eid.gov/issuers/1",
+                      "not expired": true,
+                      "holder": "person",
+                    },
+                    "person": {
+                      "> 65": "true",
+                    }
+                },
+                {
+                    "credDef": "sov:CRED_DEF:SUBSCRIPTION",
+                    "this": {
+                      "issuer": "https://moviestreaming.com/issuers/1",
+                      "not expired": true,
+                      "holder": "person",
+                    },
+                    "person": {
+                      "subscription type": "premium",
+                    }
+                }
+              ],
+              <span class="highlight">"proofs": [	<i>// the number of proofs is same as the number of claims</i>
+                {
+                    "type": "z-mix",
+                    "value": {
+                        <i>// meant to be parsed by a library supporting "z-mix"</i>
+                        ...
+                        ....
+                    }
+                },
+                {
+                    "type": "z-mix",
+                    "value": {
+                        <i>// meant to be parsed by a library supporting "z-mix"</i>
+                        ...
+                        ....
+                    }
+                }
+              ]
+            </span>
+            }
+            </pre>
       </section>
     </section>
 
@@ -1205,12 +1303,12 @@ new <code>favoriteFood</code> term so that it may only be used within the
       <section>
         <h2>Terms of Use</h2>
 
-        <p>Terms of use can be utilized by an <a>issuer</a>, <a>subject</a> or a
-        <a>holder</a> to express limitations on the use of information
-        expressed by the Verifiable Credentials Data Model. The <a>issuer</a> places
-        their terms of use inside the <a>credential</a> before it is converted into a
-        <a>verifiable credential</a>. The <a>holder</a> places issuer terms
-        of use, if applicable, plus holder terms of use, inside a <a>presentation</a>.</p>
+        <p>Terms of use can be utilized by an <a>issuer</a>, a <a>subject</a>, or a
+        <a>holder</a> to constrain the use of information expressed by the Verifiable
+        Credentials Data Model. The <a>issuer</a> places their terms of use inside
+        the <a>credential</a> before it is converted into a <a>verifiable credential</a>.
+        The <a>holder</a> places holder terms of use inside a <a>presentation</a>.
+        </p>
 
        <p class="note"> it is for further study how a subject who is not a
        holder places terms of
@@ -1241,7 +1339,7 @@ new <code>favoriteFood</code> term so that it may only be used within the
 The group is currently exploring a variety of ways of expressing the terms of
 use associated with a Verifiable Credential, namely, the
 <a href="http://w3c.github.io/poe/model/">Open Digital Rights Language</a>.
-A related initiative is the one at customercommons.org.
+A related initiative is the one at <a href="https://customercommons.org">Customer Commons</a>.
         </p>
 
         <pre class="example nohighlight" title="Usage of termsOfUse property by an Issuer">

--- a/terms.html
+++ b/terms.html
@@ -15,21 +15,21 @@ An assertion made about a <a>subject</a>.
 A set of one or more <a>claims</a> made by the issuer.
 A <dfn data-lt="verifiable credentials">verifiable credential</dfn>
 is a credential that is tamper-resistant and whose authorship can be
-cryptographically verified. Credentials can be used to build
-<a>presentations</a>, which can also be cryptographically verified.
+cryptographically verified. Verifiable credentials can be used to build
+<a>verifiable presentations</a>, which can also be cryptographically verified.
   </dd>
   <dd>
 Note: The claims in a credential may be about different subjects.
   </dd>
   <dt><dfn data-lt="credential validation">validation</dfn></dt>
   <dd>
-The process that demonstrates the information in a <a>credential</a>
-or <a>presentation</a> is well-formed.
+The process that demonstrates the information in a <a>verifiable credential</a>
+or <a>verifiable presentation</a> is well-formed.
   </dd>
   <dt><dfn data-lt="verification">verification</dfn></dt>
   <dd>
 The process that cryptographically demonstrates the authenticity of a
-<a>credential</a> or a <a>presentation</a>.
+<a>verifiable credential</a> or a <a>verifiable presentation</a>.
   </dd>
   <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn></dt>
   <dd>
@@ -50,6 +50,17 @@ associated <a>repository</a> and public key information.
   <dt><dfn>digital signature</dfn></dt>
   <dd>
 A mathematical scheme for demonstrating the authenticity of a digital message.
+  </dd>
+  <dt><dfn data-lt="predicates|derived predicates">derived predicate</dfn></dt>
+  <dd>
+    A verifiable, boolean assertion about the value of another attribute in a
+    <a>verifiable credential</a>. These are useful in zero-knowledge-proof-style
+    presentations, because they can limit information disclosure. For example, if a
+    verifiable credential contains an attribute named "height_in_cm", a derived
+    predicate such as "height_over_150cm" might reference the height attribute in
+    the credential and demonstrate that the issuer attests to a height value that
+    meets a minimum height requirement, without actually disclosing the specific
+    height value.
   </dd>
   <dt><dfn data-lt="entities|entity's">entity</dfn></dt>
   <dd>
@@ -98,16 +109,15 @@ A role an <a>entity</a> may perform by asserting <a>claims</a> about one or more
 <a>subjects</a>, creating a <a>verifiable credential</a> from these claims,
 and transmitting the verifiable credential to a <a>holder</a>.
   </dd>
-  <dt><dfn data-lt="presentation">presentation</dfn></dt>
+  <dt><dfn data-lt="presentation">verifiable presentation</dfn></dt>
   <dd>
-Data derived from one or more credentials, fitted to the needs of sharing
+Data derived from one or more verifiable credentials, fitted to the needs of sharing
 with a particular verifier, and encoded in such a way that the verifier may
 trust authorship of the data after a process of cryptographic verification. A
-credential itself may be presented, in which case the credential becomes a
-presentation. A <a>profile</a> is another type of presentation that contains
-credentials. A third type of presentation may prove that certain credentials
-exist, having specific authors and attributes, but not contain the credentials
-themselves.
+verifiable credential itself may be presented, in which case the credential becomes a
+verifiable presentation. Another type of verifiable presentation may prove that certain
+verifiable credentials exist, having specific authors and attributes, but not contain
+the credentials themselves.
   </dd>
   <dt><dfn data-lt="presentations">presentation</dfn></dt>
   <dd>

--- a/terms.html
+++ b/terms.html
@@ -15,20 +15,21 @@ An assertion made about a <a>subject</a>.
 A set of one or more <a>claims</a> made by the issuer.
 A <dfn data-lt="verifiable credentials">verifiable credential</dfn>
 is a credential that is tamper-resistant and whose authorship can be
-cryptographically verified.
+cryptographically verified. Credentials can be used to build
+<a>presentations</a>, which can also be cryptographically verified.
   </dd>
   <dd>
 Note: The claims in a credential may be about different subjects.
   </dd>
   <dt><dfn data-lt="credential validation">validation</dfn></dt>
   <dd>
-The process that demonstrates the information in a <a>credential</a> is
-well-formed.
+The process that demonstrates the information in a <a>credential</a>
+or <a>presentation</a> is well-formed.
   </dd>
-  <dt><dfn data-lt="credential verification">verification</dfn></dt>
+  <dt><dfn data-lt="verification">verification</dfn></dt>
   <dd>
 The process that cryptographically demonstrates the authenticity of a
-<a>credential</a>.
+<a>credential</a> or a <a>presentation</a>.
   </dd>
   <dt><dfn data-lt="decentralized identifiers|DID|DIDs">decentralized identifier</dfn></dt>
   <dd>
@@ -96,6 +97,17 @@ and the <a>holder</a>.
 A role an <a>entity</a> may perform by asserting <a>claims</a> about one or more
 <a>subjects</a>, creating a <a>verifiable credential</a> from these claims,
 and transmitting the verifiable credential to a <a>holder</a>.
+  </dd>
+  <dt><dfn data-lt="presentation">presentation</dfn></dt>
+  <dd>
+Data derived from one or more credentials, fitted to the needs of sharing
+with a particular verifier, and encoded in such a way that the verifier may
+trust authorship of the data after a process of cryptographic verification. A
+credential itself may be presented, in which case the credential becomes a
+presentation. A <a>profile</a> is another type of presentation that contains
+credentials. A third type of presentation may prove that certain credentials
+exist, having specific authors and attributes, but not contain the credentials
+themselves.
   </dd>
   <dt><dfn data-lt="presentations">presentation</dfn></dt>
   <dd>


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>

This embodies item #4 from https://docs.google.com/document/d/10e6lcsX0kiXkWX4_79hD1fb4p_AbFGsRm90eJJKFayI/edit -- chiefly, defining presentation and clarifying its relationship to a credential.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/vc-data-model/pull/220.html" title="Last updated on Aug 21, 2018, 5:08 PM GMT (e52e043)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/220/838e1f4...dhh1128:e52e043.html" title="Last updated on Aug 21, 2018, 5:08 PM GMT (e52e043)">Diff</a>