### PR TITLE
pedantic punctuation tweaks in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2823,13 +2823,13 @@ This correlation can occur:
 
         <ol>
           <li>
-When the same credential is presented to the same verifier more than once&mdash;that
+When the same credential is presented to the same verifier more than once &mdash; that
 verifier could infer that the holder is the same individual.
           </li>
           <li>
 When the same credential is presented to different verifiers, and either those
 verifiers collude or a third party has access to transaction records from
-both verifiers&mdash;the observant party could infer that the individual
+both verifiers &mdash; the observant party could infer that the individual
 presenting the credential is the same person at both services, i.e., the
 accounts are controlled by the same person.
           </li>
@@ -2841,7 +2841,7 @@ the holder of the credential is the same person.
           </li>
           <li>
 When the underlying information in a credential can be used to identify an
-individual across services&mdash;using information from other sources
+individual across services &mdash; using information from other sources
 (including information provided directly by the user), verifiers can use
 the information inside the credential to correlate the individual with an
 existing profile. For example, if a holder presents credentials that include
@@ -2850,7 +2850,7 @@ subject of that credential with an established profile [see Sweeney 2000
 <a href="http://dataprivacylab.org/projects/identifiability/paper1.pdf">Simple Demographics Often Identify People Uniquely</a>].
           </li>
           <li>
-When passing the identifier of a credential to a centralized revocation server&mdash;the
+When passing the identifier of a credential to a centralized revocation server &mdash; the
 centralized server can correlate the credential usage across interactions.
 For example, if a verifiable credential is used for proof of age in this manner,
 the centralized service could know everywhere that credential was presented: all

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
     <script src="./common.js" class="remove"></script>
     <script type="text/javascript" class="remove">
       var respecConfig = {
-        // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+        // specification status (e.g., WD, LCWD, NOTE, etc.). If in doubt use ED.
         specStatus: "ED",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
@@ -193,11 +193,11 @@ In the physical world, a credential may consist of:
 
       <ul>
         <li>
-information related to the subject of the credential (e.g. photo, name, and
+information related to the subject of the credential (e.g., photo, name, and
 identification number),
         </li>
         <li>
-information related to the issuing authority (e.g. city government,
+information related to the issuing authority (e.g., city government,
 national agency, or certification body),
         </li>
         <li>
@@ -583,7 +583,7 @@ All entities trust the <a>identifier registry</a> to be incorruptible and
 to be a correct record of which identifiers belong to which <a>entities</a>.
         </li>
         <li>
-The <a>subject</a> trusts the <a>issuer</a> to issue true (i.e. not false)
+The <a>subject</a> trusts the <a>issuer</a> to issue true (i.e., not false)
 <a>credentials</a> about the subject, and to revoke them quickly when
 appropriate.
         </li>
@@ -679,7 +679,7 @@ A <a href="#credentials">credential</a> object
               </td>
               <td>
 <tt>"type": ["<code>VerifiableCredential</code>"]</tt> and
-a more specific credential type (e.g. <code>ProofOfAgeCredential</code>)
+a more specific credential type (e.g., <code>ProofOfAgeCredential</code>)
               </td>
             </tr>
 
@@ -690,7 +690,7 @@ A <a href="#presentations">presentation</a> object
               <td>
 <tt>"type": ["<code>VerifiablePresentation</code>"]</tt> and optionally a
 more specific presentation type
-(e.g. <code>CredentialManagerPresentation</code>).
+(e.g., <code>CredentialManagerPresentation</code>).
               </td>
             </tr>
 
@@ -699,7 +699,7 @@ more specific presentation type
 A&nbsp;<a href="#status">credentialStatus</a>&nbsp;object
               </td>
               <td>
-A valid credential status type (e.g. <code>CredentialStatusList2017</code>)
+A valid credential status type (e.g., <code>CredentialStatusList2017</code>)
               </td>
             </tr>
 
@@ -708,7 +708,7 @@ A valid credential status type (e.g. <code>CredentialStatusList2017</code>)
 A <a href="#terms-of-use">termsOfUse</a> object
               </td>
               <td>
-A valid terms of use type (e.g. <code>OdrlPolicy2017</code>)
+A valid terms of use type (e.g., <code>OdrlPolicy2017</code>)
               </td>
             </tr>
 
@@ -717,7 +717,7 @@ A valid terms of use type (e.g. <code>OdrlPolicy2017</code>)
 An <a href="#terms-of-use">evidence</a> object
               </td>
               <td>
-A valid evidence type (e.g. <code>DocumentVerification2018</code>)
+A valid evidence type (e.g., <code>DocumentVerification2018</code>)
               </td>
             </tr>
 
@@ -727,12 +727,12 @@ A valid evidence type (e.g. <code>DocumentVerification2018</code>)
         <p>
 All <a>credentials</a>, <a>presentations</a>, and encapsulated objects MUST
 specify or be associated with additional, more narrow <a>type</a>s
-(e.g. <code>ProofOfAgeCredential</code>) such that software systems can use
+(e.g., <code>ProofOfAgeCredential</code>) such that software systems can use
 the additional information to more easily process the data.
         </p>
 
         <p>
-When processing encapsulated objects in this specification, (e.g. objects
+When processing encapsulated objects in this specification, (e.g., objects
 associated with the <code>claim</code> property or deeply nested therein),
 a software system SHOULD use type information specified in encapsulating
 objects higher in the hierarchy. For the avoidance of doubt, an
@@ -809,7 +809,7 @@ information associated with the <var>claim</var> property became valid.
       </section>
 
       <section>
-        <h2>Proofs (eg. Signatures)</h2>
+        <h2>Proofs (e.g., Signatures)</h2>
 
         <p>
 In order for a <a>credential</a> or <a>presentation</a> to be made
@@ -924,7 +924,7 @@ type instance. The precise contents of the credential status information is
           <dt><var>credentialStatus</var></dt>
           <dd>The value of this property MUST be a credential status scheme that
             provides enough information to determine the current status of the
-            credential (e.g. suspended, revoked, etc.).
+            credential (e.g., suspended, revoked, etc.).
           </dd>
         </dl>
 
@@ -1553,10 +1553,14 @@ delegation of authority instead of delegation of attributes.
       <p class="issue" data-number=204>
 The group is currently debating the best security model for delegation. Readers
 should treat this entire section as at-risk and currently under debate.
-      <p>
+      </p>
 
   <p>
-The Subject Only Terms of Use states that a verifiable credential MUST only be presented to a verifier by the subject. If a verifier is presented with a verifiable credential containing the Subject Only Terms of Use, by anyone other than the subject, it MUST refuse to accept it.</p>
+The Subject Only Terms of Use states that a verifiable credential MUST only be 
+presented to a verifier by the subject. If a verifier is presented with a 
+verifiable credential containing the Subject Only Terms of Use, by anyone other 
+    than the subject, it MUST refuse to accept it.
+     </p>
 
         <pre class="example nohighlight" title="Subject Only termsOfUse property by an Issuer">
 {
@@ -1592,7 +1596,8 @@ When the subject passes a verifiable credential to a
 holder, the subject SHOULD issue a new verifiable credential to the holder in which:
 the issuer is the subject,
 the subject is the holder to whom the verifiable credential is being passed,
-and the claim contains the properties that are being passed on. In addition, the holder creates a verifiable presentation that contains these two
+and the claim contains the properties that are being passed on. In addition, the 
+holder creates a verifiable presentation that contains these two
 verifiable credentials.
 </p>
 
@@ -1885,23 +1890,23 @@ as the specific vocabulary terms for disputed claims.
         <p>
 A concrete expression of the data model in this specification is a
 <em>conforming document</em> if it complies with the normative statements in
-this specification regarding syntax (e.g. the content in
+this specification regarding syntax (e.g., the content in
 <a href="#basic-concepts">Basic Concepts</a>,
 <a href="#advanced-concepts">Advanced Concepts</a>, and
 <a href="#syntaxes">Syntaxes</a>).
 For convenience, normative statements for <em>conforming documents</em> are
 often phrased as statements on the syntax used in properties and their
-associated values in the document (e.g. MUST be a URI,
-MUST be a string value of an ISO8601 combined date and time string).
+associated values in the document (e.g., "MUST be a URI",
+"MUST be a string value of an ISO8601 combined date and time string").
         </p>
 
         <p>
 A <em>conforming processor</em> is a software or hardware-based implementation
 of the normative statements in this specification regarding the expected
-contents of property-value pairs (e.g. the content in <a>Verification</a>).
+contents of property-value pairs (e.g., the content in <a>Verification</a>).
 For convenience, normative statements for <em>conforming processors</em> are
 often phrased as behavioral statements regarding the contents of
-property-value pairs (e.g. MUST NOT be revoked, MUST be in the expected range).
+property-value pairs (e.g., "MUST NOT be revoked", "MUST be in the expected range").
         </p>
 
       </section>
@@ -2071,7 +2076,7 @@ that enables linkages to JSON Schema or other optional validation mechanisms.
       <section>
         <h3>Syntax</h3>
         <ul>
-          <li>The document is syntactically valid (e.g. JSON, JSON-LD).</li>
+          <li>The document is syntactically valid (e.g., JSON, JSON-LD).</li>
         </ul>
       </section>
       <section>
@@ -2122,7 +2127,7 @@ properties in a credential to uniquely identify the <a>subject</a>.
         </p>
       </section>
       <section>
-        <h3>Proofs (eg. Signatures)</h3>
+        <h3>Proofs (e.g., Signatures)</h3>
 
         <p>
 The cryptographic mechanism used to prove that the information in a
@@ -2732,13 +2737,13 @@ enable bad privacy practices.
 
         <p>
 When a holder receives a credential from an issuer, the
-credential will need to be stored somewhere (e.g. in a credential repository).
+credential will need to be stored somewhere (e.g., in a credential repository).
 Holders are warned that the information in a verifiable credential may be
 sensitive in nature and highly individualized, making it a high value
 target for data mining. Therefore, there may be services
 that store verifiable credentials for free and mine personal data and sell it
 to organizations that desire individualized profiles on people and
-organizations (i.e. if the service is free, you are the product).
+organizations (i.e., if the service is free, you are the product).
         </p>
         <p>
 It is suggested that holders be aware of the terms of service for their
@@ -3073,7 +3078,7 @@ intended by the issuer.
         </p>
         <p>
 For example a university might issue two credentials to a person, each
-containing two properties i.e. "Staff Member" in the
+containing two properties, i.e., "Staff Member" in the
 "Department of Computing" and "Post Graduate Student" in the
 "Department of Economics". If these credentials are atomized into separate
 properties, then the university would issue four credentials to the person,
@@ -3115,7 +3120,7 @@ intended by the issuer.
         </p>
         <p>
 For example a university might issue two credentials to a person, each
-containing two properties i.e. "Staff Member" in the
+containing two properties, i.e., "Staff Member" in the
 "Department of Computing" and "Post Graduate Student" in the
 "Department of Economics". If these credentials are atomized into separate
 properties, then the university would issue four credentials to the person,


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-model/pull/223.html" title="Last updated on Aug 18, 2018, 6:34 PM GMT (a57cd5d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/223/e70d984...TallTed:a57cd5d.html" title="Last updated on Aug 18, 2018, 6:34 PM GMT (a57cd5d)">Diff</a>