### PR TITLE
Add caveat about JIT bearer credentials

### DIFF
--- a/index.html
+++ b/index.html
@@ -2596,13 +2596,12 @@ that issues driver's licenses could issue a set of credentials containing every
 attribute that appears on a driver's license in addition to atomized
 credentials (a credential containing only the person's birthday), and atomized
 credentials that are more abstract (a credential containing only an
-<code>ageOver</code> attribute). One possible adaptation is for the issuer to
+<code>ageOver</code> attribute). One possible simple adaptation is for the issuer to
 provide secure HTTP endpoints for retrieving single-use bearer credentials to
-promote the pseudonymous usage of credentials. Besides being impractical or unsafe
-for issuers to support this behavior in some cases, this may be less valuable than
-it first appears, because it creates a dependence on issuers at proving time,
-and introduces temporal correlation risk from the issuer.
-        </p>
+promote the pseudonymous usage of credentials. Implementers that find this
+impractical or unsafe should consider the use of selective disclosure schemes
+that eliminate dependence on issuers at proving time and reduce temporal
+correlation risk from the issuer.
         <p>
 Verifiers are urged to only request information that is absolutely
 necessary for a particular transaction to occur. This is important for at

--- a/index.html
+++ b/index.html
@@ -2596,13 +2596,15 @@ that issues driver's licenses could issue a set of credentials containing every
 attribute that appears on a driver's license in addition to atomized
 credentials (a credential containing only the person's birthday), and atomized
 credentials that are more abstract (a credential containing only an
-<code>ageOver</code> attribute). In addition, the issuer is encouraged to
+<code>ageOver</code> attribute). One possible adaptation is for the issuer to
 provide secure HTTP endpoints for retrieving single-use bearer credentials to
-promote the pseudonymous usage of credentials when it is safe for the issuer to
-issue such credentials.
+promote the pseudonymous usage of credentials. Besides being impractical or unsafe
+for issuers to support this behavior in some cases, this may be less valuable than
+it first appears, because it creates a dependence on issuers at proving time,
+and introduces temporal correlation risk from the issuer.
         </p>
         <p>
-Similarly, verifiers are urged to only request information that is absolutely
+Verifiers are urged to only request information that is absolutely
 necessary for a particular transaction to occur. This is important for at
 least two reasons: 1) it reduces the liability on the verifier for
 handling highly sensitive information that it does not need, and 2)


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>

This change addresses feedback from @dlongley, found here: https://docs.google.com/document/d/1xJ-763Y49UICVBv6HrOgbqrVLwXjvcHD1I0MFBoAY6w/edit?disco=AAAACDdQbj8

Basically, the spec was advocating something as best practice that often isn't a good idea (JIT issuance of bearer credentials). This PR adds a sentence explaining the caveats.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dhh1128/vc-data-model/pull/228.html" title="Last updated on Sep 18, 2018, 3:25 PM GMT (d15376c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/228/d7f5dd3...dhh1128:d15376c.html" title="Last updated on Sep 18, 2018, 3:25 PM GMT (d15376c)">Diff</a>