### PR TITLE
Consistently use the VerifiableCredential type

### DIFF
--- a/index.html
+++ b/index.html
@@ -1513,7 +1513,7 @@ that uniquely identifies a subject">
 {
   "@context": ["https://w3id.org/credentials/v1", "https://schema.org/"]
   "id": "http://dmv.example.gov/credentials/332",
-  "type": ["Credential", "IdentityCredential"],
+  "type": ["VerifiableCredential", "IdentityCredential"],
   "issuer": "https://dmv.example.gov/issuers/4",
   "issued": "2017-02-24",
   "claim": {
@@ -1636,7 +1636,7 @@ credential properties that have been passed to it by the subject">
   "type": ["VerifiablePresentation"],
   "credential": [{
       "id": "http://example.gov/credentials/3732",
-      "type": ["Credential", "PrescriptionCredential"],
+      "type": ["VerifiableCredential", "PrescriptionCredential"],
       "issuer": "https://dmv.example.gov",
       "issued": "2010-01-01",
       "claim": {
@@ -1651,7 +1651,7 @@ credential properties that have been passed to it by the subject">
     },
     {
       "id": "https://example.com/VC/123456789",
-      "type": ["Credential", "PrescriptionCredential"],
+      "type": ["VerifiableCredential", "PrescriptionCredential"],
       "issuer": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "issued": "2010-01-03",
       "claim": {
@@ -1724,7 +1724,7 @@ standardised by the working group.
       <pre class="example nohighlight" title="An example of the relationship
 property in a child's credential">{
   "id": "http://dmv.example.gov/credentials/3732",
-  "type": ["Credential", "ProofOfAgeCredential"],
+  "type": ["VerifiableCredential", "ProofOfAgeCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",
   "issued": "2010-01-01T19:73:24Z",
   "claim": {
@@ -1748,7 +1748,7 @@ credential if it is provided by the child or the parent.
       <pre class="example nohighlight" title="An example of a relationship
 credential issued to a parent">{
   "id": "http://dmv.example.gov/credentials/3732",
-  "type": ["Credential", "RelationshipCredential"],
+  "type": ["VerifiableCredential", "RelationshipCredential"],
   "issuer": "https://dmv.example.gov/issuers/14",
   "issued": "2010-01-01T19:73:24Z",
   "claim": {
@@ -1772,7 +1772,7 @@ if the credential above is provided with any of the child's credentials.
      <pre class="example nohighlight" title="An example of a relationship
 credential issued by a child">{
   "id": "http://example.org/credentials/23894",
-  "type": ["Credential", "RelationshipCredential"],
+  "type": ["VerifiableCredential", "RelationshipCredential"],
   "issuer": "http://example.org/credentials/23894",
   "issued": "2010-01-01T19:73:24Z",
   "claim": {
@@ -1817,7 +1817,7 @@ with the subject of the credential, but who has a relationship with the issuer">
 
 {
   "id": "http://dmv.example.gov/credentials/3732",
-  "type": ["Credential", "NameAndAddress"],
+  "type": ["VerifiableCredential", "NameAndAddress"],
   "issuer": "https://dmv.example.gov/issuers/14",
   "holder": {
     "type": "LawEnforcement",


### PR DESCRIPTION
Additionally, the context at https://w3id.org/credentials/v1 says Credential instead of VerifiableCredential as well, as I discovered today while writing some VC-related code.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cwebber/vc-data-model/pull/230.html" title="Last updated on Sep 13, 2018, 7:44 PM GMT (886ee4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/230/a75b347...cwebber:886ee4a.html" title="Last updated on Sep 13, 2018, 7:44 PM GMT (886ee4a)">Diff</a>