### PR TITLE
Better requirement for proofPurpose's presence and validity.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2248,8 +2248,11 @@ signatures, implementations MUST ensure that:
           or key purpose.</li>
           <li>The key MUST NOT be revoked or expired.</li>
           <li>The cryptographic signature MUST be valid.</li>
-          <li>If a <code>proofPurpose</code> exists, it MUST be a valid value
-          per the cryptographic suite.</li>
+          <li>
+            If the cryptographic suite expects a <code>proofPurpose</code>
+            (such as <code>credentialIssuance</code>), it MUST exist
+            and be a valid value per the cryptographic suite.
+          </li>
         </ul>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -2249,9 +2249,9 @@ signatures, implementations MUST ensure that:
           <li>The key MUST NOT be revoked or expired.</li>
           <li>The cryptographic signature MUST be valid.</li>
           <li>
-            If the cryptographic suite expects a <code>proofPurpose</code>
-            (such as <code>credentialIssuance</code>), it MUST exist
-            and be a valid value per the cryptographic suite.
+            If the cryptographic suite expects a <code>proofPurpose</code>,
+            it MUST exist and be a valid value (such as
+            <code>credentialIssuance</code>) per the cryptographic suite.
           </li>
         </ul>
 


### PR DESCRIPTION
It's not just whether the proofPurpose exists that it must be valid,
it's whether the cryptographic suite *expects* a proofPurpose to
exist and have a valid value.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/cwebber/vc-data-model/pull/249.html" title="Last updated on Oct 16, 2018, 1:14 AM GMT (fdfd492)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/249/43f46fb...cwebber:fdfd492.html" title="Last updated on Oct 16, 2018, 1:14 AM GMT (fdfd492)">Diff</a>