### PR TITLE
Use IPLD as a JSON syntax for claim

### DIFF
--- a/index.html
+++ b/index.html
@@ -2180,11 +2180,11 @@ content indentifier (CID) for content addressing resolved using
  <p>The following example demonstrates how one could
           express this data model using IPLD.</p>
 
-  <pre class="example" title="A verifiable claim with @context and previous linked data using IPLD">
+  <pre class="example" title="A verifiable claim with @context and creator of the claim as linked data using IPLD">
 { "@context" : 
     { "/" : "zdpuAmoZixxJjvosviGeYcqduzDhSwGV2bL6ZTTXo1hbEJHfq" }, 
     ... 
-    "previous" : 
+    "creator" : 
     { "/" : "zdpuAvqt1YTeAdcyyncBDdJLVgKyZNbHm17rBEJNqFzVbg24B" }
     ... 
 }

--- a/index.html
+++ b/index.html
@@ -2148,6 +2148,51 @@ JSON-LD document, then a <code>@context</code> property with a value of
 
       </section>
 
+  <section>
+        <h2>IPLD</h2>
+        
+        <p>
+Content addressing through hashes has become a widely-used means of connecting 
+data in distributed systems. <a href="https://ipld.io">IPLD</a> is a way of representing 
+hash-linked data to be used in content-addressed data retrieval systems such as 
+<a href="https://ipfs.io">IPFS</a>. Other content that can be resolved using IPLD include 
+blockchains such as Bitcoin, Ethereum, ZCash and Git repositories. IPLD enables 
+creation of decentralized data-structures that are universally addressable facilitating 
+resolving content accross different protocols. It achieves this through an interoperable 
+data model that represents various protocol formats. IPLD relies on self-describing 
+<a href="https://github.com/ipld/cid">Content Identifiers (CIDs)]</a> for content addressing. 
+CIDs are a self-describing, flexible, and interoperable way of expressing cryptographic hashes. 
+It uses several multiformats to achieve flexible self-description, namely 
+<a href="https://github.com/multiformats/multihash"> multihash </a> for hashes, 
+<a href="https://github.com/multiformats/multicodec"> multicodec </a> for data content types, and 
+<a href="https://github.com/multiformats/multibase">multibase </a> to represent the base encoding 
+of the CID itself. This interoperability makes IPLD a valuable structure for the DID document 
+that can be used across a variety of DID methods or distributed ledgers and 
+ensures cryptographic validity of the DID document.  Since both IPLD and JSON-LD 
+are 100% compatible with JSON, the large number of JSON parsers and libraries are already available. 
+      </p>
+      <p>
+The key symbol <code>"/"</code> (foward slash) SHOULD be reserved to represent a self describing 
+content indentifier (CID) for content addressing resolved using 
+<a href="https://github.com/ipld/specs">Interplanetary Linked Data (IPLD)</a>.  
+      </p>
+
+ <p>The following example demonstrates how one could
+          express this data model using IPLD.</p>
+
+  <pre class="example" title="A verifiable claim with @context and previous linked data using IPLD">
+{ "@context" : 
+    { "/" : "zdpuAmoZixxJjvosviGeYcqduzDhSwGV2bL6ZTTXo1hbEJHfq" }, 
+    ... 
+    "previous" : 
+    { "/" : "zdpuAvqt1YTeAdcyyncBDdJLVgKyZNbHm17rBEJNqFzVbg24B" }
+    ... 
+}
+  </pre>
+
+      </section>
+
+
     </section>
 
     <section>


### PR DESCRIPTION
I'd like y'all to have a serious look at IPLD for VC (as well as the DID document).  He is my draft document from the recent Rebooting Web of Trust arguing my point.

https://github.com/WebOfTrustInfo/rwot7/blob/master/draft-documents/ipld_did_documents.md

While I do like JSON-LD, having cryptographic resolution of the payload is important in this application. 

Only change here that is necessary is to reserve the key "/" for a CID and resolution over IPLD. 

```
"@context" : 
    { "/" : "zdpuAmoZixxJjvosviGeYcqduzDhSwGV2bL6ZTTXo1hbEJHfq" }, 
   ... 
 "creator" : 
    { "/" : "zdpuAvqt1YTeAdcyyncBDdJLVgKyZNbHm17rBEJNqFzVbg24B" }
```

This also binds the entire claim as a self-describing content addressed hash.  Much more secure to DNS poisoning attack. 

I don't like to argument that we have settled on JSON-LD as the only solution for a VC.  

Also, see my PR for the DID-spec: 

https://github.com/w3c-ccg/did-spec/pull/110#issuecomment-431356177


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jonnycrunch/vc-data-model/pull/261.html" title="Last updated on Mar 5, 2019, 1:19 PM UTC (a3d1090)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/261/04e1533...jonnycrunch:a3d1090.html" title="Last updated on Mar 5, 2019, 1:19 PM UTC (a3d1090)">Diff</a>