### PR TITLE
Fix markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,7 +179,6 @@ An ecosystem where <a>verifiable credentials</a> and
 The use cases and requirements that informed this specification.
         </li>
       </ul>
-      </p>
 
     <section>
       <h3>What is a Verifiable Credential?</h3>
@@ -2622,6 +2621,7 @@ to avoid duplication.
               <p>
 This specification introduces two new registered claim names which contain the JSON or JSON-LD
 verifiable credentials and presentation object enclosed in the JWT payload:
+              </p>
                   <ul>
                       <li>
 <code>vc</code>: JSON object, and MUST be present in a JWT verifiable credential. The object contains the verifiable
@@ -2631,7 +2631,6 @@ credential according to this specification.
 presentation according to this specification.
                       </li>
                   </ul>
-              </p>
             </section>
 
             <section>
@@ -2648,6 +2647,7 @@ signature.
               </p>
               <p>
 Besides, the following defines rules for JOSE headers in the context of this specification:
+              </p>
                 <ul>
                   <li>
 <code>alg</code> MUST be used for RSA and ECDSA based digital signatures. If only the
@@ -2662,10 +2662,10 @@ key in a DID Document, or can be the identifier of a key inside a JWKS.
 <code>typ</code> MUST be set to <code>JWT</code> if present.
                   </li>
                 </ul>
-              </p>
               <p>
 For backward compatibility with JWT processors the following JWT registered claim names MUST be used
 instead of or in addition to their respective verifiable credential counterparts:
+              </p>
                   <ul>
                       <li>
 <code>exp</code> MUST represent <code>expirationDate</code> encoded as a Unix timestamp (<code>NumericDate</code>).</li>
@@ -2679,7 +2679,6 @@ instead of or in addition to their respective verifiable credential counterparts
                       <li><code>sub</code> MUST represent the <code>id</code> property contained in the credential subject.</li>
                       <li><code>aud</code> MUST represent the <code>subject</code> of the consumer of the presentation.</li>
                   </ul>
-              </p>
               <p>
 Other JOSE header parameters and claim names not specified herein can be used if their use is not
 explicitly discouraged.
@@ -3882,6 +3881,8 @@ Using a separate hardware-based signature device.
 All or any combination of the above.
           </li>
         </ul>
+
+      </section>
 
     </section>
 <section>

--- a/index.html
+++ b/index.html
@@ -930,7 +930,7 @@ A valid terms of use type. For example,<br>
 
             <tr>
               <td>
-<a href="#terms-of-use">evidence</a>&nbsp;object
+<a href="#evidence">evidence</a>&nbsp;object
               </td>
               <td>
 A valid evidence type. For example,<br>

--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,7 @@ In the example above, the <a>issuer</a> specifies a manual
       </section>
 
       <section>
-       <h3>Mode of Operation</h3>
+        <h3>Mode of Operation</h3>
 
 <em>This section is non-normative.</em>
 
@@ -1781,7 +1781,7 @@ or <a>verifier</a>.
      </section>
 
       <section>
-        <h2>Terms of Use</h2>
+        <h3>Terms of Use</h3>
 
         <p>
 Terms of use can be used by an <a>issuer</a>, a <a>subject</a>, or a
@@ -2435,7 +2435,7 @@ on top of this specification.
       </section>
 
       <section>
-        <h2>Syntactic Sugar</h2>
+        <h3>Syntactic Sugar</h3>
 
         <p>
 In general, the data model and syntaxes described in this document are
@@ -2478,7 +2478,7 @@ each graph is preserved.
       </section>
 
       <section>
-        <h2>Conformance</h2>
+        <h3>Conformance</h3>
 
         <p>
 A concrete expression of the data model in this specification is a
@@ -2594,7 +2594,7 @@ Credentials Data Model is available at
       </section>
 
         <section>
-            <h2>JSON Web Token</h2>
+            <h3>JSON Web Token</h3>
             <p>
 JSON Web Token (JWT) [[!RFC7519]] is still a widely used means to express claims to be transferred
 between two parties. Providing a representation of the verifiable credentials data
@@ -2605,7 +2605,7 @@ A JWT encodes a set of claims as a JSON object that is contained in a JSON Web S
             </p>
 
             <section>
-              <h3>Relation to the VC Data Model</h3>
+              <h4>Relation to the VC Data Model</h4>
               <p>
 This specification defines encoding rules of the verifiable credential and presentation data
 model onto JWT and JWS. It further defines processing rules how and when to make use of specific
@@ -2617,7 +2617,7 @@ to avoid duplication.
             </section>
 
             <section>
-              <h3>IANA Considerations</h3>
+              <h4>IANA Considerations</h4>
               <p>
 This specification introduces two new registered claim names which contain the JSON or JSON-LD
 verifiable credentials and presentation object enclosed in the JWT payload:
@@ -2634,7 +2634,7 @@ presentation according to this specification.
             </section>
 
             <section>
-              <h3>JWT and JWS Considerations</h3>
+              <h4>JWT and JWS Considerations</h4>
               <p>
 If the JWS is present, the digital signature either refers to the issuer of the verifiable credential
 or the holder of the credential in case of a presentation. The JWS will prove that the issuer of the
@@ -3795,7 +3795,8 @@ is either not known or cannot be trusted.
       </section>
 
       <section>
-        <h2>Token Binding</h2>
+        <h3>Token Binding</h3>
+
         <p>
 A <a>verifier</a> might need to ensure it is the intended recipient of a
 <a>verifiable presentation</a> and not the target of a

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@ pre .comment {
   font-weight: bold;
   color: Gray;
 }
-</style>
+    </style>
   </head>
   <body>
     <section id='abstract'>
@@ -125,10 +125,10 @@ or send them to
 <a href="https://lists.w3.org/Archives/Public/public-vc-comments/">archives</a>).
       </p>
 
-        <p class="issue" data-number=201>
+      <p class="issue" data-number=201>
 There remain a list of editorial issues that need to be processed in this
 document.
-        </p>
+      </p>
     </section>
 
     <section>
@@ -181,31 +181,31 @@ The use cases and requirements that informed this specification.
         </li>
       </ul>
 
-    <section>
-      <h3>What is a Verifiable Credential?</h3>
+      <section>
+        <h3>What is a Verifiable Credential?</h3>
 
-      <p>
+        <p>
 In the physical world, a <a>credential</a> might consist of:
-      </p>
+        </p>
 
-      <ul>
-        <li>
+        <ul>
+          <li>
 Information related to the subject of the <a>credential</a> (for example, a
 photo, name, and identification number)
-        </li>
-        <li>
+          </li>
+          <li>
 Information related to the issuing authority (for example, a city government,
 national agency, or certification body)
-        </li>
-        <li>
+          </li>
+          <li>
 Evidence related to how the <a>credential</a> was derived
-        </li>
-        <li>
+          </li>
+          <li>
 Information related to expiration dates.
-        </li>
-      </ul>
+          </li>
+        </ul>
 
-      <p>
+        <p>
 A <a>verifiable credential</a> can represent all of the same information that a
 physical <a>credential</a> represents. The addition of technologies, such as
 digital signatures, makes <a>verifiable credentials</a> more tamper-evident and
@@ -216,8 +216,8 @@ these <a>presentations</a> with <a>verifiers</a> to prove they possess
 <a>credentials</a> and <a>presentations</a> can be transmitted rapidly, making
 them more convenient than their physical counterparts when trying to establish
 trust at a distance.
-      </p>
-      <p>
+        </p>
+        <p>
 While this specification attempts to improve the ease of expressing digital
 <a>credentials</a>, it also attempts to balance this goal with a number of
 privacy-preserving goals. The persistence of digital information, and the ease
@@ -228,46 +228,47 @@ machine-readable <a>credentials</a> threatens to make worse. The
 document outlines and attempts to address a number of these issues. Examples of
 how to use this data model using privacy-enhancing technologies, such as
 zero-knowledge proofs, are also provided throughout this document.
-      </p>
-    </section>
-    <section>
-      <h3>Ecosystem Overview</h3>
+        </p>
+      </section>
 
-      <em>This section is non-normative.</em>
+      <section>
+        <h3>Ecosystem Overview</h3>
 
-      <p>
+        <em>This section is non-normative.</em>
+
+        <p>
 This section describes the roles of the core actors and the relationships
 between them in an ecosystem where <a>verifiable credentials</a> are expected
 to be useful. A role is an abstraction that might be implemented in many
 different ways. The separation of roles suggests likely interfaces and
 protocols for standardization. The following roles are introduced in this
 specification:
-      </p>
+        </p>
 
-      <dl>
-        <dt><a>holder</a></dt>
-        <dd>
+        <dl>
+          <dt><a>holder</a></dt>
+          <dd>
 A role an <a>entity</a> might perform by possessing one or more
 <a>verifiable credentials</a> and generating <a>presentations</a> from them.
 Example holders include students, employees, and customers.
-        </dd>
-        <dt><a>issuer</a></dt>
-        <dd>
+          </dd>
+          <dt><a>issuer</a></dt>
+          <dd>
 A role an <a>entity</a> might perform by creating a
 <a>verifiable credential</a>, associating it with a specific <a>subject</a>,
 and transmitting it to a <a>holder</a>. Example issuers include
 corporations, non-profit organizations, trade associations, governments, and
 individuals.
-        </dd>
-        <dt><a>verifier</a></dt>
-        <dd>
+          </dd>
+          <dt><a>verifier</a></dt>
+          <dd>
 A role an <a>entity</a> might perform by requesting and receiving a
 <a>verifiable presentation</a> that proves the <a>holder</a> possesses the
 required <a>verifiable credentials</a> with certain characteristics. Example
 verifiers include employers, security personnel, and websites.
-        </dd>
-        <dt><a>verifiable data registry</a></dt>
-        <dd>
+          </dd>
+          <dt><a>verifiable data registry</a></dt>
+          <dd>
 A role a system might perform by mediating the creation and verification of
 <a>issuer</a> identifiers, keys, and other relevant data, such as
 <a>verifiable credential</a> schemas and revocation registries, which might be
@@ -276,127 +277,127 @@ require correlatable identifiers for <a>subjects</a>. Example verifiable data
 registries include trusted databases, decentralized databases, government ID
 databases, and distributed ledgers. Often there is more than one type of
 verifiable data registry utilized in an ecosystem.
-        </dd>
-      </dl>
+          </dd>
+        </dl>
 
-      <figure>
-        <img style="margin: auto; display: block;" width="75%" src="diagrams/ecosystem.svg">
-        <figcaption style="text-align: center;">
-The roles and information flows forming the basis for this specification.
-        </figcaption>
-      </figure>
+        <figure>
+          <img style="margin: auto; display: block;" width="75%" src="diagrams/ecosystem.svg">
+          <figcaption style="text-align: center;">
+            The roles and information flows forming the basis for this specification.
+          </figcaption>
+        </figure>
 
-      <p class="note">
+        <p class="note">
 The ecosystem above is provided as an example to ground the rest of the
 concepts in this specification. Other ecosystems exist, such as protected
 environments or proprietary systems, where <a>verifiable credentials</a> also
 provide benefit.
-      </p>
-    </section>
+        </p>
+      </section>
 
-    <section>
-      <h3>Use Cases and Requirements</h3>
+      <section>
+        <h3>Use Cases and Requirements</h3>
 
-      <em>This section is non-normative.</em>
+        <em>This section is non-normative.</em>
 
-      <p>
+        <p>
 The Verifiable Credentials Use Cases [[VC-USECASES]] document outlines a number
 of key topics that readers might find useful, including:
-      </p>
+        </p>
 
-      <ul>
-        <li>
+        <ul>
+          <li>
 A more thorough explanation of the
 <a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-roles">roles</a>
 introduced above
-        </li>
-        <li>
+          </li>
+          <li>
 The
 <a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-needs">needs</a>
 identified in market verticals, such as education, finance, healthcare, retail,
 professional licensing, and government
-        </li>
-        <li>
+          </li>
+          <li>
 Common
 <a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-tasks">tasks</a>
 performed by the roles in the ecosystem, as well as their associated
 requirements
-        </li>
-        <li>
+          </li>
+          <li>
 Common
 <a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-sequences">sequences and flows</a>
 identified by the Working Group.
-        </li>
-      </ul>
+          </li>
+        </ul>
 
-      <p>
+        <p>
 As a result of documenting and analyzing the use cases document, a number of
 desirable ecosystem characteristics were identified for this specification,
 specifically:
-      </p>
+        </p>
 
-      <ul>
-        <li>
+        <ul>
+          <li>
 <a>Holders</a> receive and store <a>verifiable credentials</a> from
 <a>issuers</a>. <a>Holders</a> might interact with an <a>issuer</a> through an
 agent that the <a>issuer</a> does not need to trust.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> are positioned between <a>issuers</a> and <a>verifiers</a>
 and use <a>verifiable credentials</a> to make <a>verifiable presentations</a>
 to <a>verifiers</a>.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> might interact with <a>verifiers</a> through an agent that
 <a>verifiers</a> do not need to trust; <a>verifiers</a> only need to trust
 <a>issuers</a>.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Verifiable credentials</a> are associated with <a>subjects</a>, not
 specific services; <a>holders</a> decide how to aggregate and manage
 <a>verifiable credentials</a> and the <a>verifiable presentations</a>
 associated with them.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> can easily acquire and control their identifiers.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> control which <a>verifiable credentials</a> to use and when.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> can freely choose and change the agents they employ to help
 them manage their <a>verifiable credentials</a> and generate and share
 <a>verifiable presentations</a>.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> can share <a>verifiable presentations</a> that can be verified
 without revealing the identity of the <a>verifier</a> to the <a>issuer</a>.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Holders</a> in <a>presentations</a> can either disclose the attributes or
 satisfy <a>derived predicates</a> requested by the <a>verifier</a>.
 <a>Derived predicates</a> are boolean conditions like greater than, less than,
 equal to, is in set, and so on.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Verifiable credentials</a> and <a>verifiable presentations</a> are
 expressed in one or more standard, machine-readable data formats, which can
 also be extended with minimal coordination.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Issuers</a> issue <a>verifiable credentials</a>, and <a>holders</a> store
 them. <a>Holders</a> offer <a>verifiable presentations</a>, and
 <a>verifiers</a> verify them. Issuing of <a>credentials</a>, storage of
 <a>credentials</a>, generation of <a>presentations</a>, sharing of
 <a>presentations</a>, and verification of <a>presentations</a> are
 each independent processes.
-        </li>
-        <li>
+          </li>
+          <li>
 <a>Verifiable credentials</a> can be revoked by the <a>issuer</a>.
-        </li>
-      </ul>
+          </li>
+        </ul>
 
-      <p class="issue">
+        <p class="issue">
 There are
 <a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-tasks">other requirements</a>
 listed in the Verifiable Credentials Use Cases
@@ -404,10 +405,10 @@ document that may or may not be aligned with the requirements listed above.
 The VCWG will be ensuring alignment of the list of requirements from both
 documents over time and will most likely move the list of requirements to a
 single document.
-      </p>
+        </p>
+      </section>
     </section>
 
-  </section>
     <section>
       <h2>Terminology</h2>
 
@@ -442,57 +443,57 @@ expressed using
 relationships.
         </p>
 
-      <figure>
-        <img style="margin: auto; display: block;"
-          width="50%" src="diagrams/claim.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;"
+            width="50%" src="diagrams/claim.svg">
+          <figcaption style="text-align: center;">
 The basic structure of a claim.
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-      <p>
+        <p>
 The data model for <a>claims</a> described above is powerful and can be used
 to express a large variety of statements. For example, whether or not someone
 graduated from a particular university can be expressed as shown below.
-      </p>
+        </p>
 
-      <figure>
-        <img style="margin: auto; display: block;"
-          width="60%" src="diagrams/claim-example.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;"
+            width="60%" src="diagrams/claim-example.svg">
+          <figcaption style="text-align: center;">
 An example of a basic claim expressing that Pat is an alumni of
 "Example University".
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-      <p>
+        <p>
 These <a>claims</a> can be merged together to express a <a>graph</a> of
 information about a <a>subject</a>. The example below extends the previous
 <a>graph</a> of information by adding <a>claims</a> stating that Pat knows Sam
 and that Sam is employed as a professor.
-      </p>
+        </p>
 
-      <figure>
-        <img style="margin: auto; display: block;"
-          width="75%" src="diagrams/claim-extended.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;"
+            width="75%" src="diagrams/claim-extended.svg">
+          <figcaption style="text-align: center;">
 Multiple claims can be combined to express a more complex graph.
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-      <p>
+        <p>
 To this point, the concept of a <a>claim</a> and a <a>graph</a> of information
 is introduced. To be able to trust <a>claims</a>, more information must be
 added.
-      </p>
+        </p>
+      </section>
 
-    </section>
-    <section>
-      <h3>Credentials</h3>
+      <section>
+        <h3>Credentials</h3>
 
-      <em>This section is non-normative.</em>
+        <em>This section is non-normative.</em>
 
-      <p>
+        <p>
 A <a>credential</a> is set of one or more <a>claims</a> made by the same
 <a>entity</a>. <a>Credentials</a> might include an identifier as well as
 metadata to describe properties of the <a>credential</a>, such as the
@@ -501,29 +502,29 @@ for <a>verification</a> purposes, the revocation mechanism, and so on. This
 metadata might be signed by the <a>issuer</a>. A <a>verifiable credential</a>
 is a set of tamper-evident <a>claims</a> and metadata that cryptographically
 prove who issued it.
-      </p>
+        </p>
 
-      <figure>
-        <img style="margin: auto; display: block;" width="50%" src="diagrams/credential.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;" width="50%" src="diagrams/credential.svg">
+          <figcaption style="text-align: center;">
 The basic components of a verifiable credential.
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-      <p>
+        <p>
 Examples of <a>verifiable credentials</a> include digital employee
 identification cards, digital birth certificates, and digital educational
 certificates.
-      </p>
+        </p>
 
-      <p class="note">
+        <p class="note">
 <a>Credential</a> identifiers are often used to identify specific instances
 of a <a>credential</a>. These identifiers can also be used for correlation. A
 <a>holder</a> wanting to minimize correlation MUST use a selective disclosure
 scheme that does not reveal the <a>credential</a> identifier.
-      </p>
+        </p>
 
-      <p>
+        <p>
 The example above provides a simple visual describing the components of a
 <a>verifiable credential</a>, but abstracts some of the details about how
 <a>claims</a> are organized into <a>graphs</a>, which are then organized into
@@ -536,69 +537,69 @@ The first <a>graph</a> expresses the <a>credential</a> itself, which contains
 The second <a>graph</a> expresses the
 <span style="color:#b6d7a8ff;font-weight:bold;text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;">digital proof</span>,
 which is usually a digital signature.
-      </p>
+        </p>
 
-      <figure>
-        <img style="margin: auto; display: block;" width="100%" src="diagrams/credential-graph.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;" width="100%" src="diagrams/credential-graph.svg">
+          <figcaption style="text-align: center;">
 A visual depiction of the information graphs associated with a basic verifiable
 credential.
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-      <p class="note">
+        <p class="note">
 It is possible to have a <a>credential</a>, such as a marriage certificate,
 containing multiple <a>claims</a> about different <a>subjects</a> that are
 not required to be related.
-      </p>
+        </p>
+      </section>
 
-    </section>
-    <section>
-      <h3>Presentations</h3>
+      <section>
+        <h3>Presentations</h3>
 
-      <em>This section is non-normative.</em>
+        <em>This section is non-normative.</em>
 
-      <p>
+        <p>
 Because this specification takes a privacy-first approach, it is important for
 <a>entities</a> using this technology to be able to express only the portions
 of their persona that are appropriate for a given situation. The expression of
 a subset of one's persona is called a <a>verifiable presentation</a>.
-      </p>
+        </p>
 
-      <p>
+        <p>
 A <a>verifiable presentation</a> expresses data from one or more
 <a>verifiable credentials</a>, and is packaged in such a way that the
 authorship of the data is verifiable. If <a>credentials</a> are directly
 presented, they become a <a>presentation</a>. Data formats derived from
 <a>credentials</a> that are cryptographically verifiable but do not of
 themselves contain <a>credentials</a>, might also be <a>presentations</a>.
-      </p>
-      <p>
+        </p>
+        <p>
 The data in a <a>presentation</a> is often about the same <a>subject</a>, but
 was issued by multiple <a>issuers</a>. The aggregation of this information
 typically expresses an aspect of a person, organization, or <a>entity</a>.
-      </p>
+        </p>
 
-      <figure>
-        <img style="margin: auto; display: block;"
-          width="50%" src="diagrams/presentation.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;"
+            width="50%" src="diagrams/presentation.svg">
+          <figcaption style="text-align: center;">
 The basic components of a verifiable presentation.
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-      <p>
+        <p>
 Examples of different <a>presentations</a> include a person's professional
 persona, their online gaming persona, or their home-life persona.
-      </p>
+        </p>
 
-      <p class="note">
+        <p class="note">
 It is possible to have a <a>presentation</a>, such as a business persona,
 that draws on multiple <a>credentials</a> about different <a>subjects</a>
 that are often, but not required to be, related.
-      </p>
+        </p>
 
-      <p>
+        <p>
 If a <a>presentation</a> supports <a>derived predicates</a>, a <a>claim</a>
 about birthdate in a <a>credential</a> can become the basis of proof that at a
 given point in time, the age of a <a>subject</a> did or will fall within a
@@ -611,18 +612,18 @@ about those <a>claims</a>. For example, a <a>claim</a> specifying a
 the <a>subject's</a> birthdate. The <a>holder</a> has the flexibility to use
 the <a>claim</a> in any way that is applicable to the desired
 <a>presentation</a>.
-      </p>
+        </p>
 
-          <figure>
-              <img style="margin: auto; display: block;"
-                   width="50%" src="diagrams/claim-example-2.svg">
-              <figcaption style="text-align: center;">
-                  An example of a basic claim expressing that Pat's date of
-				  birth is 2010-01-01T19:73:24Z.
-                  Date encoding would be determined by the schema.
-              </figcaption>
-          </figure>
-    </section>
+        <figure>
+          <img style="margin: auto; display: block;"
+            width="50%" src="diagrams/claim-example-2.svg">
+          <figcaption style="text-align: center;">
+An example of a basic claim expressing that Pat's date of
+birth is 2010-01-01T19:73:24Z.
+Date encoding would be determined by the schema.
+          </figcaption>
+        </figure>
+      </section>
     </section>
 
     <section>
@@ -639,12 +640,12 @@ The <a>verifiable credentials</a> trust model is as follows:
 The <a>verifier</a> trusts the <a>issuer</a> to issue the <a>credential</a>
 that it received. To establish this trust, a <a>credential</a> MUST either:
           <ul>
-			<li>
+            <li>
 Include a <a href="#proofs-signatures">proof</a> establishing that the
 <a>issuer</a> generated the <a>credential</a> (that is, it is a
 <a>verifiable credential</a>)
             </li>
-			<li>
+            <li>
 Have been transmitted in a way clearly establishing that the <a>issuer</a>
 generated the <a>credential</a> and that the <a>credential</a> was not
 tampered with in transit or storage. This trust could be weakened depending
@@ -696,7 +697,7 @@ with various threat models studied by the Working Group are urged to read
 the Verifiable Credentials Use Cases Document [[VC-USECASES]].
       </p>
 
-<p class="note">
+      <p class="note">
 The data model detailed in this specification does not imply a transitive trust
 model, such as that provided by more traditional Certificate Authority trust
 models. In the Verifiable Credentials Data Model, a <a>verifier</a> either
@@ -859,7 +860,7 @@ using the <code>type</code> property.
         </p>
 
         <dl>
-           <dt><dfn data-lt="type|types">type</dfn></dt>
+          <dt><dfn data-lt="type|types">type</dfn></dt>
           <dd>
 The value of the <code>type</code> property MUST be, or map to, one or more
 URIs. If more than one URI is provided, the URIs MUST be interpreted as an
@@ -983,14 +984,14 @@ associated with the <code>credentialSubject</code> property contains the
 identifier for the:
         </p>
 
-          <ul>
-			<li>
+        <ul>
+          <li>
 <a>Subject</a> in the <code>id</code> property.
-            </li>
-			<li>
+          </li>
+          <li>
 Age assertion in the <code>ageOver</code> property.
-            </li>
-          </ul>
+          </li>
+        </ul>
 
         <p>
 This enables implementers to rely on values associated with the
@@ -1165,7 +1166,7 @@ date and time the <a>credential</a> ceases to be valid.
 Information about the current status of a <a>verifiable credential</a>, such
 as whether it is suspended or revoked, MAY be provided using the
 <code>credentialStatus</code> <a>property</a>.
-	      </p>
+        </p>
 
         <dl>
           <dt><var>credentialStatus</var></dt>
@@ -1173,23 +1174,23 @@ as whether it is suspended or revoked, MAY be provided using the
 If specified, the value of the <code>credentialStatus</code> property MUST
 include the:
 
-	<ul>
-	  <li>
+            <ul>
+              <li>
 <a>Credential</a> status type (also referred to as the <a>credential</a>
 status scheme), which MUST provide enough information to determine the
 current status of the <a>credential</a> (for example, suspended or
 revoked).
-	  </li>
-	  <li>
+              </li>
+              <li>
 <a>id</a> of the status type instance.
-	  </li>
-	</ul>
+              </li>
+            </ul>
 
 The precise contents of the <a>credential</a> status information is determined
 by the specific <code>credentialStatus</code> type definition, and varies
 depending on factors such as whether it is simple to implement or if it is
 privacy-enhancing.
-	  </dd>
+          </dd>
         </dl>
 
         <pre class="example nohighlight" title="Usage of status property">
@@ -1230,9 +1231,9 @@ exists for implementers who want to implement <a>credential<a> status checking.
         <p>
 <a>Verifiable presentations</a> MAY be used to combine and present
 <a>verifiable credentials</a>.
-	</p>
+        </p>
 
-	<p>
+        <p>
 If <a>verifiable presentations</a> are used, they MUST be constructed from
 <a>verifiable credentials</a> themselves, or of data derived from
 <a>verifiable credentials</a> in a cryptographically verifiable format.
@@ -1285,7 +1286,7 @@ that contains derived data instead of directly embedded verifiable credentials.
     <section>
       <h2>Advanced Concepts</h2>
 
-	  <p>
+      <p>
 Building on the concepts introduced in Section <a href="#basic-concepts"></a>,
 this section explores more complex topics about <a>verifiable credentials</a>.
       </p>
@@ -1367,7 +1368,7 @@ associated with <code>did:example:abcdef1234567</code> has a <code>name</code>
 with a value of <code>Jane Doe</code>.
         </p>
 
-		<p>
+        <p>
 Now let us assume that a developer wants to extend the
 <a>verifiable credential</a> to store two additional pieces of information: an
 internal corporate reference number, and Jane's favorite food.
@@ -1504,17 +1505,17 @@ collection of data. There are at least two types of data schemas that this
 specification contemplates:
         </p>
 
-          <ul>
-            <li>
+        <ul>
+          <li>
 Data verification schemas, which are used to verify that the structure and
 contents of a <a>verifiable credential</a> conform to a published schema.
-            </li>
-			<li>
+          </li>
+          <li>
 Data encoding schemas, which are used to map the contents of a
 <a>verifiable credential</a> to an alternative representation format, such as a
 binary format used in a zero-knowledge proof.
-            </li>
-          </ul>
+          </li>
+        </ul>
 
         <p>
 The expression of a data schema can be performed using the following
@@ -1633,7 +1634,7 @@ including the refresh reference inside the <a>verifiable credential</a>
 enables both the <a>holder</a> and the <a>verifier</a> to perform future
 updates of the <a>credential</a>.
         </p>
-       <p>
+        <p>
 A refresh service can be expressed using the following <a>property</a>:
         </p>
 
@@ -1686,7 +1687,7 @@ In the example above, the <a>issuer</a> specifies a manual
       <section>
         <h3>Mode of Operation</h3>
 
-<em>This section is non-normative.</em>
+        <em>This section is non-normative.</em>
 
         <p>
 Section <a href="#ecosystem-overview"></a> provided an overview of the
@@ -1698,41 +1699,41 @@ how the ecosystem is envisaged to operate, as follows:
 The order of the following steps is not fixed and some steps might be repeated.
         </p>
 
-          <ol>
-            <li>
+        <ol>
+          <li>
 The <a>verifier</a> defines its policies for accepting
 <a>verifiable credentials</a> from <a>holders</a> for its supported actions.
-            </li>
-            <li>
+          </li>
+          <li>
 The <a>issuer</a> issues a <a>verifiable credential</a> to the <a>holder</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 The <a>holder</a> might pass on its <a>verifiable credentials</a> to another
 <a>holder</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 The final <a>holder</a> presents its <a>verifiable credentials</a> to the
 <a>verifier</a> in a <a>verifiable presentation</a>, requesting a supported
 action.
-            </li>
-            <li>
+          </li>
+          <li>
 The <a>verifier</a> verifies the authenticity of the
 <a>verifiable presentation</a> and <a>verifiable credentials</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 The <a>verifier</a> verifies that the <a>holder</a> posses the
 <a>verifiable credentials</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 The <a>verifier</a> decides whether to accept the <a>verifiable credentials</a>
 for the requested action, taking into account its policy, the <a>holder</a>,
 and the contents of the <a>verifiable credentials</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 The <a>verifier</a> either performs the requested action or rejects the
 request.
-            </li>
-          </ol>
+          </li>
+        </ol>
 
         <p>
 This specification does not define any protocol for transfering
@@ -1741,15 +1742,15 @@ other specifications do specify how they are transferred between entities, then
 this Verifiable Credential Data Model is:
         </p>
 
-          <ul>
-            <li>
+        <ul>
+          <li>
 Directly applicable to steps 2, 3, 4, 5, and 6.
-            </li>
-            <li>
+          </li>
+          <li>
 Not sufficient on its own for steps 1, 7, and 8 because an authorization
 framework is needed as well.
-            </li>
-          </ul>
+          </li>
+        </ul>
 
         <p>
 In particular, Sections <a href="#terms-of-use"></a> and
@@ -1757,24 +1758,24 @@ In particular, Sections <a href="#terms-of-use"></a> and
 determine:
         </p>
 
-          <ul>
-            <li>
+        <ul>
+          <li>
 Whether the <a>holder</a> is the <a>subject</a> of a
 <a>verifiable credential</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 The relationship between the <a>subject</a> and the <a>holder</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 Whether the original <a>holder</a> passed a <a>verifiable credential</a> to a
 subsequent <a>holder</a>.
-            </li>
-            <li>
+          </li>
+          <li>
 Any restrictions using the <a>verifiable credentials</a> by the <a>holder</a>
 or <a>verifier</a>.
-            </li>
-          </ul>
-     </section>
+          </li>
+        </ul>
+      </section>
 
       <section>
         <h3>Terms of Use</h3>
@@ -1788,7 +1789,7 @@ The <a>holder</a> places <a>holder</a> terms of use inside a
 <a>presentation</a>.
         </p>
 
-       <p class="note">
+        <p class="note">
 Further study is required to determine how a <a>subject</a> who is not a
 <a>holder</a> places terms of use on their <a>verifiable credentials</a>. One
 way could be for the <a>subject</a> to request the <a>issuer</a> to place the
@@ -1796,8 +1797,8 @@ terms of use inside the issued <a>verifiable credentials</a>. Another way
 could be for the <a>subject</a> to delegate a <a>verifiable credential</a> to
 a <a>holder</a> and placing terms of use restrictions on the delegated
 <a>verifiable credential</a>.
-       </p>
-       <p>
+        </p>
+        <p>
 Terms of use can be expressed using the following <a>property</a>:
         </p>
 
@@ -1987,64 +1988,64 @@ information, such as documentary evidence, related to the integrity of the
 express machine-verifiable mathematical proofs related to the authenticity of
 the <a>issuer</a> and integrity of the <a>credential</a>.
         </p>
+      </section>
 
-    </section>
-    <section>
-      <h3>Subject-Holder Relationships</h3>
+      <section>
+        <h3>Subject-Holder Relationships</h3>
 
-      <p>
+        <p>
 This section describes the possible relationships between a <a>subject</a>
 and a <a>holder</a> and how the Verifiable Claims Data Model expresses these
 relationships. The following diagram illustrates the different types of
 relationships covered in the rest of this section.
-     </p>
+        </p>
 
-      <figure>
-        <img style="margin: auto; display: block;" width="75%"
-          src="diagrams/subject-ne-holder.svg">
-        <figcaption style="text-align: center;">
+        <figure>
+          <img style="margin: auto; display: block;" width="75%"
+            src="diagrams/subject-ne-holder.svg">
+          <figcaption style="text-align: center;">
 Subject-Holder Relationships in Verifiable Credentials.
-        </figcaption>
-      </figure>
+          </figcaption>
+        </figure>
 
-     <p>
+        <p>
 The following sections describe how each of these relationships are handled in
 the data model.
-     </p>
+        </p>
 
-    <section>
-      <h4>Subject is the Holder</h4>
+        <section>
+          <h4>Subject is the Holder</h4>
 
-      <p>
+          <p>
 The most common case is when a <a>subject</a> is the <a>holder</a>. For
 example, a <a>verifier</a> can easily deduce that a <a>subject</a> is the
 <a>holder</a> if the <a>verifiable presentation</a> is digitally signed by the
 <a>holder</a> and all contained <a>verifiable credentials</a> are about a
 <a>subject</a> that can be identified to be the same as the <a>holder</a>.
-      </p>
+          </p>
 
-     <p>
+          <p>
 If only the credentialSubject is allowed to insert a verifiable credential
 into a verifiable presentation the issuer MAY insert the "subjectOnly" property 
 into the verifiable credential, as defined below. 
 
-<span class="issue">
+          <span class="issue">
 This feature is at risk and is likely to be removed due to lack of consensus.
-</span>
+          </span>
       </p>
 
-   <section>
-   <h5> 'Subject Only' Property </h5>
+          <section>
+            <h5>'Subject Only' Property</h5>
 
-  <p>
+            <p>
 The Subject Only property states that a verifiable credential MUST only be
 encapsulated into a verifiable presentation whose proof was issued by the 
 credentialSubject. A verifiable presentation that contains a verifiable credential 
 containing the subjectOnly property whose proof creator is not 
 the credentialSubject is invalid.
-     </p>
+            </p>
 
-        <pre class="example nohighlight" title="Subject Only Property">
+            <pre class="example nohighlight" title="Subject Only Property">
 {
   "id": "http://dmv.example.gov/credentials/3732",
   "type": ["VerifiableCredential", "ProofOfAgeCredential"],
@@ -2059,15 +2060,14 @@ the credentialSubject is invalid.
   "creator": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   ... }
 }
-        </pre>
-       </section>
-    </section>
+            </pre>
+          </section>
+        </section>
 
-    <section>
+        <section>
+          <h4>Credential Uniquely Identifies a Subject</h4>
 
-      <h4>Credential Uniquely Identifies a Subject</h4>
-
-      <p>
+          <p>
 In this case, the <code>credentialSubject</code> property might contain
 multiple properties that each provide an aspect of the identity of the
 <a>subject</a>, and which together, unambiguously identify the subject. Some
@@ -2075,9 +2075,9 @@ use cases might not require the <a>holder</a> to be identified at all, such as
 checking to see if a doctor (the <a>subject</a>) is board certified. Other use
 cases might require the <a>verifier</a> to use out-of-band knowledge to
 determine the relationship between the <a>subject</a> and the <a>holder</a>.
-      </p>
+          </p>
 
-      <pre class="example nohighlight" title="An example of a credential
+          <pre class="example nohighlight" title="An example of a credential
 that uniquely identifies a subject">
 {
   "@context": ["https://w3.org/2018/credentials/v1", "https://schema.org/"]
@@ -2098,78 +2098,78 @@ that uniquely identifies a subject">
   },
   "proof": { ... }
 }
-      </pre>
+          </pre>
 
-      <p>
+          <p>
 The example above uniquely identifies the <a>subject</a> using the name,
 address, and birth date of the individual.
-      </p>
-   </section>
+          </p>
+        </section>
 
-    <section>
-         <h4>Subject Passes the Verifiable Credential to a Holder</h4>
+        <section>
+          <h4>Subject Passes the Verifiable Credential to a Holder</h4>
 
-      <p>
+          <p>
 Normally verifiable credentials will be presented to verifiers by the
 subject. However in some cases, the subject may need to pass the whole or
 part of a verifiable credential to another holder. For example, a patient
 (the subject) may be too ill to take a prescription (the verifiable credential)
 to the pharmacist (the verifier), and so may ask a friend to take the
 prescription for him/her in order to pick up the medication.
-</p>
+          </p>
 
-<p>
+          <p>
 The data model allows for this, by the subject issuing a new verifiable
 credential and giving it to the new holder, so that the holder can present
 both verifiable credentials to the verifier. However, the content of this
 second verifiable credential is likely to be application specific, and therefore
 this specification does not standardise the contents of this second verifiable
 credential. Nevertheless a non-normative example is given in Appendix A.2
-      </p>
-   </section>
+          </p>
+        </section>
 
-   <section>
-      <h4>Holder Acts on Behalf of the Subject</h4>
+        <section>
+          <h4>Holder Acts on Behalf of the Subject</h4>
 
-      <p>
+          <p>
 The Verifiable Credentials Data Model supports the <a>holder</a> acting on
 behalf of the <a>subject</a> in at least the following ways:
-      </p>
+          </p>
 
-      <ul>
-        <li>
+          <ul>
+            <li>
 The <a>issuer</a> can include the relationship between the <a>holder</a> and
 the <a>subject</a> in the <code>credentialSubject</code> property.
-        </li>
-        <li>
+            </li>
+            <li>
 The <a>issuer</a> can express the relationship between the <a>holder</a> and
 the <a>subject</a> by issuing a new <a>verifiable credential</a>, which the
 <a>holder</a> utilizes.
-        </li>
-        <li>
+            </li>
+            <li>
 The <a>subject</a> can express their relationship with the <a>holder</a> by
 issuing a new <a>verifiable credential</a>, which the holder utilizes.
-        </li>
-      </ul>
+            </li>
+          </ul>
 
-      <p>
+          <p>
 The mechanisms listed above describe the relationship between the
 <a>holder</a> and the <a>subject</a> and helps the <a>verifier</a> decide
 whether the relationship is sufficiently expressed for the given use case.
-      </p>
+          </p>
 
-      <p class="note">
+          <p class="note">
 The additional mechanisms the <a>issuer</a> or the <a>verifier</a> uses to
 verify the relationship between the <a>subject</a> and the <a>holder</a> are
 outside of the scope of this specification.
-      </p>
+          </p>
 
-      <p class="issue">
+          <p class="issue">
 It is for further study which, if any, of these mechanisms is to be
 standardised by the working group.
-      </p>
+          </p>
 
-      <pre class="example nohighlight" title="An example of the relationship
+          <pre class="example nohighlight" title="An example of the relationship
 property in a child's credential">{
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential", "RelationshipCredential"],
@@ -2185,15 +2185,15 @@ property in a child's credential">{
   },
   "proof": { ... } // the proof is generated by the DMV
 }
-      </pre>
+          </pre>
 
-      <p>
+          <p>
 In the example above, the <a>issuer</a> expresses the relationship between the
 child and the parent such that a <a>verifier</a> would most likely accept the
 <a>credential</a> if it is provided by the child or the parent.
-      </p>
+          </p>
 
-      <pre class="example nohighlight" title="An example of a relationship
+          <pre class="example nohighlight" title="An example of a relationship
 credential issued to a parent">{
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "RelationshipCredential"],
@@ -2208,17 +2208,17 @@ credential issued to a parent">{
   },
   "proof": { ... } // the proof is generated by the DMV
 }
-</pre>
+          </pre>
 
-     <p>
+          <p>
 In the example above, the <a>issuer</a> expresses the relationship between the
 child and the parent in a separate <a>credential</a> such that a
 <a>verifier</a> would most likely accept any of the child's <a>credentials</a>
 if they are provided by the child or if the <a>credential</a> above is
 provided with any of the child's <a>credentials</a>.
-     </p>
+          </p>
 
-     <pre class="example nohighlight" title="An example of a relationship
+          <pre class="example nohighlight" title="An example of a relationship
 credential issued by a child">{
   "id": "http://example.org/credentials/23894",
   "type": ["VerifiableCredential", "RelationshipCredential"],
@@ -2233,34 +2233,34 @@ credential issued by a child">{
   },
   "proof": { ... } // the proof is generated by the child
 }
-</pre>
+          </pre>
 
-      <p>
+          <p>
 In the example above, the child has expressed the relationship between the
 child and the parent in a separate <a>credential</a> such that a
 <a>verifier</a> would most likely accept any of the child's <a>credentials</a>
 if the <a>credential</a> above is provided.
-      </p>
+          </p>
 
-      <p>
+          <p>
 Similarly, these same strategies can be used for many other types of use cases
 such as power of attorney, pet ownership, and patient prescription pickup.
-      </p>
-    </section>
+          </p>
+        </section>
 
-  <section>
-      <h4>Issuer Authorises Holder</h4>
+        <section>
+          <h4>Issuer Authorises Holder</h4>
 
-      <p>
+          <p>
 When an <a>issuer</a> wants to authorize a <a>holder</a> to possess a
 <a>credential</a> that describes a <a>subject</a> who is not the
 <a>holder</a>, and the <a>holder</a> has no known relationship with the
 <a>subject</a>, then the <a>issuer</a> inserts the relationship of the
 <a>holder</a> to itself into the <a>credential</a> for the <a>subject</a>.
-      </p>
+          </p>
 
 
-        <pre class="example nohighlight" title="An example of a credential
+          <pre class="example nohighlight" title="An example of a credential
 issued to a holder who is not the subject of the credential, who has no relationship
 with the subject of the credential, but who has a relationship with the issuer">
 
@@ -2285,21 +2285,20 @@ with the subject of the credential, but who has a relationship with the issuer">
     "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
     "signatureValue": "pY9...Cky6Ed = "
   }
-}        </pre>
+}
+          </pre>
+        </section>
 
-     </section>
-
-  <section>
-      <h4>Holder Acts on Behalf of the Verifier, or has no Relationship with
+        <section>
+          <h4>Holder Acts on Behalf of the Verifier, or has no Relationship with
 the Subject, Issuer, or Verifier</h4>
 
-      <p>
+          <p>
 The Verifiable Credentials Data Model currently does not support either of
 these scenarios. It is for further study how they might be supported.
-      </p>
+          </p>
+        </section>
       </section>
-
-   </section>
 
       <section>
         <h3>Disputes</h3>
@@ -2309,17 +2308,17 @@ There are at least two different cases to consider for an <a>entity</a>
 wanting to dispute a <a>credential</a> issued by an <a>issuer</a>:
         </p>
 
-  			<ul>
-  				<li>
+        <ul>
+          <li>
 A <a>subject</a> disputes a claim made by the <a>issuer</a>. For example, the
 address property is out of date.
-  	 			</li>
-  				<li>
+          </li>
+          <li>
 An entity disputes a potentially false claim made by the <a>issuer</a> about a
 different <a>subject</a>. For example, an imposter claims the social security
 number for an <a>entity</a>.
-  				</li>
-  			</ul>
+          </li>
+        </ul>
 
         <p>
 Only the <a>subject</a> of a <a>verifiable credential</a> is entitled to issue
@@ -2434,20 +2433,20 @@ noteworthy syntactic sugars used throughout the ecosystem are as follows:
         </p>
 
         <ul>
-		  <li>
+          <li>
 If processed using a JSON-LD processor:
-			<ul>
-			  <li>
+            <ul>
+              <li>
 The <code>@id</code> and <code>@type</code> keywords are aliased to
 <code>id</code> and <code>type</code> respectively, enabling developers to use
 this specification as idiomatic JSON.
-			  </li>
-			  <li>
+              </li>
+              <li>
 Data types, such as integers, dates, units of measure, and URLs, are
 automatically typed to provide stronger type guarantees for use cases that
 require them.
-			  </li>
-			  <li>
+              </li>
+              <li>
 The <code>verifiableCredential</code> and <code>proof</code> properties are
 treated as <em>graph containers</em>. That is, mechanisms used to isolate sets
 of data asserted by different entities. This ensures, for example, proper
@@ -2455,9 +2454,9 @@ cryptographic separation between the data graph provided by each <a>issuer</a>
 and the one provided by the <a>holder</a> presenting the
 <a>verifiable credential</a> to ensure the provenance of the information for
 each graph is preserved.
-			  </li>
-			</ul>
-		  </li>
+              </li>
+            </ul>
+          </li>
         </ul>
       </section>
 
@@ -2505,35 +2504,35 @@ such as XML, YAML, or CBOR, that is capable of expressing the data model.
       <section>
         <h3>JSON</h3>
 
-          <p>
+        <p>
 The data model as described in Section <a href="#core-data-model"></a> can be
 encoded in Javascript Object Notation (JSON) [[!RFC8259]] by mapping property
 values to JSON types as follows:
-          </p>
+        </p>
 
-          <ul>
-            <li>
+        <ul>
+          <li>
 Numeric values representable as IEEE754 SHOULD be represented as a Number type.
-            </li>
-            <li>
+          </li>
+          <li>
 Boolean values SHOULD be represented as a Boolean type.
-            </li>
-            <li>
+          </li>
+          <li>
 Sequence value SHOULD be represented as an Array type.
-            </li>
-            <li>
+          </li>
+          <li>
 Unordered sets of values SHOULD be represented as an Array type.
-            </li>
-            <li>
+          </li>
+          <li>
 Sets of <a>properties</a> SHOULD be represented as an Object type.
-            </li>
-            <li>
+          </li>
+          <li>
 Empty values SHOULD be represented as a null value.
-            </li>
-            <li>
+          </li>
+          <li>
 Other values MUST be represented as a String type.
-            </li>
-          </ul>
+          </li>
+        </ul>
       </section>
 
       <section>
@@ -2574,52 +2573,55 @@ Credentials Data Model is available at
         </p>
       </section>
 
-        <section>
-            <h3>JSON Web Token</h3>
+      <section>
+        <h3>JSON Web Token</h3>
 
-            <p>
+        <p>
 JSON Web Token (JWT) [[!RFC7519]] is still a widely used means to express claims to be transferred
 between two parties. Providing a representation of the verifiable credentials data
 model for JWT will allow existing systems and libraries to participate in the
 ecosystem as described in Section <a href="#ecosystem-overview"></a>.
 A JWT encodes a set of claims as a JSON object that is contained in a JSON Web Signature
 (JWS) [[!RFC7515]] and/or JWE [[!RFC7516]]. For this specification, the use of JWE is out of scope.
-            </p>
+        </p>
 
-            <section>
-              <h4>Relation to the VC Data Model</h4>
+        <section>
+          <h4>Relation to the VC Data Model</h4>
 
-              <p>
+          <p>
 This specification defines encoding rules of the verifiable credential and presentation data
 model onto JWT and JWS. It further defines processing rules how and when to make use of specific
 JWT registered claim names and specific JWS registered header parameter names to allow systems based
 on JWT to comply with this specification. If these specific claim names and header parameters are
 present, their respective counterpart in the verifiable credential and presentation MAY be omitted
 to avoid duplication.
-              </p>
-            </section>
+          </p>
+        </section>
 
-            <section>
-              <h4>IANA Considerations</h4>
-              <p>
+        <section>
+          <h4>IANA Considerations</h4>
+
+          <p>
 This specification introduces two new registered claim names which contain the JSON or JSON-LD
 verifiable credentials and presentation object enclosed in the JWT payload:
-              </p>
+          </p>
 
-                  <ul>
-                      <li>
+          <ul>
+            <li>
 <code>vc</code>: JSON object, and MUST be present in a JWT verifiable credential. The object contains the verifiable
 credential according to this specification.
-                      <li>
+            </li>
+            <li>
 <code>vp</code>: JSON object, and MUST be present in a JWT verifiable presentation. The object contains the verifiable
 presentation according to this specification.
-                      </li>
-                  </ul>
-            </section>
+            </li>
+          </ul>
+        </section>
 
-            <section>
-              <h4>JWT and JWS Considerations</h4>
-              <p>
+        <section>
+          <h4>JWT and JWS Considerations</h4>
+
+          <p>
 If the JWS is present, the digital signature either refers to the issuer of the verifiable credential
 or the holder of the credential in case of a presentation. The JWS will prove that the issuer of the
 JWT signed the contained JWT payload and therefore, the <code>proof</code> property can be omitted. If no JWS is
@@ -2628,64 +2630,71 @@ complex proofs, e.g., if the creator is different from the issuer, or a <code>pr
 digital signatures such as proof of work. The issuer MAY include both, a JWS and a <code>proof</code> property.
 For backward compatibility reasons, the issuer MUST use JWS to represent proofs based on a digital
 signature.
-              </p>
+          </p>
 
-              <p>
+          <p>
 Besides, the following defines rules for JOSE headers in the context of this specification:
-              </p>
+          </p>
 
-                <ul>
-                  <li>
+          <ul>
+            <li>
 <code>alg</code> MUST be used for RSA and ECDSA based digital signatures. If only the
 <code>proof</code> attribute was used, the <code>alg</code> header MUST be set to <code>none</code>.
-                  </li>
-                  <li>
+            </li>
+            <li>
 <code>kid</code> MAY be used if there are multiple keys associated with the issuer of the JWT.
 The key discovery is out of the scope of this specification. For example, the <code>kid</code> can refer to a
 key in a DID Document, or can be the identifier of a key inside a JWKS.
-                  </li>
-                  <li>
+            </li>
+            <li>
 <code>typ</code> MUST be set to <code>JWT</code> if present.
-                  </li>
-                </ul>
+            </li>
+          </ul>
 
-              <p>
+          <p>
 For backward compatibility with JWT processors the following JWT registered claim names MUST be used
 instead of or in addition to their respective verifiable credential counterparts:
-              </p>
+          </p>
 
-                  <ul>
-                      <li>
-<code>exp</code> MUST represent <code>expirationDate</code> encoded as a Unix timestamp (<code>NumericDate</code>).</li>
-                      <li>
+          <ul>
+            <li>
+<code>exp</code> MUST represent <code>expirationDate</code> encoded as a Unix timestamp (<code>NumericDate</code>).
+            </li>
+            <li>
 <code>iss</code> MUST represent the <code>issuer</code> property.
-                      </li>
-                      <li>
+            </li>
+            <li>
 <code>iat</code> MUST represent <code>issuanceDate</code> encoded as a Unix timestamp (<code>NumericDate</code>).
-                      </li>
-                      <li><code>jti</code> MUST represent the <code>id</code> property of the verifiable credential.</li>
-                      <li><code>sub</code> MUST represent the <code>id</code> property contained in the credential subject.</li>
-                      <li><code>aud</code> MUST represent the <code>subject</code> of the consumer of the presentation.</li>
-                  </ul>
+            </li>
+            <li>
+<code>jti</code> MUST represent the <code>id</code> property of the verifiable credential.
+            </li>
+            <li>
+<code>sub</code> MUST represent the <code>id</code> property contained in the credential subject.
+            </li>
+            <li>
+<code>aud</code> MUST represent the <code>subject</code> of the consumer of the presentation.
+            </li>
+          </ul>
 
-              <p>
+          <p>
 Other JOSE header parameters and claim names not specified herein can be used if their use is not
 explicitly discouraged.
-              </p>
+          </p>
 
-              <pre class="example nohighlight" title="JWT header of a JWT-based verifiable credential using JWS as a proof (non-normative)">
+          <pre class="example nohighlight" title="JWT header of a JWT-based verifiable credential using JWS as a proof (non-normative)">
 {
     "alg": "RS256",
     "typ": "JWT",
     "kid": "did:example:abfe13f712120431c276e12ecab#keys-1"
 }
-              </pre>
+          </pre>
 
-              <p class="issue">
+          <p class="issue">
 Add a short description explaining the example above.
-              </p>
+          </p>
 
-              <pre class="example nohighlight" title="JWT payload of a JWT-based verifiable credential using JWS as a proof (non-normative)">
+          <pre class="example nohighlight" title="JWT payload of a JWT-based verifiable credential using JWS as a proof (non-normative)">
 {
   "sub": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "jti": "http://example.edu/credentials/3732",
@@ -2707,29 +2716,29 @@ Add a short description explaining the example above.
     }
   }
 }
-              </pre>
+          </pre>
 
-              <p class="issue">
+          <p class="issue">
 Add a short description explaining the example above.
-              </p>
+          </p>
 
-              <p class="issue">
+          <p class="issue">
 Add an example of what a base64 JWT encoded verifiable credential looks.
-              </p>
+          </p>
 
-              <pre class="example nohighlight" title="JWT header of a JWT based verifiable presentation (non-normative)">
+          <pre class="example nohighlight" title="JWT header of a JWT based verifiable presentation (non-normative)">
 {
   "alg": "RS256",
   "typ": "JWT",
   "kid": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1"
 }
-              </pre>
+          </pre>
 
-              <p class="issue">
+          <p class="issue">
 Add a short description explaining the example above.
-              </p>
+          </p>
 
-              <pre class="example nohighlight" title="JWT payload of a JWT based verifiable presentation (non-normative)">
+          <pre class="example nohighlight" title="JWT payload of a JWT based verifiable presentation (non-normative)">
 {
   "iss": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "jti": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
@@ -2747,23 +2756,23 @@ Add a short description explaining the example above.
     "verifiableCredential": ["..."]
   }
 }
-              </pre>
+          </pre>
 
-              <p class="issue">
+          <p class="issue">
 Add a short description explaining the example above. Also mention that @context might be omitted.
-              </p>
+          </p>
 
-              <p class="issue">
+          <p class="issue">
 Add an example of what a base64 JWT encoded verifiable presentation looks.
-              </p>
+          </p>
 
-              <p class="issue">
+          <p class="issue">
 A number of the concerns have been raised around security,
 composability, reusability, and extensibility with respect
 to the use of JWTs for Verifiable Credentials. These concerns
 will be documented in time in at least the Verfiable Claims Model
 and Security Considerations section of this document.
-              </p>
+          </p>
         </section>
       </section>
     </section>
@@ -2771,65 +2780,65 @@ and Security Considerations section of this document.
     <section>
       <h2>Verification</h2>
 
-        <p>
+      <p>
 This section describes a number of checks required to verify a
 <a>credential</a>. Some checks are essential for all
 <a>verifiable credentials</a>, while other checks are applicable to only some
 <a>credentials</a>.
-        </p>
+      </p>
 
-        <p class="issue" data-number=128>
+      <p class="issue" data-number=128>
 The group is currently discussing whether a mechanism should be provided
 that enables linkages to JSON Schema or other optional verification mechanisms.
-        </p>
+      </p>
 
       <section>
         <h3>Syntax</h3>
 
-          <p>
+        <p>
 The document is syntactically valid. For example, syntactically valid JSON or
 JSON-LD.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Credential</h3>
 
-          <p>
+        <p>
 Required properties MUST be present. For example, for a
 <a>verifiable credential</a>, <code>type</code>, and <code>proof</code>
 properties are required.
-          </p>
+        </p>
 
-          <p>
+        <p>
 Property values MUST match expectations described in this specification. For
 example, the document <code>type</code> property for a
 <a>verifiable credential</a> MUST contain the
 <code>VerifiableCredential</code> class.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Issuer</h3>
 
-          <p>
+        <p>
 The value associated with the <code>issuer</code> property MUST identify an
 <a>issuer</a> that is known to and trusted by the <a>verifier</a>.
-          </p>
+        </p>
 
-          <p>
+        <p>
 Pertinent metadata about the <code>issuer</code> MUST be available to the
 <a>verifier</a>. For example, an <a>issuer</a> can publish information
 containing the public keys it uses to digitally sign
 <a>verifiable credentials</a> that it has issued. This metadata is pertinent
 when checking the proofs on the <a>verifiable credential</a>.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Subject</h3>
 
-          <p>
+        <p>
 The value associated with the <code>id</code> property for each
 <code>credentialSubject</code> MUST identify a <a>subject</a> to the
 <a>verifier</a>. For example, if a <a>subject</a> is identified and the
@@ -2837,68 +2846,68 @@ The value associated with the <code>id</code> property for each
 used for authentication purposes, the verifier MAY be able to authenticate the
 <a>subject</a> using a signature generated by the <a>subject</a> contained in
 the <a>verifiable presentation</a>.
-          </p>
+        </p>
 
-          <p class="issue" data-number=162>
+        <p class="issue" data-number=162>
 The group is currently discussing how authentication and WebAuthn may work.
-          </p>
+        </p>
 
-          <p class="note">
+        <p class="note">
 The <code>id</code> property is optional. <a>Verifiers</a> MAY use other
 properties in a <a>credential</a> to uniquely identify a <a>subject</a>.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Proofs (Signatures)</h3>
 
-          <p>
+        <p>
 The cryptographic mechanism used to prove that the information in a
 <a>verifiable credential</a> or a <a>verifiable presentation</a> has not been
 tampered with is called a <em>proof</em>. There are many types of
 cryptographic proofs including, but not limited to, digital signatures,
 zero-knowledge proofs, proofs of work, and proofs of stake. In general, when
 verifying proofs implementations MUST ensure that:
-          </p>
+        </p>
 
-          <ul>
-            <li>
+        <ul>
+          <li>
 The proof is available in the form of a known proof suite.
-            </li>
-            <li>
+          </li>
+          <li>
 All required proof suite properties are present.
-            </li>
-            <li>
+          </li>
+          <li>
 The proof suite verification agorithm, when applied to the data, results in an
 acceptable proof.
-            </li>
-          </ul>
+          </li>
+        </ul>
 
-          <p>
+        <p>
 Some proofs are digital signatures. In general, when verifying digital
 signatures, implementations MUST ensure that:
-          </p>
+        </p>
 
-          <ul>
-            <li>
+        <ul>
+          <li>
 Acceptably recent metadata regarding the public key associated with the
 signature is available. For example, the metadata might include properties
 related to expiration, key owner, or key purpose.
-            </li>
-            <li>
+          </li>
+          <li>
 The key MUST NOT be revoked or expired.
-            </li>
-            <li>
+          </li>
+          <li>
 The cryptographic signature MUST verify.
-            </li>
-            <li>
+          </li>
+          <li>
 If the cryptographic suite expects a <code>proofPurpose</code>, it MUST exist
 and be a valid value (such as <code>credentialIssuance</code>) as per the
 cryptographic suite.
-            </li>
-          </ul>
+          </li>
+        </ul>
 
-          <p class="note">
+        <p class="note">
 The digital signature provides a number of protections, other than tamper
 resistance, that are not immediately obvious. For example, a Linked Data
 Signature <code>created</code> property establishes a date and time before
@@ -2909,71 +2918,71 @@ public key is not revoked or expired. The <code>proofPurpose</code> property
 ensures the reason the entity created the signature, such as for
 authentication or creating a <a>verifiable credential</a>, is clear and
 protected in the signature.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Issuance</h3>
 
-          <p>
+        <p>
 The <code>issuanceDate</code> MUST be within an expected range for the
 <a>verifier</a>. For example, a <a>verifier</a> can ensure that the issuance
 date of a <a>verifiable credential</a> is not in the future.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Expiration</h3>
 
-          <p>
+        <p>
 The <code>expirationDate</code> MUST be within an expected range for the
 <a>verifier</a>. For example, a <a>verifier</a> can ensure that the expiration
 date of a <a>verifiable credential</a> is not in the past.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Revocation</h3>
 
-          <p>
+        <p>
 If revocation instructions are present, the <a>credential</a> MUST NOT
 have been revoked.
-          </p>
+        </p>
       </section>
 
       <section>
         <h3>Fitness for Purpose</h3>
 
-          <p>
+        <p>
 Custom properties in the <a>credential</a> are appropriate for the purpose of
 the <a>verifier</a>. For example, if a <a>verifier</a> needs to determine if a
 <a>subject</a> is older than 21 years of age, they might accept claims of
 specific <code>birthdate</code> or abstract properties such as
 <code>ageOver</code>.
-          </p>
+        </p>
 
-          <p>
+        <p>
 The <a>issuer</a> is trusted by the <a>verifier</a> to make the claims at
 hand. For example, a franchised fast food restaurant location will trust
 discount coupon claims made by the corporate headquarters of the franchise.
-          </p>
+        </p>
 
-          <p>
+        <p>
 All policy information expressed by an <a>issuer</a> in a
 <a>verifiable credential</a> MUST be enforced unless <a>verifiers</a> accept
 the risk of not enforcing the policy information. For example, an
 <a>issuer</a> might limit the use of a <a>credential</a> to specific
 <a>verifiers</a>, to <a>holders</a> within a specific age range, or between
 specific dates.
-          </p>
+        </p>
 
-          <p>
+        <p>
 All policy information expressed by a <a>holder</a> in a
 <a>verifiable presentation</a> MUST be enforced unless <a>verifiers</a> accept
 the risk of not enforcing the policy information. For example, a <a>holder</a>
 might limit the use of a <a>credential</a> to specific <a>verifiers</a> or for
 specific purposes (such as authentication, but not data mining).
-          </p>
+        </p>
       </section>
     </section>
 
@@ -3119,17 +3128,17 @@ If strong anti-correlation properties are a requirement in a
 are either:
         </p>
 
-		  <ul>
-		    <li>
+        <ul>
+          <li>
 Bound to a single origin
-		    </li>
-			<li>
+          </li>
+          <li>
 Single-use
-			</li>
-			<li>
+          </li>
+          <li>
 Not used at all, but instead replaced by short-lived, single-use bearer tokens.
-			</li>
-		  </ul>
+          </li>
+        </ul>
       </section>
 
       <section>
@@ -3150,7 +3159,7 @@ signature values and metadata are regenerated each time using technologies like
 third-party pairwise signatures, zero-knowledge proofs, or group signatures.
         </p>
 
-		<p class="note">
+        <p class="note">
 Even when using anti-correlation signatures, information might still be
 contained in a <a>credential</a> that defeats the anti-correlation properties
 of the cryptography used.
@@ -3265,24 +3274,24 @@ promote the pseudonymous usage of <a>credentials</a>. Implementers that find
 this impractical or unsafe, should consider using selective disclosure schemes
 that eliminate dependence on <a>issuers</a> at proving time and reduce temporal
 correlation risk from <a>issuers</a>.
-		</p>
+        </p>
 
         <p>
 <a>Verifiers</a> are urged to only request information that is absolutely
 necessary for a specific transaction to occur. This is important for at
 least two reasons. It:
-		</p>
+        </p>
 
-		  <ul>
-			<li>
+        <ul>
+          <li>
 Reduces the liability on the <a>verifier</a> for handling highly sensitive
 information that it does not need to.
-			</li>
-			<li>
+          </li>
+          <li>
 Enhances the privacy of the individual by only asking for information required
 for a specific transaction.
-			</li>
-          </ul>
+          </li>
+        </ul>
 
         <p class="note">
 While it is possible to practice the Principle of Minimum Disclosure, it might
@@ -3347,17 +3356,17 @@ statistically identify an individual when used together in the same
 are expected to provide privacy-enhancing benefits that:
         </p>
 
-          <ul>
-		    <li>
+        <ul>
+          <li>
 Are single-use, where possible
-		    </li>
-			<li>
+          </li>
+          <li>
 Do not contain personally identifying information
-            </li>
-			<li>
+          </li>
+          <li>
 Are not unduly correlatable.
-			</li>
-		  </ul>
+          </li>
+        </ul>
 
         <p>
 <a>Holders</a> SHOULD be warned by their software if bearer credentials

--- a/index.html
+++ b/index.html
@@ -3867,27 +3867,32 @@ All or any combination of the above.
       </section>
     </section>
 
-<section>
-<h2> Appendix A.2 Subject passes a verifiable credential to someone else</h2>
+    <section class="appendix">
+      <h2>Advanced Examples</h2>
 
-      <em>This section is non-normative.</em>
+      <section class="appendix">
+        <h3>Subject Passes a Verifiable Credential to Someone Else</h3>
 
-<p>
-When the subject passes a verifiable credential to another
-holder, the subject may issue a new verifiable credential to the holder in which:
-the issuer is the subject,
-the subject is the holder to whom the verifiable credential is being passed,
-and the claim contains the properties that are being passed on. 
-The holder may now create a verifiable presentation that contains these two
-verifiable credentials, so that the verifier can verify that the subject gave
-the original verifiable credential to the holder.
+        <em>This section is non-normative.</em>
 
-      <pre class="example nohighlight" title="An example of a holder presenting 
+        <p>
+When the <a>subject</a> passes a <a>verifiable credential</a> to another
+holder, the <a>subject</a> may issue a new <a>verifiable credential</a> to the <a>holder</a> in which:
+the <a>issuer</a> is the <a>subject</a>,
+the <a>subject</a> is the <a>holder</a> to whom the <a>verifiable credential</a> is being passed,
+and the <a>claim</a> contains the properties that are being passed on. 
+The <a>holder</a> may now create a <a>verifiable presentation</a> that contains these two
+<a>verifiable credentials</a>, so that the <a>verifier</a> can verify that the <a>subject</a> gave
+the original <a>verifiable credential</a> to the <a>holder</a>.
+        </p>
+
+        <pre class="example nohighlight" title="An example of a holder presenting 
 a verifiable credential that has been passed to it by the subject">
 {
   "id": "did:example:76e12ec21ebhyu1f712ebc6f1z2",
   "type": ["VerifiablePresentation"],
-  "credential": [{
+  "credential": [
+    {
       "id": "http://example.gov/credentials/3732",
       "type": ["VerifiableCredential", "PrescriptionCredential"],
       "issuer": "https://dmv.example.gov",
@@ -3916,7 +3921,7 @@ a verifiable credential that has been passed to it by the subject">
         "created": "2017-06-17T10:03:48Z",
         "creator": "did:example:ebfeb1f712ebc6f1c276e12ec21/keys/234",
         "nonce": "d61c4599-0cc2-4479-9efc-c63add3a43b2",
-        "signatureValue": "pYw8XNi1..Cky6Ed = "
+        "signatureValue": "pYw8XNi1..Cky6Ed="
       }
     }
   ],
@@ -3925,17 +3930,19 @@ a verifiable credential that has been passed to it by the subject">
     "created": "2017-06-18T21:19:10Z",
     "creator": "did:example:76e12ec21ebhyu1f712ebc6f1z2/keys/2",
     "nonce": "c0ae1c8e-c7e7-469f-b252-86e6a0e7387e",
-    "signatureValue": "BavEll0/I1..W3JT24 = "
+    "signatureValue": "BavEll0/I1..W3JT24="
   }]
 }
         </pre>
 
-<p>
+        <p>
 In the above example, a patient (the original subject) has passed a prescription 
 (the original verifiable credential) to a friend, and has issued a new verifiable
 credential to the friend, in which the friend is the subject, the original subject is
 the issuer, and the credential is a copy of the original prescription.
-</p>
+        </p>
+      </section>
+    </section>
   </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -131,10 +131,8 @@ document.
       </p>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Introduction</h2>
-
-      <em>This section is non-normative.</em>
 
       <p>
 <a>Credentials</a> are a part of our daily lives; driver's licenses are used to
@@ -231,10 +229,8 @@ zero-knowledge proofs, are also provided throughout this document.
         </p>
       </section>
 
-      <section>
+      <section class="informative">
         <h3>Ecosystem Overview</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 This section describes the roles of the core actors and the relationships
@@ -295,10 +291,8 @@ provide benefit.
         </p>
       </section>
 
-      <section>
+      <section class="informative">
         <h3>Use Cases and Requirements</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 The Verifiable Credentials Use Cases [[VC-USECASES]] document outlines a number
@@ -409,20 +403,16 @@ single document.
       </section>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Terminology</h2>
-
-      <em>This section is non-normative.</em>
 
       <div data-include="./terms.html"
         data-oninclude="restrictReferences">
       </div>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Core Data Model</h2>
-
-      <em>This section is non-normative.</em>
 
       <p>
 The following sections outline core data model concepts, such as
@@ -430,10 +420,8 @@ The following sections outline core data model concepts, such as
 foundation of this specification.
       </p>
 
-      <section>
+      <section class="informative">
         <h3>Claims</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 A <a>claim</a> is statement about a <a>subject</a>. A <a>subject</a> is an
@@ -488,10 +476,8 @@ added.
         </p>
       </section>
 
-      <section>
+      <section class="informative">
         <h3>Credentials</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 A <a>credential</a> is set of one or more <a>claims</a> made by the same
@@ -554,10 +540,8 @@ not required to be related.
         </p>
       </section>
 
-      <section>
+      <section class="informative">
         <h3>Presentations</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 Because this specification takes a privacy-first approach, it is important for
@@ -626,10 +610,8 @@ Date encoding would be determined by the schema.
       </section>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Trust Model</h2>
-
-      <em>This section is non-normative.</em>
 
       <p>
 The <a>verifiable credentials</a> trust model is as follows:
@@ -1684,10 +1666,8 @@ In the example above, the <a>issuer</a> specifies a manual
         </p>
       </section>
 
-      <section>
+      <section class="informative">
         <h3>Mode of Operation</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 Section <a href="#ecosystem-overview"></a> provided an overview of the
@@ -2986,10 +2966,8 @@ specific purposes (such as authentication, but not data mining).
       </section>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Accessibility Considerations</h2>
-
-      <em>This section is non-normative.</em>
 
       <p>
 There are a number of accessibility considerations implementers should be
@@ -3032,10 +3010,8 @@ abilities.
       </section>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Privacy Considerations</h2>
-
-      <em>This section is non-normative.</em>
 
       <p>
 This section details the general privacy considerations and specific privacy
@@ -3718,10 +3694,8 @@ keeping the identifier embedded and signed in the <a>credential</a>.
       </section>
     </section>
 
-    <section>
+    <section class="informative">
       <h2>Security Considerations</h2>
-
-      <em>This section is non-normative.</em>
 
       <p>
 There are a number of security considerations that <a>issuers</a>,
@@ -3870,10 +3844,8 @@ All or any combination of the above.
     <section class="appendix">
       <h2>Advanced Examples</h2>
 
-      <section class="appendix">
+      <section class="appendix informative">
         <h3>Subject Passes a Verifiable Credential to Someone Else</h3>
-
-        <em>This section is non-normative.</em>
 
         <p>
 When the <a>subject</a> passes a <a>verifiable credential</a> to another

--- a/index.html
+++ b/index.html
@@ -2506,7 +2506,7 @@ revoked", or "MUST be in the expected range").
       </section>
 
     </section>
-<a href="index.html" id="" title="index">index</a>
+
     <section>
       <h2>Syntaxes</h2>
 

--- a/index.html
+++ b/index.html
@@ -2028,11 +2028,11 @@ example, a <a>verifier</a> can easily deduce that a <a>subject</a> is the
 If only the credentialSubject is allowed to insert a verifiable credential
 into a verifiable presentation the issuer MAY insert the "subjectOnly" property 
 into the verifiable credential, as defined below. 
+          </p>
 
-          <span class="issue">
+          <p class="issue">
 This feature is at risk and is likely to be removed due to lack of consensus.
-          </span>
-      </p>
+          </p>
 
           <section>
             <h5>'Subject Only' Property</h5>

--- a/index.html
+++ b/index.html
@@ -796,7 +796,7 @@ expressed using the <code>id</code> property.
 
         <p class="note">
 Developers should remember that identifiers might be harmful in scenarios
-where pseudonymity is required. Developers are encourged to read
+where pseudonymity is required. Developers are encouraged to read
 Section <a href="#privacy-considerations"></a> carefully when considering
 such scenarios.
         </p>
@@ -2426,7 +2426,7 @@ In general, the data model and syntaxes described in this document are
 designed such that developers can copy and paste examples to incorporate
 <a>verifiable credentials</a> into their software systems. The design goal of
 this approach is to provide a low barrier to entry while still ensuring global
-interoperability between a heterogenous set of software systems. This section
+interoperability between a heterogeneous set of software systems. This section
 describes some of these approaches, which will most likely go unnoticed by most
 developers, but whose details will be of interest to implementers. The most
 noteworthy syntactic sugars used throughout the ecosystem are as follows:
@@ -2770,7 +2770,7 @@ Add an example of what a base64 JWT encoded verifiable presentation looks.
 A number of the concerns have been raised around security,
 composability, reusability, and extensibility with respect
 to the use of JWTs for Verifiable Credentials. These concerns
-will be documented in time in at least the Verfiable Claims Model
+will be documented in time in at least the Verifiable Claims Model
 and Security Considerations section of this document.
           </p>
         </section>
@@ -2878,7 +2878,7 @@ The proof is available in the form of a known proof suite.
 All required proof suite properties are present.
           </li>
           <li>
-The proof suite verification agorithm, when applied to the data, results in an
+The proof suite verification algorithm, when applied to the data, results in an
 acceptable proof.
           </li>
         </ul>
@@ -2992,11 +2992,11 @@ specific purposes (such as authentication, but not data mining).
       <em>This section is non-normative.</em>
 
       <p>
-There are a number of accessibility considerations implementors should be
+There are a number of accessibility considerations implementers should be
 aware of when processing data described in this specification. As with any web
 standards or protocols implementation, ignoring accessibility issues makes
 this information unusable to a large subset of the population. It is important
-to follow accessiblity guidelines and standards, such as [[WCAG21]], to ensure
+to follow accessibility guidelines and standards, such as [[WCAG21]], to ensure
 all people, regardless of ability, can make use of this data. This is
 especially important when establishing systems that utilize cryptography and
 encryption, which historically, have created problems for assistive

--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@ or send them to
 There remain a list of editorial issues that need to be processed in this
 document.
         </p>
-
     </section>
 
     <section>
@@ -160,10 +159,12 @@ This specification provides a standard way to express <a>credentials</a> on the
 Web in a way that is cryptographically secure, privacy-respecting, and
 machine-verifiable.
       </p>
+
       <p>
 For those unfamiliar with the concepts related to
 <a>verifiable credentials</a>, the following sections provide an overview of:
       </p>
+
       <ul>
         <li>
 The components that constitute a <a>verifiable credential</a>
@@ -291,7 +292,6 @@ concepts in this specification. Other ecosystems exist, such as protected
 environments or proprietary systems, where <a>verifiable credentials</a> also
 provide benefit.
       </p>
-
     </section>
 
     <section>
@@ -408,7 +408,6 @@ single document.
     </section>
 
   </section>
-
     <section>
       <h2>Terminology</h2>
 
@@ -613,6 +612,7 @@ the <a>subject's</a> birthdate. The <a>holder</a> has the flexibility to use
 the <a>claim</a> in any way that is applicable to the desired
 <a>presentation</a>.
       </p>
+
           <figure>
               <img style="margin: auto; display: block;"
                    width="50%" src="diagrams/claim-example-2.svg">
@@ -622,7 +622,6 @@ the <a>claim</a> in any way that is applicable to the desired
                   Date encoding would be determined by the schema.
               </figcaption>
           </figure>
-
     </section>
     </section>
 
@@ -1014,7 +1013,6 @@ developers and document authors do not need to understand the specifics of the
 JSON-LD type system, implementers of this specification who want to support
 interoperable extensibility, do.
         </p>
-
       </section>
 
       <section>
@@ -1024,6 +1022,7 @@ interoperable extensibility, do.
 <a>Issuer</a> information can be expressed using the following
 <a>properties</a>:
         </p>
+
         <dl>
           <dt><var>issuer</var></dt>
           <dd>
@@ -1041,6 +1040,7 @@ earliest date when the information associated with the
 <code>credentialSubject</code> property became valid.
           </dd>
         </dl>
+
         <pre class="example nohighlight" title="Usage of issuer properties">
 {
   "@context": [
@@ -1070,6 +1070,7 @@ earliest date when the information associated with the
 For a <a>credential</a> or <a>presentation</a> to be verifiable, the following
 <a>property</a> MUST be present:
         </p>
+
         <dl>
           <dt><var>proof</var></dt>
           <dd>
@@ -1079,6 +1080,7 @@ proof mechanism, the <code>proof</code> property is expected to have a value
 that is a set of name-value pairs including at least a signature, a reference
 to the signing entity, and a representation of the signing date.</dd>
         </dl>
+
         <pre class="example nohighlight"
           title="Usage of proof property on a verifiable credential">
 {
@@ -1114,7 +1116,6 @@ to the signing entity, and a representation of the signing date.</dd>
 The group is currently discussing various alignments with the JOSE stack,
 specifically JWS and JWK.
         </p>
-
       </section>
 
       <section>
@@ -1155,7 +1156,6 @@ date and time the <a>credential</a> ceases to be valid.
   "proof": { ... }
 }
         </pre>
-
       </section>
 
       <section>
@@ -1166,6 +1166,7 @@ Information about the current status of a <a>verifiable credential</a>, such
 as whether it is suspended or revoked, MAY be provided using the
 <code>credentialStatus</code> <a>property</a>.
 	      </p>
+
         <dl>
           <dt><var>credentialStatus</var></dt>
           <dd>
@@ -1491,9 +1492,7 @@ new <code>favoriteFood</code> term so that it can only be used within the
   }
 }
           </pre>
-
         </section>
-
       </section>
 
       <section>
@@ -1610,7 +1609,6 @@ data format that is capable of transforming the input data into a format,
 which can then be used by a <a>verifier</a> to determine if the
 proof provided with the <a>verifiable credential</a> is valid.
         </p>
-
       </section>
 
       <section>
@@ -1683,7 +1681,6 @@ In the example above, the <a>issuer</a> specifies a manual
 <code>refreshService</code> that can be used by directing the <a>holder</a> to
 <code>https://dmv.example.gov/refresh/283947</code>.
         </p>
-
       </section>
 
       <section>
@@ -1777,7 +1774,6 @@ Any restrictions using the <a>verifiable credentials</a> by the <a>holder</a>
 or <a>verifier</a>.
             </li>
           </ul>
-
      </section>
 
       <section>
@@ -1909,7 +1905,6 @@ prohibiting a specific <a>verifier</a>
 provided to correlate the <a>holder</a> with the <a>subject</a> using a
 third-party service.
         </p>
-
       </section>
 
       <section>
@@ -1994,9 +1989,7 @@ the <a>issuer</a> and integrity of the <a>credential</a>.
         </p>
 
     </section>
-
     <section>
-
       <h3>Subject-Holder Relationships</h3>
 
       <p>
@@ -2029,6 +2022,7 @@ example, a <a>verifier</a> can easily deduce that a <a>subject</a> is the
 <a>holder</a> and all contained <a>verifiable credentials</a> are about a
 <a>subject</a> that can be identified to be the same as the <a>holder</a>.
       </p>
+
      <p>
 If only the credentialSubject is allowed to insert a verifiable credential
 into a verifiable presentation the issuer MAY insert the "subjectOnly" property 
@@ -2040,7 +2034,6 @@ This feature is at risk and is likely to be removed due to lack of consensus.
       </p>
 
    <section>
-
    <h5> 'Subject Only' Property </h5>
 
   <p>
@@ -2067,10 +2060,7 @@ the credentialSubject is invalid.
   ... }
 }
         </pre>
-
        </section>
-
-
     </section>
 
     <section>
@@ -2114,12 +2104,11 @@ that uniquely identifies a subject">
 The example above uniquely identifies the <a>subject</a> using the name,
 address, and birth date of the individual.
       </p>
-
- 
    </section>
 
     <section>
          <h4>Subject Passes the Verifiable Credential to a Holder</h4>
+
       <p>
 Normally verifiable credentials will be presented to verifiers by the
 subject. However in some cases, the subject may need to pass the whole or
@@ -2137,7 +2126,6 @@ second verifiable credential is likely to be application specific, and therefore
 this specification does not standardise the contents of this second verifiable
 credential. Nevertheless a non-normative example is given in Appendix A.2
       </p>
- 
    </section>
 
    <section>
@@ -2258,7 +2246,6 @@ if the <a>credential</a> above is provided.
 Similarly, these same strategies can be used for many other types of use cases
 such as power of attorney, pet ownership, and patient prescription pickup.
       </p>
-
     </section>
 
   <section>
@@ -2411,7 +2398,6 @@ The group is currently exploring whether the specification of a vocabulary
 term to express content-based identifiers for claims is within scope as well
 as the specific vocabulary terms for disputed claims.
         </p>
-
       </section>
 
       <section>
@@ -2431,7 +2417,6 @@ The Working Group did consider authorization use cases during the creation of
 this specification and is pursuing that work as an architectural layer built
 on top of this specification.
         </p>
-
       </section>
 
       <section>
@@ -2474,7 +2459,6 @@ each graph is preserved.
 			</ul>
 		  </li>
         </ul>
-
       </section>
 
       <section>
@@ -2502,9 +2486,7 @@ contents of property-value pairs (for example, the content in
 regarding the contents of property-value pairs (for example, "MUST NOT be
 revoked", or "MUST be in the expected range").
         </p>
-
       </section>
-
     </section>
 
     <section>
@@ -2590,11 +2572,11 @@ cached client side. The associated vocabulary document for the Verifiable
 Credentials Data Model is available at
 <code>https://w3.org/2018/credentials</code>.
         </p>
-
       </section>
 
         <section>
             <h3>JSON Web Token</h3>
+
             <p>
 JSON Web Token (JWT) [[!RFC7519]] is still a widely used means to express claims to be transferred
 between two parties. Providing a representation of the verifiable credentials data
@@ -2606,6 +2588,7 @@ A JWT encodes a set of claims as a JSON object that is contained in a JSON Web S
 
             <section>
               <h4>Relation to the VC Data Model</h4>
+
               <p>
 This specification defines encoding rules of the verifiable credential and presentation data
 model onto JWT and JWS. It further defines processing rules how and when to make use of specific
@@ -2622,6 +2605,7 @@ to avoid duplication.
 This specification introduces two new registered claim names which contain the JSON or JSON-LD
 verifiable credentials and presentation object enclosed in the JWT payload:
               </p>
+
                   <ul>
                       <li>
 <code>vc</code>: JSON object, and MUST be present in a JWT verifiable credential. The object contains the verifiable
@@ -2645,9 +2629,11 @@ digital signatures such as proof of work. The issuer MAY include both, a JWS and
 For backward compatibility reasons, the issuer MUST use JWS to represent proofs based on a digital
 signature.
               </p>
+
               <p>
 Besides, the following defines rules for JOSE headers in the context of this specification:
               </p>
+
                 <ul>
                   <li>
 <code>alg</code> MUST be used for RSA and ECDSA based digital signatures. If only the
@@ -2662,10 +2648,12 @@ key in a DID Document, or can be the identifier of a key inside a JWKS.
 <code>typ</code> MUST be set to <code>JWT</code> if present.
                   </li>
                 </ul>
+
               <p>
 For backward compatibility with JWT processors the following JWT registered claim names MUST be used
 instead of or in addition to their respective verifiable credential counterparts:
               </p>
+
                   <ul>
                       <li>
 <code>exp</code> MUST represent <code>expirationDate</code> encoded as a Unix timestamp (<code>NumericDate</code>).</li>
@@ -2679,6 +2667,7 @@ instead of or in addition to their respective verifiable credential counterparts
                       <li><code>sub</code> MUST represent the <code>id</code> property contained in the credential subject.</li>
                       <li><code>aud</code> MUST represent the <code>subject</code> of the consumer of the presentation.</li>
                   </ul>
+
               <p>
 Other JOSE header parameters and claim names not specified herein can be used if their use is not
 explicitly discouraged.
@@ -2776,9 +2765,7 @@ will be documented in time in at least the Verfiable Claims Model
 and Security Considerations section of this document.
               </p>
         </section>
-
       </section>
-
     </section>
 
     <section>
@@ -2803,7 +2790,6 @@ that enables linkages to JSON Schema or other optional verification mechanisms.
 The document is syntactically valid. For example, syntactically valid JSON or
 JSON-LD.
           </p>
-
       </section>
 
       <section>
@@ -2821,7 +2807,6 @@ example, the document <code>type</code> property for a
 <a>verifiable credential</a> MUST contain the
 <code>VerifiableCredential</code> class.
           </p>
-
       </section>
 
       <section>
@@ -2839,7 +2824,6 @@ containing the public keys it uses to digitally sign
 <a>verifiable credentials</a> that it has issued. This metadata is pertinent
 when checking the proofs on the <a>verifiable credential</a>.
           </p>
-
       </section>
 
       <section>
@@ -2863,7 +2847,6 @@ The group is currently discussing how authentication and WebAuthn may work.
 The <code>id</code> property is optional. <a>Verifiers</a> MAY use other
 properties in a <a>credential</a> to uniquely identify a <a>subject</a>.
           </p>
-
       </section>
 
       <section>
@@ -2937,7 +2920,6 @@ The <code>issuanceDate</code> MUST be within an expected range for the
 <a>verifier</a>. For example, a <a>verifier</a> can ensure that the issuance
 date of a <a>verifiable credential</a> is not in the future.
           </p>
-
       </section>
 
       <section>
@@ -2948,7 +2930,6 @@ The <code>expirationDate</code> MUST be within an expected range for the
 <a>verifier</a>. For example, a <a>verifier</a> can ensure that the expiration
 date of a <a>verifiable credential</a> is not in the past.
           </p>
-
       </section>
 
       <section>
@@ -2958,7 +2939,6 @@ date of a <a>verifiable credential</a> is not in the past.
 If revocation instructions are present, the <a>credential</a> MUST NOT
 have been revoked.
           </p>
-
       </section>
 
       <section>
@@ -2994,9 +2974,7 @@ the risk of not enforcing the policy information. For example, a <a>holder</a>
 might limit the use of a <a>credential</a> to specific <a>verifiers</a> or for
 specific purposes (such as authentication, but not data mining).
           </p>
-
       </section>
-
     </section>
 
     <section>
@@ -3023,6 +3001,7 @@ account when utilizing this data model.
 
       <section>
         <h3>Data First Approaches</h3>
+
         <p>
 Many physical credentials in use today, such as government identification
 cards, have poor accessibility characteristics, including, but not limited to,
@@ -3057,6 +3036,7 @@ environments.
 
       <section>
         <h3>Spectrum of Privacy</h3>
+
         <p>
 It is important to recognize there is a spectrum of privacy ranging from
 pseudonymous to strongly identified. Depending on the use case, people have
@@ -3097,7 +3077,6 @@ anonymity for any specific transaction. The following sections provide
 guidance for implementers who want to avoid specific scenarios that are
 hostile to privacy.
         </p>
-
       </section>
 
       <section>
@@ -3518,7 +3497,6 @@ not to be technological in nature, but policy driven instead. Therefore, if
 a <a>holder</a> does not want information about them to be aggregated, they
 must express this in the <a>verifiable presentations</a> they transmit.
         </p>
-
       </section>
 
       <section>
@@ -3688,7 +3666,6 @@ repeatedly use credentials with short lifespans, which could result in
 behavior correlation. <a>Issuers</a> should avoid issuing <a>credentials</a> in
 a way that enables them to correlate usage patterns.
         </p>
-
       </section>
 
       <section>
@@ -3730,7 +3707,6 @@ and might even allow hiding the identifier from the <a>issuer</a>, while still
 keeping the identifier embedded and signed in the <a>credential</a>.
         </p>
       </section>
-
     </section>
 
     <section>
@@ -3778,7 +3754,6 @@ cryptography suite or library failure. Regular monitoring of systems to ensure
 proper upgrades are made in a timely manner are also important to ensure the
 long term viability of systems processing <a>verifiable credentials</a>.
         </p>
-
       </section>
 
       <section>
@@ -3809,11 +3784,11 @@ The Token Binding Protocol v1.0</a>, which ties the request for a
 <a>verifiable presentation</a> with the response. Any protocol that does not
 perform token binding is susceptible to man-in-the-middle attacks.
         </p>
-
       </section>
 
       <section>
         <h3>Bundling Dependent Claims</h3>
+
         <p>
 It is considered best practice for <a>issuers</a> to atomize information in a
 <a>credential</a>, or use a signature scheme that allows for selective
@@ -3833,7 +3808,6 @@ of Computing", and "Department of Economics". The <a>holder</a> could then
 transfer the "Staff Member" and "Department of Economics" <a>credentials</a> to
 a <a>verifier</a>, which together would comprise a false claim.
         </p>
-
       </section>
 
       <section>
@@ -3850,7 +3824,6 @@ shorter than the timeframe where the information expressed by the
 <a>credentials</a> that are appropriate to the use case and the expected
 lifetime for the information contained in the <a>credential</a>.
         </p>
-
       </section>
 
       <section>
@@ -3882,10 +3855,9 @@ Using a separate hardware-based signature device.
 All or any combination of the above.
           </li>
         </ul>
-
       </section>
-
     </section>
+
 <section>
 <h2> Appendix A.2 Subject passes a verifiable credential to someone else</h2>
 

--- a/index.html
+++ b/index.html
@@ -2390,9 +2390,9 @@ that the <a>credential</a> is disputed.
     "disputedClaim": {
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "degree": {
-      "type": "BachelorDegree",
-      "name": "Bachelor of Science in Mechanical Engineering"
-    }
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science in Mechanical Engineering"
+      }
     }
   }</span>,
   "issuer": "https://example.com/people#me",
@@ -2712,10 +2712,10 @@ Add a short description explaining the example above.
     ],
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
     "credentialSubject": {
-        "degree": {
-          "type": "BachelorDegree",
-          "name": "Bachelor of Science in Mechanical Engineering"
-        }
+      "degree": {
+        "type": "BachelorDegree",
+        "name": "Bachelor of Science in Mechanical Engineering"
+      }
     }
   }
 }


### PR DESCRIPTION
An attempt to restore markup sanity.

~~Includes commit from https://github.com/w3c/vc-data-model/pull/321.  Pull that first.~~ (Removed commit.)

Quite possible this will cause conflicts in all other PRs.  If those are pulled in first I can update this PR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-data-model/pull/322.html" title="Last updated on Dec 20, 2018, 12:52 AM UTC (72de4ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/322/959241b...davidlehn:72de4ae.html" title="Last updated on Dec 20, 2018, 12:52 AM UTC (72de4ae)">Diff</a>