### PR TITLE
Section 3.2 links and grammar and other suggestions

### DIFF
--- a/index.html
+++ b/index.html
@@ -493,10 +493,10 @@ A <a>credential</a> is set of one or more <a>claims</a> made by the same
 <a>entity</a>. <a>Credentials</a> might include an identifier as well as
 metadata to describe properties of the <a>credential</a>, such as the
 <a>issuer</a>, the expiry time, a representative image, a public key to use
-for verification purposes, the revocation mechanism, and so on. This metadata
-might be signed by the <a>issuer</a>. A <a>verifiable credential</a> is a set
-of tamper-evident <a>claims</a> and metadata that cryptographically prove who
-issued it.
+for <a>verification</a> purposes, the revocation mechanism, and so on. This
+metadata might be signed by the <a>issuer</a>. A <a>verifiable credential</a>
+is a set of tamper-evident <a>claims</a> and metadata that cryptographically
+prove who issued it.
       </p>
 
       <figure>
@@ -507,37 +507,38 @@ The basic components of a verifiable credential.
       </figure>
 
       <p>
-Examples of <a>verifiable credentials</a> include digital employee identification
-cards, digital birth certificates, and digital educational certificates.
+Examples of <a>verifiable credentials</a> include digital employee
+identification cards, digital birth certificates, and digital educational
+certificates.
       </p>
 
       <p class="note">
 <a>Credential</a> identifiers are often used to identify specific instances
-of a credential. These identifiers can also be used for correlation. A
+of a <a>credential</a>. These identifiers can also be used for correlation. A
 <a>holder</a> wanting to minimize correlation MUST use a selective disclosure
 scheme that does not reveal the <a>credential</a> identifier.
       </p>
 
       <p>
 The example above provides a simple visual describing the components of a
-<a>verifiable credential</a>, but abstracts some of the details of how
-<a>claims</a> are organized into <a>graph</a>s, which are then organized into
+<a>verifiable credential</a>, but abstracts some of the details about how
+<a>claims</a> are organized into <a>graphs</a>, which are then organized into
 <a>verifiable credentials</a>. The example below attempts to provide a
 complete visual depiction of a <a>verifiable credential</a>, which is
-normally composed of at least two graphs of information.
-The first information graph expresses the credential itself, which contains
+normally composed of at least two <a>graphs</a> of information.
+The first <a>graph</a> expresses the <a>credential</a> itself, which contains
 <span style="color:#d5a6bdff;font-weight:bold;text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;">credential metadata</span> and
 <span style="color:#ffe599ff;font-weight:bold;text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;">claims</span>.
-The second information graph expresses the
+The second <a>graph</a> expresses the
 <span style="color:#b6d7a8ff;font-weight:bold;text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;">digital proof</span>,
-which is typically a digital signature.
+which is usually a digital signature.
       </p>
 
       <figure>
         <img style="margin: auto; display: block;" width="100%" src="diagrams/credential-graph.svg">
         <figcaption style="text-align: center;">
-A visual depiction of the information graphs associated with a basic
-<a>verifiable credential</a>.
+A visual depiction of the information graphs associated with a basic verifiable
+credential.
         </figcaption>
       </figure>
 


### PR DESCRIPTION
The text describing the information graphs has some "funky" styling that might not be appropriate for the tone of the document? :) Perhaps suggest just using <em> tags instead?
Also, I removed a link from a figure title. Usually terms in headings and in figure and table labels are not linked? At least that seems to be the convention so far.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/grantnoble/vc-data-model/pull/326.html" title="Last updated on Dec 18, 2018, 3:18 AM UTC (a643450)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/326/8c132b4...grantnoble:a643450.html" title="Last updated on Dec 18, 2018, 3:18 AM UTC (a643450)">Diff</a>