### PR TITLE
Update conformance section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -693,6 +693,31 @@ in the manner adopted by Certificate Authority systems.
       </p>
     </section>
 
+    <section id="conformance">
+      <p>
+A concrete expression of the data model in this specification is a
+<em>conforming document</em> if it complies with the normative statements in
+this specification regarding syntax. That is, the content in the
+<a href="#basic-concepts">Basic Concepts</a>,
+<a href="#advanced-concepts">Advanced Concepts</a>, and
+<a href="#syntaxes">Syntaxes</a> sections of this document. For convenience,
+normative statements for <em>conforming documents</em> are
+often phrased as statements on the syntax used in properties and their
+associated values in the document (for example, "MUST be a URI", or
+"MUST be a string value of an ISO8601 combined date and time string").
+      </p>
+
+      <p>
+A <em>conforming processor</em> is a software or hardware-based implementation
+of the normative statements in this specification regarding the expected
+contents of property-value pairs (for example, the content in
+<a>Verification</a>). For convenience, normative statements for
+<em>conforming processors</em> are often phrased as behavioral statements
+regarding the contents of property-value pairs (for example, "MUST NOT be
+revoked", or "MUST be in the expected range").
+      </p>
+    </section>
+
     <section>
       <h2>Basic Concepts</h2>
 
@@ -2438,33 +2463,6 @@ each graph is preserved.
             </ul>
           </li>
         </ul>
-      </section>
-
-      <section>
-        <h3>Conformance</h3>
-
-        <p>
-A concrete expression of the data model in this specification is a
-<em>conforming document</em> if it complies with the normative statements in
-this specification regarding syntax. That is, the content in the
-<a href="#basic-concepts">Basic Concepts</a>,
-<a href="#advanced-concepts">Advanced Concepts</a>, and
-<a href="#syntaxes">Syntaxes</a> sections of this document. For convenience,
-normative statements for <em>conforming documents</em> are
-often phrased as statements on the syntax used in properties and their
-associated values in the document (for example, "MUST be a URI", or
-"MUST be a string value of an ISO8601 combined date and time string").
-        </p>
-
-        <p>
-A <em>conforming processor</em> is a software or hardware-based implementation
-of the normative statements in this specification regarding the expected
-contents of property-value pairs (for example, the content in
-<a>Verification</a>). For convenience, normative statements for
-<em>conforming processors</em> are often phrased as behavioral statements
-regarding the contents of property-value pairs (for example, "MUST NOT be
-revoked", or "MUST be in the expected range").
-        </p>
       </section>
     </section>
 


### PR DESCRIPTION
- Use ReSpec "conformance" id to add standard boilerplate.
- Move to top level section vs mistakenly getting under Advanced Concepts.
- Move earlier in doc.

Some other random specs I looked at had the conformance section early.  Is that what we want here?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-data-model/pull/343.html" title="Last updated on Dec 20, 2018, 1:22 AM UTC (fe2d71a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/343/1f69427...davidlehn:fe2d71a.html" title="Last updated on Dec 20, 2018, 1:22 AM UTC (fe2d71a)">Diff</a>