### PR TITLE
Add section on Syntax and Proof Format Trade-Offs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4428,7 +4428,8 @@ whitespace does not invalidate signature.
 
         <tr>
           <td>
-<a href="#pf16">PF16.</a> Support experimental signature systems.
+<a href="#pf16">PF16.</a> Designed to easily support experimental signature 
+systems.
           </td>
           <td class="missing">✖</td>
           <td class="missing">✖</td>
@@ -4662,7 +4663,7 @@ shortcoming of JWTs make it challenging to, for example, express signed data in
 web pages that search crawlers index.
       </dd>
       <dt id="pf16">
-PF16: Support experimental signature systems.
+PF16: Designed to easily support experimental signature systems.
       </dt>
       <dd>
 The LD-Proof format is naturally extensible, not requiring the format to be

--- a/index.html
+++ b/index.html
@@ -4261,24 +4261,20 @@ All or any combination of the above.
   </section>
 
   <section class="appendix">
-    <h2>Proof Format Trade-Offs</h2>
+    <h2>Syntax and Proof Format Trade-Offs</h2>
 
     <p>
 The Verifiable Credentials Data Model is designed to be compatible with a
 variety of existing and emerging syntaxes and digital proof formats. Each
-format has benefits and drawbacks. The following table is intended to summarize
-a number of these native trade-offs.
+approach has benefits and drawbacks. The following table is intended to
+summarize a number of these native trade-offs.
     </p>
 
     <p>
-The table below compares three proof format ecosystems; JSON+JWTs,
-JSON-LD+JWTs, and JSON-LD+LD-Proofs. At the time of publication of this
-specification, no organization is planning to use JSON+JWTs. The existence
-of JSON+JWTs in the table below is provided based on review comments on the
-specification for readers that were curious about the benefits that JSON-LD
-provided over JSON. Readers should also be aware that Zero-Knowledge Proofs
-are currently proposed as a sub-type of LD-Proofs and thus fall into the
-final colum below.
+The table below compares three syntax and proof format ecosystems; JSON+JWTs,
+JSON-LD+JWTs, and JSON-LD+LD-Proofs. Readers should be aware that
+Zero-Knowledge Proofs are currently proposed as a sub-type of LD-Proofs and
+thus fall into the final column below.
     </p>
 
     <table class="simple">

--- a/index.html
+++ b/index.html
@@ -4334,8 +4334,8 @@ in semantics or structure.
         </tr>
         <tr>
           <td>
-<a href="#pf6">PF6.</a> A way to associate datatypes with values such as
-dates and times.
+<a href="#pf6">PF6.</a> A way to associate arbitrary datatypes, such as dates
+and times, with arbitrary property values.
           </td>
           <td class="missing">✖</td>
           <td class="supported">✓</td>
@@ -4535,12 +4535,13 @@ or Japanese, in which a text string is expressed via the use of language tags.
 JSON does not provide such a feature.
       </dd>
       <dt id="pf6">
-PF6: A way to associate datatypes with values such as dates and times.
+PF6: A way to associate arbitrary datatypes, such as dates
+and times, with arbitrary property values.
       </dt>
       <dd>
-JSON-LD enables a developer to specify the data type, such as Date,
-unsigned integer, or Temperature, in which a string is expressed as a native
-feature of the language. JSON does not provide such a feature.
+JSON-LD enables a developer to specify the data type of a property value,
+such as Date, unsigned integer, or Temperature by specifying it in the
+JSON-LD Context. JSON does not provide such a feature.
       </dd>
       <dt id="pf7">
 PF7: A facility to express one or more directed graphs, such as a social

--- a/index.html
+++ b/index.html
@@ -4391,8 +4391,8 @@ double for every embedding.
 
         <tr>
           <td>
-<a href="#pf13">PF13.</a> Proof format supports arbitrary proofs such as
-Proof of Work, Proof of Elapsed Time, and Proof of Stake.
+<a href="#pf13">PF13.</a> Proof format supports arbitrary proofs such as Proof
+of Work, Timestamp Proofs, and Proof of Stake.
           </td>
           <td class="missing">✖</td>
           <td class="missing">✖</td>
@@ -4586,58 +4586,116 @@ PF11: Nesting signed data does not cause data size to double for every
 embedding.
       </dt>
       <dd>
-
+When a JWT is encapsulated by another JWT, the entire payload must be base-64
+encoded in the initial JWT, and then base-64 encoded again in the encapsulating
+JWT. This is often necessary when a cryptographic signature is required on a
+document that contains a cryptographic signature, such as when a Notary
+signs a document that has been signed by someone else seeking the Notary's
+services. LD-Proofs do not require base-64 encoding the signed portion of a
+document and instead rely on a canonicalization process that is just as
+secure, and that only requires the cryptographic signature to be encoded
+instead of the entire payload.
       </dd>
       <dt id="pf12">
 PF12: Proof format supports Zero-Knowledge Proofs.
       </dt>
       <dd>
-
+The LD-Proof format is capable of modifying the algorithm that generates
+the hash or hashes that are cryptographically signed. This cryptographic
+agility enables digital signature systems, such as Zero-Knowledge Proofs,
+to be layered on top of LD-Proofs instead of an entirely new digital signature
+container format to be created. JWTs are designed such that an entirely new
+digital signature container format will be required to support Zero-Knowledge
+Proofs.
       </dd>
       <dt id="pf13">
-PF13: Proof format supports arbitrary proofs such as Proof of Work, Proof of
-Elapsed Time, and Proof of Stake.
+PF13: Proof format supports arbitrary proofs such as Proof of Work, Timestamp
+Proofs, and Proof of Stake.
       </dt>
       <dd>
-
+The LD-Proof format was designed with a broader range of proof types in mind
+and supports cryptographic proofs beyond simple cryptographic signatures.
+These proof types are in common usage in systems such as decentralized ledgers
+and provide additional guarantees to
+<a>verifiable credentials</a>, such as the ability to prove that a particular
+claim was made at a particular time or that a certain amount of energy was
+expended to generate a particular credential. The JWT format does not support
+arbitrary proof formats.
       </dd>
       <dt id="pf14">
-PF14: Proofs can be expressed unmodified in other data syntaxes such as YAML,
-N-Quads, and CBOR.
+PF14: Proofs can be expressed unmodified in other data syntaxes such as XML,
+YAML, N-Quads, and CBOR.
       </dt>
       <dd>
-
+The LD-Proof format utilizes a canonicalization algorithm to generate a
+cryptographic hash that is used as an input to the cryptographic proof
+algorithm. This enables the bytes generated as the cryptographic proof to be
+compact and expressible in a variety of other syntaxes such as XML,
+YAML, N-Quads, and CBOR. Since JWTs require the use of JSON to be generated,
+they are inextricably tied to the JSON syntax.
       </dd>
       <dt id="pf15">
 PF15: Changing key-value ordering, or introducing whitespace does not
 invalidate signature.
       </dt>
       <dd>
-
+Since LD-Proofs utilize a canonicalization algorithm, the introduction of
+whitespace that does not change the meaning of the information being expressed
+has no effect on the final cryptographic hash over the information. This means
+that simple changes in whitespace formatting, such as those changes made when
+writing data to a schema-less database and then retrieving the same information
+from the same database do not cause the digital signature to fail. JWTs
+encode the payload using the base-64 format which is not resistant to
+whitespace formatting that has no effect on the information expressed. This
+shortcoming of JWTs make it challenging to, for example, express signed data in
+web pages that search crawlers index.
       </dd>
       <dt id="pf16">
 PF16: Support experimental signature systems.
       </dt>
       <dd>
-
+The LD-Proof format is naturally extensible, not requiring the format to be
+extended in a formal international standards working group in order to
+prevent namespace collisions. The JWT format requires entries in a centralized
+registry and does not support experimentation as easily as the LD-Proof format
+does. LD-Proof format extension is done through the decentralized publication
+of cryptographic suites that are guaranteed to not conflict with other LD-Proof
+extensions. This approach enables developers to easily experiment with new
+cryptographic signature mechanisms that support selective disclosure,
+zero-knowledge proofs, and post-quantum algorithms.
       </dd>
       <dt id="pf17">
 PF17: Supports signature chaining.
       </dt>
       <dd>
-
+A signature chain is an ordered set of signatures over a data payload. Use
+cases, such as cryptographic signatures applied to a notarized document,
+typically require a signature by the signing party and then an additional one
+by a notary to be made after the original signing party has made their
+signature. Linked Data Proofs, including Linked Data Signatures, natively
+support chains of signatures. JWTs only enable a single signature over a
+single payload.
       </dd>
       <dt id="pf18">
 PF18: Does not require pre-processing or post-processing.
       </dt>
       <dd>
-
+In order to encode a <a>verifiable credential</a> or a 
+<a>verifiable presentation</a> in a JWT, an extra set of steps
+are required to convert the data to and from the JWT format. No such extra
+converstion step are required for <a>verifiable credentials</a> and
+<a>verifiable presentations</a> protected by LD-Proofs.
       </dd>
       <dt id="pf19">
 PF19: Canonicalization requires more than base-64 encoding.
       </dt>
       <dd>
-
+The JWT format utilizes a simple base-64 encoding format to generate the
+cryptographic hash of the data. The encoding format for LD-Proofs require 
+a more complex canonicalization algorithm to generate the cryptographic 
+hash. The benefits of the JWT approach are simplicity at the cost of 
+encoding flexibility. The benefits of the LD-Proof approach are flexibility at 
+the cost of implementation complexity.
       </dd>
     </dl>
 

--- a/index.html
+++ b/index.html
@@ -109,6 +109,12 @@ pre .comment {
   font-weight: bold;
   text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
 }
+.supported {
+  background-color: #93c47d;
+}
+.missing {
+  background-color: #e06666;
+}
     </style>
   </head>
   <body>
@@ -3097,6 +3103,208 @@ request: <a href="https://github.com/w3c/vc-data-model/pull/384">Add section on 
           </p>
 
         </section>
+
+      </section>
+      <section>
+        <h3>Proof Format Trade-Offs</h3>
+
+        <p>
+The Verifiable Credentials Data Model is designed to be compatible with a
+variety of existing and emerging syntaxes and digital proof formats. Each
+format has benefits and drawbacks. The following table is intended to summarize
+a number of these native trade-offs.
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th style="text-align: center;">Feature</th>
+              <th style="text-align: center;">JSON<br>+<br>JWTs</th>
+              <th style="text-align: center;">JSON&#8209;LD<br>+<br>JWTs</th>
+              <th style="text-align: center;">JSON&#8209;LD<br>+<br>LD&#8209;Proofs</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>
+Support for open world data modelling.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+Universal identifier mechanism for JSON objects via the use of URLs.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+A way to disambiguate keys shared among different JSON documents by mapping
+them to IRIs via a context.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+A mechanism in which a value in a JSON object may refer to a resource on a
+different site on the Web.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+The ability to annotate strings with their language.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+A way to associate datatypes with values such as dates and times.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+A facility to express one or more directed graphs, such as a social network,
+in a single document.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+Supports signature sets.
+              </td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+Embeddable in HTML such that search crawlers will index the machine-readable
+content.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+            <tr>
+              <td>
+Data on the wire is easy to debug.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Nesting signed data does not cause data size to double for every embedding.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Proof format supports Zero-Knowledge Proofs.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Proof format supports arbitrary proofs such as Proof of Work, Proof of
+Elapsed Time, and Proof of Stake.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Proofs can be expressed unmodified in other data syntaxes such as
+YAML, N-Quads, and CBOR.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Changing key-value ordering, or introducing whitespace does not
+invalidate signature.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Support experimental signature systems.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Supports signature chaining.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Does not require pre-processing or post-processing.
+              </td>
+              <td class="missing">✖</td>
+              <td class="missing">✖</td>
+              <td class="supported">✓</td>
+            </tr>
+
+            <tr>
+              <td>
+Canonicalization requires more than base-64 encoding.
+              </td>
+              <td class="supported">✓</td>
+              <td class="supported">✓</td>
+              <td class="missing">✖</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <p class="note">
+Some of the features listed in the table above are debateable since a feature
+can always be added to a particular syntax or digital proof format. The table
+is intended to identify native features of each combination such that no
+additional language design or extension is required to achieve the identified
+feature. Features that all languages provide, such as the ability to express
+numbers, have not been included for the purposes of brevity.
+        </p>
 
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -3105,208 +3105,6 @@ request: <a href="https://github.com/w3c/vc-data-model/pull/384">Add section on 
         </section>
 
       </section>
-      <section>
-        <h3>Proof Format Trade-Offs</h3>
-
-        <p>
-The Verifiable Credentials Data Model is designed to be compatible with a
-variety of existing and emerging syntaxes and digital proof formats. Each
-format has benefits and drawbacks. The following table is intended to summarize
-a number of these native trade-offs.
-        </p>
-
-        <table class="simple">
-          <thead>
-            <tr>
-              <th style="text-align: center;">Feature</th>
-              <th style="text-align: center;">JSON<br>+<br>JWTs</th>
-              <th style="text-align: center;">JSON&#8209;LD<br>+<br>JWTs</th>
-              <th style="text-align: center;">JSON&#8209;LD<br>+<br>LD&#8209;Proofs</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <tr>
-              <td>
-Support for open world data modelling.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-Universal identifier mechanism for JSON objects via the use of URLs.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-A way to disambiguate keys shared among different JSON documents by mapping
-them to IRIs via a context.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-A mechanism in which a value in a JSON object may refer to a resource on a
-different site on the Web.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-The ability to annotate strings with their language.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-A way to associate datatypes with values such as dates and times.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-A facility to express one or more directed graphs, such as a social network,
-in a single document.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-Supports signature sets.
-              </td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-Embeddable in HTML such that search crawlers will index the machine-readable
-content.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-            <tr>
-              <td>
-Data on the wire is easy to debug.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Nesting signed data does not cause data size to double for every embedding.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Proof format supports Zero-Knowledge Proofs.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Proof format supports arbitrary proofs such as Proof of Work, Proof of
-Elapsed Time, and Proof of Stake.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Proofs can be expressed unmodified in other data syntaxes such as
-YAML, N-Quads, and CBOR.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Changing key-value ordering, or introducing whitespace does not
-invalidate signature.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Support experimental signature systems.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Supports signature chaining.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Does not require pre-processing or post-processing.
-              </td>
-              <td class="missing">✖</td>
-              <td class="missing">✖</td>
-              <td class="supported">✓</td>
-            </tr>
-
-            <tr>
-              <td>
-Canonicalization requires more than base-64 encoding.
-              </td>
-              <td class="supported">✓</td>
-              <td class="supported">✓</td>
-              <td class="missing">✖</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <p class="note">
-Some of the features listed in the table above are debateable since a feature
-can always be added to a particular syntax or digital proof format. The table
-is intended to identify native features of each combination such that no
-additional language design or extension is required to achieve the identified
-feature. Features that all languages provide, such as the ability to express
-numbers, have not been included for the purposes of brevity.
-        </p>
-
-      </section>
     </section>
 
     <section>
@@ -4460,6 +4258,389 @@ All or any combination of the above.
         </li>
       </ul>
     </section>
+  </section>
+
+  <section class="appendix">
+    <h2>Proof Format Trade-Offs</h2>
+
+    <p>
+The Verifiable Credentials Data Model is designed to be compatible with a
+variety of existing and emerging syntaxes and digital proof formats. Each
+format has benefits and drawbacks. The following table is intended to summarize
+a number of these native trade-offs.
+    </p>
+
+    <table class="simple">
+      <thead>
+        <tr>
+          <th style="text-align: center;">Feature</th>
+          <th style="text-align: center;">JSON<br>+<br>JWTs</th>
+          <th style="text-align: center;">JSON&#8209;LD<br>+<br>JWTs</th>
+          <th style="text-align: center;">JSON&#8209;LD<br>+<br>LD&#8209;Proofs</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr>
+          <td>
+<a href="#pf1">PF1.</a> Support for open world data modelling.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf2">PF2.</a> Universal identifier mechanism for JSON objects via
+the use of URIs.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf3">PF3.</a> A way to disambiguate keys shared among different
+JSON documents by mapping them to IRIs via a context.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf4">PF4.</a> A mechanism to refer to data in an external document,
+where the data may be merged with the local document without a merge conflict
+in semantics or structure.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf5">PF5.</a> The ability to annotate strings with their language.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf6">PF6.</a> A way to associate datatypes with values such as
+dates and times.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf7">PF7.</a> A facility to express one or more directed graphs,
+such as a social network, in a single document.
+          </td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf8">PF8.</a> Supports signature sets.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf9">PF9.</a> Embeddable in HTML such that search crawlers will
+index the machine-readable content.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+        <tr>
+          <td>
+<a href="#pf10">PF10.</a> Data on the wire is easy to debug and serialize to
+database systems.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf11">PF11.</a> Nesting signed data does not cause data size to
+double for every embedding.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf12">PF12.</a> Proof format supports Zero-Knowledge Proofs.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf13">PF13.</a> Proof format supports arbitrary proofs such as
+Proof of Work, Proof of Elapsed Time, and Proof of Stake.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf14">PF14.</a> Proofs can be expressed unmodified in other data
+syntaxes such as YAML, N-Quads, and CBOR.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf15">PF15.</a> Changing key-value ordering, or introducing
+whitespace does not invalidate signature.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf16">PF16.</a> Support experimental signature systems.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf17">PF17.</a> Supports signature chaining.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf18">PF18.</a> Does not require pre-processing or post-processing.
+          </td>
+          <td class="missing">✖</td>
+          <td class="missing">✖</td>
+          <td class="supported">✓</td>
+        </tr>
+
+        <tr>
+          <td>
+<a href="#pf19">PF19.</a> Canonicalization requires more than base-64 encoding.
+          </td>
+          <td class="supported">✓</td>
+          <td class="supported">✓</td>
+          <td class="missing">✖</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="note">
+Some of the features listed in the table above are debateable since a feature
+can always be added to a particular syntax or digital proof format. The table
+is intended to identify native features of each combination such that no
+additional language design or extension is required to achieve the identified
+feature. Features that all languages provide, such as the ability to express
+numbers, have not been included for the purposes of brevity.
+    </p>
+
+    <dl>
+      <dt id="pf1">
+PF1: Support for open world data modelling
+      </dt>
+      <dd>
+An <em>open world data model</em> is one where any entity can make any
+statement about anything while simultaneously ensuring that the semantics of
+the statement are unambiguous. This specification is enabled by an open world
+data model called Linked Data. One defining characteristic of supporting an open
+world data model is the ability to specify the semantic context in which data
+is being expressed. JSON-LD provides this mechanism via the
+<code>@context</code> property. JSON has no such feature.
+      </dd>
+      <dt id="pf2">
+PF2: Universal identifier mechanism for JSON objects via the use of URIs.
+      </dt>
+      <dd>
+All entities in a JSON-LD document are identified either via an automatic URI,
+or via an explicit URI. This enables all entities in a document to be
+unambiguously referenced. JSON does not have a native URI type nor does it
+require objects to have one, making it difficult to impossible to unambiguously
+identify an entity expressed in JSON.
+      </dd>
+      <dt id="pf3">
+PF3: A way to disambiguate keys shared among different JSON documents by
+mapping them to IRIs via a context.
+      </dt>
+      <dd>
+All object keys in a JSON-LD document are either keywords or they are mapped to
+an IRI. This feature enables open world systems to identify the semantic
+meaning of the key in an unambiguous way, which enables seamless merging of
+data between disparate systems. JSON object keys are not mapped to IRIs, which
+result in ambiguities with respect to the semantic meaning of the key.
+      </dd>
+      <dt id="pf4">
+PF4: A mechanism to refer to data in an external document, where the data may
+be merged with the local document without a merge conflict in semantics or
+structure.
+      </dt>
+      <dd>
+JSON-LD provides a mechanism that enables a data value to use a URL to refer
+to data outside of the local document. This external data may then be
+automatically merged with the local document without a merge conflict in
+semantics or structure. This feature enables a system to apply the
+"follow your nose" principle to discover a richer set of data that is
+associated with the local document. While a JSON document can contain pointers
+to external data, interpreting the pointer is often application specific and
+usually does not support merging the external data to construct a richer data
+set.
+      </dd>
+      <dt id="pf5">
+PF5: The ability to annotate strings with their language.
+      </dt>
+      <dd>
+JSON-LD enables a developer to specify the language, such as English, French,
+or Japanese, in which a text string is expressed via the use of language tags.
+JSON does not provide such a feature.
+      </dd>
+      <dt id="pf6">
+PF6: A way to associate datatypes with values such as dates and times.
+      </dt>
+      <dd>
+JSON-LD enables a developer to specify the data type, such as Date,
+unsigned integer, or Temperature, in which a string is expressed as a native
+feature of the language. JSON does not provide such a feature.
+      </dd>
+      <dt id="pf7">
+PF7: A facility to express one or more directed graphs, such as a social
+network, in a single document.
+      </dt>
+      <dd>
+JSON-LD's abstract data model supports the expression of information
+as a directed graph of labeled nodes and edges, which enables an open world
+data model to be supported. JSON's abstract data model only supports the
+expression of information as a tree of unlabeled nodes and edges, which
+restricts the types of relationships and structures that can be natively
+expressed in the language.
+      </dd>
+      <dt id="pf8">
+PF8: Supports signature sets.
+      </dt>
+      <dd>
+A signature set is an unordered set of signatures over a data payload. Use
+cases, such as cryptographic signatures applied to a legal contract,
+typically require more than one signature to be associated with the contract
+in order to legally bind two or more parties under the terms of the contract.
+Linked Data Proofs, including Linked Data Signatures, natively support sets of
+signatures. JWTs only enable a single signature over a single payload.
+      </dd>
+      <dt id="pf9">
+PF9: Embeddable in HTML such that search crawlers will index the
+machine-readable content.
+      </dt>
+      <dd>
+All major search crawlers natively parse and index information expressed as
+JSON-LD in HTML pages. LD-Proofs enable the current data format that search
+engines use to be extended to support digital signatures. JWTs have no mechanism
+to express data in HTML pages and are currently not indexed by search crawlers.
+      </dd>
+      <dt id="pf10">
+PF10: Data on the wire is easy to debug and serialize to database systems.
+      </dt>
+      <dd>
+When developers are debugging software systems, it is beneficial for them to be
+able to see the data that they are operating on using common debugging tools.
+Similarly, it is useful to be able to serialize data from the network to a
+database and then from the database back out to the network using a minimal
+number of pre and post processing steps. LD-Proofs enable developers to use
+common JSON tooling without having to convert the format into a different
+format or structure. JWTs base-64 encode payload information, resulting in
+complicated pre and post processing steps to convert the data into JSON data
+while not destroying the digital signature. Similarly, schema-less databases,
+which are typically used to index JSON data, cannot index information
+that is expressed in an opaque base-64 encoded wrapper.
+      </dd>
+      <dt id="pf11">
+PF11: Nesting signed data does not cause data size to double for every
+embedding.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf12">
+PF12: Proof format supports Zero-Knowledge Proofs.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf13">
+PF13: Proof format supports arbitrary proofs such as Proof of Work, Proof of
+Elapsed Time, and Proof of Stake.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf14">
+PF14: Proofs can be expressed unmodified in other data syntaxes such as YAML,
+N-Quads, and CBOR.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf15">
+PF15: Changing key-value ordering, or introducing whitespace does not
+invalidate signature.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf16">
+PF16: Support experimental signature systems.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf17">
+PF17: Supports signature chaining.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf18">
+PF18: Does not require pre-processing or post-processing.
+      </dt>
+      <dd>
+
+      </dd>
+      <dt id="pf19">
+PF19: Canonicalization requires more than base-64 encoding.
+      </dt>
+      <dd>
+
+      </dd>
+    </dl>
+
   </section>
 
     <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -4428,7 +4428,7 @@ whitespace does not invalidate signature.
 
         <tr>
           <td>
-<a href="#pf16">PF16.</a> Designed to easily support experimental signature 
+<a href="#pf16">PF16.</a> Designed to easily support experimental signature
 systems.
           </td>
           <td class="missing">✖</td>
@@ -4669,9 +4669,10 @@ PF16: Designed to easily support experimental signature systems.
 The LD-Proof format is naturally extensible, not requiring the format to be
 extended in a formal international standards working group in order to
 prevent namespace collisions. The JWT format requires entries in a centralized
-registry and does not support experimentation as easily as the LD-Proof format
-does. LD-Proof format extension is done through the decentralized publication
-of cryptographic suites that are guaranteed to not conflict with other LD-Proof
+registry in order to avoid naming collisions and does not support 
+experimentation as easily as the LD-Proof format does. LD-Proof format 
+extension is done through the decentralized publication of cryptographic 
+suites that are guaranteed to not conflict with other LD-Proof
 extensions. This approach enables developers to easily experiment with new
 cryptographic signature mechanisms that support selective disclosure,
 zero-knowledge proofs, and post-quantum algorithms.

--- a/index.html
+++ b/index.html
@@ -4270,6 +4270,17 @@ format has benefits and drawbacks. The following table is intended to summarize
 a number of these native trade-offs.
     </p>
 
+    <p>
+The table below compares three proof format ecosystems; JSON+JWTs,
+JSON-LD+JWTs, and JSON-LD+LD-Proofs. At the time of publication of this
+specification, no organization is planning to use JSON+JWTs. The existence
+of JSON+JWTs in the table below is provided based on review comments on the
+specification for readers that were curious about the benefits that JSON-LD
+provided over JSON. Readers should also be aware that Zero-Knowledge Proofs
+are currently proposed as a sub-type of LD-Proofs and thus fall into the
+final colum below.
+    </p>
+
     <table class="simple">
       <thead>
         <tr>
@@ -4680,7 +4691,7 @@ single payload.
 PF18: Does not require pre-processing or post-processing.
       </dt>
       <dd>
-In order to encode a <a>verifiable credential</a> or a 
+In order to encode a <a>verifiable credential</a> or a
 <a>verifiable presentation</a> in a JWT, an extra set of steps
 are required to convert the data to and from the JWT format. No such extra
 converstion step are required for <a>verifiable credentials</a> and
@@ -4691,10 +4702,10 @@ PF19: Canonicalization requires more than base-64 encoding.
       </dt>
       <dd>
 The JWT format utilizes a simple base-64 encoding format to generate the
-cryptographic hash of the data. The encoding format for LD-Proofs require 
-a more complex canonicalization algorithm to generate the cryptographic 
-hash. The benefits of the JWT approach are simplicity at the cost of 
-encoding flexibility. The benefits of the LD-Proof approach are flexibility at 
+cryptographic hash of the data. The encoding format for LD-Proofs require
+a more complex canonicalization algorithm to generate the cryptographic
+hash. The benefits of the JWT approach are simplicity at the cost of
+encoding flexibility. The benefits of the LD-Proof approach are flexibility at
 the cost of implementation complexity.
       </dd>
     </dl>

--- a/index.html
+++ b/index.html
@@ -4307,7 +4307,7 @@ the use of URIs.
         </tr>
         <tr>
           <td>
-<a href="#pf3">PF3.</a> A way to disambiguate keys shared among different
+<a href="#pf3">PF3.</a> A way to disambiguate properties shared among different
 JSON documents by mapping them to IRIs via a context.
           </td>
           <td class="missing">✖</td>
@@ -4418,7 +4418,7 @@ syntaxes such as YAML, N-Quads, and CBOR.
 
         <tr>
           <td>
-<a href="#pf15">PF15.</a> Changing key-value ordering, or introducing
+<a href="#pf15">PF15.</a> Changing property-value ordering, or introducing
 whitespace does not invalidate signature.
           </td>
           <td class="missing">✖</td>
@@ -4497,15 +4497,18 @@ require objects to have one, making it difficult to impossible to unambiguously
 identify an entity expressed in JSON.
       </dd>
       <dt id="pf3">
-PF3: A way to disambiguate keys shared among different JSON documents by
+PF3: A way to disambiguate properties shared among different JSON documents by
 mapping them to IRIs via a context.
       </dt>
       <dd>
-All object keys in a JSON-LD document are either keywords or they are mapped to
-an IRI. This feature enables open world systems to identify the semantic
-meaning of the key in an unambiguous way, which enables seamless merging of
-data between disparate systems. JSON object keys are not mapped to IRIs, which
-result in ambiguities with respect to the semantic meaning of the key.
+All object properties in a JSON-LD document, such as the property "homepage",
+are either keywords or they are mapped to an IRI. This feature enables open
+world systems to identify the semantic meaning of the property in an unambiguous
+way, which enables seamless merging of data between disparate systems.
+JSON object properties are not mapped to IRIs, which result in ambiguities with
+respect to the semantic meaning of the property. For example, one JSON document
+can use "title" (meaning "book title") in a way that is semantically
+incompatible with another JSON document using "title" (meaning "job title").
       </dd>
       <dt id="pf4">
 PF4: A mechanism to refer to data in an external document, where the data may
@@ -4642,7 +4645,7 @@ YAML, N-Quads, and CBOR. Since JWTs require the use of JSON to be generated,
 they are inextricably tied to the JSON syntax.
       </dd>
       <dt id="pf15">
-PF15: Changing key-value ordering, or introducing whitespace does not
+PF15: Changing property-value ordering, or introducing whitespace does not
 invalidate signature.
       </dt>
       <dd>


### PR DESCRIPTION
This PR adds a section on Proof Format Trade-Offs since it is a question that comes up often when discussing the different proof formats in the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/384.html" title="Last updated on Feb 23, 2019, 10:29 PM UTC (64bd3f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/384/5f09c57...64bd3f0.html" title="Last updated on Feb 23, 2019, 10:29 PM UTC (64bd3f0)">Diff</a>