### PR TITLE
Fix nesting of sections 10, 11 and 12

### DIFF
--- a/common.js
+++ b/common.js
@@ -84,6 +84,12 @@ var vcwg = {
       status:   'CG-DRAFT',
       publisher:  'Credentials W3C Community Group'
     },
+    'DEMOGRAPHICS': {
+      title: 'Simple Demographics Often Identify People Uniquely',
+      href: 'http://dataprivacylab.org/projects/identifiability/paper1.pdf',
+      authors: ['Latanya Sweeney'],
+      publisher: 'Data Privacy Lab'
+    }
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -3883,8 +3883,7 @@ information inside the <a>credential</a> to correlate the individual with an
 existing profile. For example, if a <a>holder</a> presents <a>credentials</a>
 that include postal code, age, and sex, a <a>verifier</a> can potentially
 correlate the <a>subject</a> of that <a>credential</a> with an established
-profile. For more information, see Sweeney 2000
-<a href="http://dataprivacylab.org/projects/identifiability/paper1.pdf">Simple Demographics Often Identify People Uniquely</a>].
+profile. For more information, see [[DEMOGRAPHICS]].
           </li>
           <li>
 Passing the identifier of a <a>credential</a> to a centralized revocation

--- a/index.html
+++ b/index.html
@@ -3324,11 +3324,12 @@ and verifiers unless they accept the liability of ignoring the policy.
 </p>
 
     </section>
+  </section>
 
-    <section class="informative">
-      <h2>Accessibility Considerations</h2>
+  <section class="informative">
+    <h2>Accessibility Considerations</h2>
 
-      <p>
+    <p>
 There are a number of accessibility considerations implementers should be
 aware of when processing data described in this specification. As with any web
 standards or protocols implementation, ignoring accessibility issues makes
@@ -3338,24 +3339,24 @@ all people, regardless of ability, can make use of this data. This is
 especially important when establishing systems that utilize cryptography and
 encryption, which historically, have created problems for assistive
 technologies.
-      </p>
+    </p>
 
-      <p>
+    <p>
 This section details the general accessibility considerations to take into
 account when utilizing this data model.
-      </p>
+    </p>
 
-      <section>
-        <h3>Data First Approaches</h3>
+    <section>
+      <h3>Data First Approaches</h3>
 
-        <p>
+      <p>
 Many physical credentials in use today, such as government identification
 cards, have poor accessibility characteristics, including, but not limited to,
 small print, reliance on small and high-resolution images, and no affordances
 for people with vision impairments.
-        </p>
+      </p>
 
-        <p>
+      <p>
 When utilizing this data model to create <a>verifiable credentials</a>, it is
 suggested that data model designers use a <em>data first</em> approach. For example,
 given the choice of using data or a graphical image to depict a
@@ -3365,9 +3366,9 @@ machine readable way instead of just relying on the image to convey this
 information. Using a data first approach is preferred because it provides the
 foundational elements of building different interfaces for people with varying
 abilities.
-        </p>
-      </section>
+      </p>
     </section>
+  </section>
 
     <section class="informative">
       <h2>Privacy Considerations</h2>


### PR DESCRIPTION
Sections 10, 11 and 12 were subsumed by section 9 for a while; this puts them back at the top level.

Also added an informative link to a paper to the references, instead of inline.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rhiaro/vc-data-model/pull/390.html" title="Last updated on Jan 22, 2019, 3:14 PM UTC (a69cab0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/390/dc060a3...rhiaro:a69cab0.html" title="Last updated on Jan 22, 2019, 3:14 PM UTC (a69cab0)">Diff</a>