### PR TITLE
Clean up conformance section

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,21 +710,12 @@ A concrete expression of the data model in this specification is a
 this specification regarding syntax. That is, the content in the
 <a href="#basic-concepts">Basic Concepts</a>,
 <a href="#advanced-concepts">Advanced Concepts</a>, and
-<a href="#syntaxes">Syntaxes</a> sections of this document. For convenience,
-normative statements for <em>conforming documents</em> are
-often phrased as statements on the syntax used in properties and their
-associated values in the document (for example, "MUST be a URI", or
-"MUST be a string value of an ISO8601 combined date and time string").
+<a href="#syntaxes">Syntaxes</a> sections of this document.
       </p>
-
+      
       <p>
-A <em>conforming processor</em> is a software or hardware-based implementation
-of the normative statements in this specification regarding the expected
-contents of property-value pairs (for example, the content in
-<a>Verification</a>). For convenience, normative statements for
-<em>conforming processors</em> are often phrased as behavioral statements
-regarding the contents of property-value pairs (for example, "MUST NOT be
-revoked", or "MUST be in the expected range").
+This document makes no normative statements with regard to conformance of
+document processors such as Issuers, Holders, or Verifiers.
       </p>
     </section>
 


### PR DESCRIPTION
This PR modifies the conformance section to only talk about document conformance as suggested in issue #317.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/397.html" title="Last updated on Jan 26, 2019, 5:32 PM UTC (987ca82)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/397/ce656da...987ca82.html" title="Last updated on Jan 26, 2019, 5:32 PM UTC (987ca82)">Diff</a>