### PR TITLE
Remove empty docuent sections

### DIFF
--- a/VCDMExplainer.md
+++ b/VCDMExplainer.md
@@ -336,11 +336,6 @@ implementors, but it was determined that requiring such capability might be too 
 The data model in its current form supports selective disclosure as a best practice,
 but does not require it.
 
-### Authorization Framework
-tocome
-
-### Terms of Use
-tocome
 
 ## Features at Risk
 


### PR DESCRIPTION
Removed the empty sections for ToU and Authorizations after that content was added elsewhere