### PR TITLE
change namespace URI to www.w3.org-based

### DIFF
--- a/WD/2019-01-15/index.html
+++ b/WD/2019-01-15/index.html
@@ -1711,7 +1711,7 @@ use must mean the same thing to each other. This specification uses the
           <dd>
 The value of the <code>@context</code> property <em class="rfc2119" title="MUST">MUST</em> be one or more URIs,
 where the value of the first URI is
-<code>https://w3.org/2018/credentials/v1</code>. If more than one URI is
+<code>https://www.w3.org/2018/credentials/v1</code>. If more than one URI is
 provided, the URIs <em class="rfc2119" title="MUST">MUST</em> be interpreted as an ordered set. It is <em class="rfc2119" title="RECOMMENDED">RECOMMENDED</em>
 that dereferencing the URIs results in a document containing machine-readable
 information about the context.
@@ -1722,7 +1722,7 @@ information about the context.
           <div class="marker"><a class="self-link" href="#ex-1-usage-of-the-context-property">Example 1</a><span class="example-title">: Usage of the @context property</span></div>
           <pre class="nohighlight">{
   <span class="highlight">"@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ]</span>,
   "id": "http://example.edu/credentials/58473",
@@ -1737,7 +1737,7 @@ information about the context.
 
         <p>
 The example above uses the base context URI
-(<code>https://w3.org/2018/credentials/v1</code>) to establish that the
+(<code>https://www.w3.org/2018/credentials/v1</code>) to establish that the
 conversation is about a <a href="#dfn-verifiable-credentials" class="internalDFN" data-link-type="dfn">verifiable credential</a>. The second
 URI (<code>https://example.com/examples/v1</code>) establishes that the
 conversation is about examples.
@@ -1751,11 +1751,11 @@ other purpose, such as in pilot or production systems.
         </p></div>
 
         <p>
-The data available at <code>https://w3.org/2018/credentials/v1</code> is a
+The data available at <code>https://www.w3.org/2018/credentials/v1</code> is a
 static document that is never updated and <em class="rfc2119" title="MAY">MAY</em> be downloaded and cached. The
 associated human-readable vocabulary document for the Verifiable Credentials
 Data Model is available at
-<a href="https://w3.org/2018/credentials">https://w3.org/2018/credentials</a>.
+<a href="https://www.w3.org/2018/credentials">https://www.w3.org/2018/credentials</a>.
 This concept is further expanded on in Section <a href="#extensibility" class="sec-ref"><span class="secno">7.1</span> <span class="sec-title">Extensibility</span></a>.
         </p>
       </section>
@@ -1792,7 +1792,7 @@ machine-readable information about the identifier.
           <div class="marker"><a class="self-link" href="#ex-2-usage-of-the-id-property">Example 2</a><span class="example-title">: Usage of the id property</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   <span class="highlight">"id": "http://example.edu/credentials/3732"</span>,
@@ -1854,7 +1854,7 @@ the type.
           <div class="marker"><a class="self-link" href="#ex-3-usage-of-the-type-property">Example 3</a><span class="example-title">: Usage of the type property</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2026,7 +2026,7 @@ earliest date when the information associated with the
           <div class="marker"><a class="self-link" href="#ex-4-usage-of-issuer-properties">Example 4</a><span class="example-title">: Usage of issuer properties</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2067,7 +2067,7 @@ to the signing entity, and a representation of the signing date.</dd>
           <div class="marker"><a class="self-link" href="#ex-5-usage-of-the-proof-property-on-a-verifiable-credential">Example 5</a><span class="example-title">: Usage of the proof property on a verifiable credential</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.gov/credentials/3732",
@@ -2121,7 +2121,7 @@ date and time the <a href="#dfn-credential" class="internalDFN" data-link-type="
           <div class="marker"><a class="self-link" href="#ex-6-usage-of-the-expirationdate-property">Example 6</a><span class="example-title">: Usage of the expirationDate property</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2181,7 +2181,7 @@ privacy-enhancing.
           <div class="marker"><a class="self-link" href="#ex-7-usage-of-the-status-property">Example 7</a><span class="example-title">: Usage of the status property</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2234,7 +2234,7 @@ The example below shows a <a href="#dfn-verifiable-presentations" class="interna
           <div class="marker"><a class="self-link" href="#ex-8-basic-structure-of-a-presentation">Example 8</a><span class="example-title">: Basic structure of a presentation</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
@@ -2335,7 +2335,7 @@ Let us assume that we start with the following <a href="#dfn-verifiable-credenti
           <div class="marker"><a class="self-link" href="#ex-9-a-simple-credential">Example 9</a><span class="example-title">: A simple credential</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.com/credentials/4643",
@@ -2389,7 +2389,7 @@ this example by including the context and adding the new properties to the
           <div class="marker"><a class="self-link" href="#ex-11-a-verifiable-credential-with-a-custom-extension">Example 11</a><span class="example-title">: A verifiable credential with a custom extension</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     <span class="highlight">"https://example.com/contexts/mycontext.jsonld"</span>
   ],
   "id": "http://example.com/credentials/4643",
@@ -2471,7 +2471,7 @@ new <code>favoriteFood</code> term so that it can only be used within the
   "@context": {
     "referenceNumber": "https://example.com/vocab#referenceNumber",
     <span class="highlight">"credentialSubject": {
-      "@id": "https://w3.org/2018/credentials#credentialSubject",
+      "@id": "https://www.w3.org/2018/credentials#credentialSubject",
       "@context": {
         "favoriteFood": "https://example.com/vocab#favoriteFood"
       }
@@ -2526,7 +2526,7 @@ data schema is determined by the specific type definition.
           <div class="marker"><a class="self-link" href="#ex-13-usage-of-the-credentialschema-property-to-perform-json-schema-validation">Example 13</a><span class="example-title">: Usage of the credentialSchema property to perform JSON schema validation</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.org/motorlicense/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2569,7 +2569,7 @@ such as those used to perform zero-knowledge proofs.
           <div class="marker"><a class="self-link" href="#ex-14-usage-of-the-credentialschema-property-to-perform-zero-knowledge-validation">Example 14</a><span class="example-title">: Usage of the credentialSchema property to perform zero-knowledge validation</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.org/motorlicense/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2644,7 +2644,7 @@ definition.
           <div class="marker"><a class="self-link" href="#ex-15-usage-of-the-refreshservice-property-by-an-issuer">Example 15</a><span class="example-title">: Usage of the refreshService property by an issuer</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.org/motorlicense/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2814,7 +2814,7 @@ A related initiative is the one at <a href="https://customercommons.org">Custome
           <div class="marker"><a class="self-link" href="#ex-16-usage-of-the-termsofuse-property-by-an-issuer">Example 16</a><span class="example-title">: Usage of the termsOfUse property by an issuer</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.org/motorlicense/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -2852,7 +2852,7 @@ storing the data in an archive.
           <div class="marker"><a class="self-link" href="#ex-17-usage-of-the-termsofuse-property-by-a-holder">Example 17</a><span class="example-title">: Usage of the termsOfUse property by a holder</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.org/motorlicense/v1"
   ],
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
@@ -2943,7 +2943,7 @@ credentials are supported by the specification.
           <div class="marker"><a class="self-link" href="#ex-18-usage-of-the-evidence-property">Example 18</a><span class="example-title">: Usage of the evidence property</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.org/motorlicense/v1"
   ],
   "id": "http://example.edu/credentials/3732",
@@ -3032,7 +3032,7 @@ Proof system, also known as "CL Signatures".
           <div class="marker"><a class="self-link" href="#ex-19-a-verifiable-credential-that-supports-cl-signatures">Example 19</a><span class="example-title">: A verifiable credential that supports CL Signatures</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -3100,13 +3100,13 @@ intend to share.
           <div class="marker"><a class="self-link" href="#ex-20-a-verifiable-presentation-that-supports-cl-signatures">Example 20</a><span class="example-title">: A verifiable presentation that supports CL Signatures</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "type": "VerifiablePresentation",
   "verifiableCredential": [{
     "@context": [
-      "https://w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/v1",
       "https://example.com/examples/v1"
     ],
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -3234,7 +3234,7 @@ to determine the relationship between the <a href="#dfn-subjects" class="interna
           <div class="example" id="ex-22-a-credential-uniquely-identifying-a-subject">
           <div class="marker"><a class="self-link" href="#ex-22-a-credential-uniquely-identifying-a-subject">Example 22</a><span class="example-title">: A credential uniquely identifying a subject</span></div>
           <pre class="nohighlight">{
-  "@context": ["https://w3.org/2018/credentials/v1", "https://schema.org/"]
+  "@context": ["https://www.w3.org/2018/credentials/v1", "https://schema.org/"]
   "id": "http://example.edu/credentials/332",
   "type": ["VerifiableCredential", "IdentityCredential"],
   "issuer": "https://example.edu/issuers/4",
@@ -3525,7 +3525,7 @@ that the <a href="#dfn-credential" class="internalDFN" data-link-type="dfn">cred
           <div class="marker"><a class="self-link" href="#ex-27-a-subject-disputes-a-credential">Example 27</a><span class="example-title">: A subject disputes a credential</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.com/credentials/123",
@@ -3718,12 +3718,12 @@ about <a href="#dfn-credential" class="internalDFN" data-link-type="dfn">credent
 <a href="#dfn-verifiable-credentials" class="internalDFN" data-link-type="dfn">verifiable credential</a> or <a href="#dfn-verifiable-presentations" class="internalDFN" data-link-type="dfn">verifiable presentation</a>, and a
 <code>@context</code> property is not present at the top-level of the JSON-LD
 document, then a <code>@context</code> property with a value of
-<code>https://w3.org/2018/credentials/v1</code> <em class="rfc2119" title="MUST">MUST</em> be assumed. The JSON-LD
-Context available at <code>https://w3.org/2018/credentials/v1</code> is a
+<code>https://www.w3.org/2018/credentials/v1</code> <em class="rfc2119" title="MUST">MUST</em> be assumed. The JSON-LD
+Context available at <code>https://www.w3.org/2018/credentials/v1</code> is a
 static document that is never updated and can therefore be downloaded and
 cached client side. The associated vocabulary document for the Verifiable
 Credentials Data Model is available at
-<code>https://w3.org/2018/credentials</code>.
+<code>https://www.w3.org/2018/credentials</code>.
         </p>
       </section>
 
@@ -3881,7 +3881,7 @@ In the example above, the VC uses a <code>proof</code> based on <code>JWS</code>
   "nonce": "660!6345FSer",
   "vc": {
     "@context": [
-      "https://w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/v1",
       "https://example.com/examples/v1"
     ],
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -3948,7 +3948,7 @@ and the corresponding verification key can be obtained using the <code>kid</code
   "nonce": "343s$FSFDa-",
   "vp": {
     "@context": [
-      "https://w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/v1",
       "https://example.com/examples/v1"
     ],
     "type": ["VerifiablePresentation"],
@@ -4548,7 +4548,7 @@ credential:
           <div class="marker"><a class="self-link" href="#ex-35-usage-of-issuer-properties">Example 35</a><span class="example-title">: Usage of issuer properties</span></div>
           <pre class="nohighlight">{
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.edu/credentials/temporary/28934792387492384",


### PR DESCRIPTION
need to use a URI starting with https://www.w3.org as a namespace, so changed the namespace URI for the VC data model spec to "https://www.w3.org/2018/credentials"