### PR TITLE
fix revocation by issuer #456

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,8 @@ serializable in one or more interoperable machine-readable data formats.
 The data model and serialization must be extendable with minimal coordination.
           </li>
           <li>
-Revocation by the <a>issuer</a> should not reveal any identifying information
+Revocation by the <a>issuer</a> should not reveal 
+any identifying information
 about the <a>subject</a>, the <a>holder</a>, the specific
 <a>verifiable credential</a>, or the <a>verifier</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@ serializable in one or more interoperable machine-readable data formats.
 The data model and serialization must be extendable with minimal coordination.
           </li>
           <li>
-Revocation should not reveal to the <a>issuer</a> any identifying information
+Revocation by the <a>issuer</a> should not reveal any identifying information
 about the <a>subject</a>, the <a>holder</a>, the specific
 <a>verifiable credential</a>, or the <a>verifier</a>.
           </li>


### PR DESCRIPTION
Fixes #456.

One line change from
"Revocation should not reveal to the issuer any identifying information about the subject, the holder, the specific verifiable credential, or the verifier."

to
"Revocation by the issuer should not reveal any identifying information about the subject, the holder, the specific credential, or the verifier."


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ken-ebert/vc-data-model/pull/461.html" title="Last updated on Mar 19, 2019, 1:58 PM UTC (fc4ec6b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/461/b3bc88d...ken-ebert:fc4ec6b.html" title="Last updated on Mar 19, 2019, 1:58 PM UTC (fc4ec6b)">Diff</a>