### PR TITLE
Remove faulty assertion regarding consent

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,7 +914,7 @@ to the <a>verifier</a> and <a>verified</a>.
         PAYuNzVBAh4vGHSrQyHUdBBPM"
     }
   }],
-  <span class='comment'>// digital signature by Pat on the presentation establishes consent and
+  <span class='comment'>// digital signature by Pat on the presentation 
   // protects against replay attacks</span>
   "proof": {
     "type": "RsaSignature2018",


### PR DESCRIPTION
digital signature's don't necessarily represent consent. Removing overreaching assertion in the example comment.

Fixes issue #472


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/476.html" title="Last updated on Mar 26, 2019, 7:46 PM UTC (9318201)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/476/d2d7488...9318201.html" title="Last updated on Mar 26, 2019, 7:46 PM UTC (9318201)">Diff</a>