### PR TITLE
Remove must/should from informative text

### DIFF
--- a/index.html
+++ b/index.html
@@ -4116,25 +4116,21 @@ critical systems using the technology outlined in this specification.
 
       <p>
 Some aspects of the data model described in this specification can be
-protected through the use of cryptography. Implementers should be aware of the
-underlying cryptography suites and libraries used to implement the creation
-and verification of digital signatures and mathematical proofs used by their
-systems when processing <a>credentials</a> and <a>presentations</a>. Software
-developers with extensive experience implementing or auditing systems that use
-cryptography must be employed to ensure systems are properly designed. Proper
-<a href="https://en.wikipedia.org/wiki/Red_team">red teaming</a> is also
-suggested to remove bias from security reviews.
+protected through the use of cryptography. It is important that Implementers
+understand the cryptography suites and libraries used to create and process
+<a>credentials</a> and <a>presentations</a>. Implementing and auditing
+cryptography systems generally requires substantial experience. Effective
+<a href="https://en.wikipedia.org/wiki/Red_team">red teaming</a> can also
+help remove bias from security reviews.
       </p>
 
       <p>
 Cryptography suites and libraries have a shelf life and eventually fall to
-new attacks and technology advances. Production quality systems must take
+new attacks and technology advances. Production quality systems need to take
 this into account and ensure mechanisms exist to easily and proactively upgrade
-expired or broken cryptography suites and libraries. Procedures should also
-exist to invalidate and replace existing <a>credentials</a> in the event of a
-cryptography suite or library failure. Regular monitoring of systems to ensure
-proper upgrades are made in a timely manner are also important to ensure the
-long term viability of systems processing <a>verifiable credentials</a>.
+expired or broken cryptography suites and libraries, and to invalidate
+and replace existing <a>credentials</a>. Regular monitoring is important to
+ensure the long term viability of systems processing <a>verifiable credentials</a>.
       </p>
     </section>
 


### PR DESCRIPTION
fixes the part of  #493 that isn't a proposal for new normative requirements.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/499.html" title="Last updated on Mar 27, 2019, 9:53 AM UTC (447f36c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/499/1ad7698...447f36c.html" title="Last updated on Mar 27, 2019, 9:53 AM UTC (447f36c)">Diff</a>