### PR TITLE
unification of ecosystem overview and terminology

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,8 @@ Appendix <a href="#subject-holder-relationships"></a>
           <dt><a>verifier</a></dt>
           <dd>
 A role an <a>entity</a> might perform by receiving one or more
-<a>verifiable presentations</a>, for processing. Example verifiers include
+<a>verifiable credentials</a>, optionally inside a
+<a>verifiable presentation</a>, for processing. Example verifiers include
 employers, security personnel, and websites.
           </dd>
           <dt><a>verifiable data registry</a></dt>

--- a/index.html
+++ b/index.html
@@ -352,7 +352,8 @@ Appendix <a href="#subject-holder-relationships"></a>
           <dt><a>verifier</a></dt>
           <dd>
 A role an <a>entity</a> might perform by receiving one or more
-<a>verifiable presentations</a> for processing. Example verifiers include
+<a>verifiable credentials</a>, optionally inside a
+<a>verifiable presentations</a>, for processing. Example verifiers include
 employers, security personnel, and websites.
           </dd>
           <dt><a>verifiable data registry</a></dt>

--- a/index.html
+++ b/index.html
@@ -332,16 +332,15 @@ Example holders include students, employees, and customers.
           </dd>
           <dt><a>issuer</a></dt>
           <dd>
-A role an <a>entity</a> might perform by creating a
-<a>verifiable credential</a>, associating it with a specific <a>subject</a>,
-and transmitting it to a <a>holder</a>. Example issuers include
-corporations, non-profit organizations, trade associations, governments, and
-individuals.
+A role an <a>entity</a> might perform by asserting <a>claims</a> about one or
+more <a>subjects</a>, creating a <a>verifiable credential</a> from these
+<a>claims</a>, and transmitting the <a>verifiable credential</a> to a
+<a>holder</a>. Example issuers include corporations, non-profit organizations,
+trade associations, governments, and individuals.
           </dd>
           <dt><a>subject</a></dt>
           <dd>
-A role an <a>entity</a> might perform by having one or more
-<a>verifiable credentials</a> asserted about it. Example subjects include
+An <a>entity</a> about which <a>claims</a> are made. Example subjects include
 human beings, animals, and things. While in many cases the <a>holder</a> of
 a <a>verifiable credential</a> is the subject, in certain cases it is not. For
 example, a parent (the <a>holder</a>) might hold the
@@ -352,21 +351,20 @@ Appendix <a href="#subject-holder-relationships"></a>
           </dd>
           <dt><a>verifier</a></dt>
           <dd>
-A role an <a>entity</a> might perform by requesting and receiving a
-<a>verifiable presentation</a> that proves the <a>holder</a> possesses the
-required <a>verifiable credentials</a> with certain characteristics. Example
-verifiers include employers, security personnel, and websites.
+A role an <a>entity</a> might perform by receiving one or more
+<a>verifiable presentations</a> for processing. Example verifiers include
+employers, security personnel, and websites.
           </dd>
           <dt><a>verifiable data registry</a></dt>
           <dd>
 A role a system might perform by mediating the creation and <a>verification</a>
 of identifiers, keys, and other relevant data, such as
-<a>verifiable credential</a> schemas and revocation registries, which might be
-required to use <a>verifiable credentials</a>. Some configurations might
-require correlatable identifiers for <a>subjects</a>. Example verifiable data
-registries include trusted databases, decentralized databases, government ID
-databases, and distributed ledgers. Often there is more than one type of
-verifiable data registry utilized in an ecosystem.
+<a>verifiable credential</a> schemas, revocation registries, issuer public keys,
+and so on. Some configurations might require correlatable identifiers for
+<a>subjects</a>. Example verifiable data registries include trusted databases,
+decentralized databases, government ID databases, and distributed ledgers. Often
+there is more than one type of verifiable data registry utilized in an
+ecosystem.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -360,9 +360,10 @@ employers, security personnel, and websites.
 A role a system might perform by mediating the creation and <a>verification</a>
 of identifiers, keys, and other relevant data, such as
 <a>verifiable credential</a> schemas, revocation registries, issuer public keys,
-and so on. Some configurations might require correlatable identifiers for
-<a>subjects</a>. Example verifiable data registries include trusted databases,
-decentralized databases, government ID databases, and distributed ledgers. Often
+and so on, which might be required to use <a>verifiable credentials</a>. Some
+configurations might require correlatable identifiers for <a>subjects</a>.
+Example verifiable data registries include trusted databases, decentralized
+databases, government ID databases, and distributed ledgers. Often
 there is more than one type of verifiable data registry utilized in an
 ecosystem.
           </dd>

--- a/index.html
+++ b/index.html
@@ -352,7 +352,6 @@ Appendix <a href="#subject-holder-relationships"></a>
           <dt><a>verifier</a></dt>
           <dd>
 A role an <a>entity</a> might perform by receiving one or more
-<a>verifiable credentials</a>, optionally inside a
 <a>verifiable presentations</a>, for processing. Example verifiers include
 employers, security personnel, and websites.
           </dd>

--- a/terms.html
+++ b/terms.html
@@ -145,12 +145,11 @@ their usage. Validating <a>verifiable credentials</a> or
   <dd>
 A role a system might perform by mediating the creation and <a>verification</a>
 of identifiers, keys, and other relevant data, such as
-<a>verifiable credential</a> schemas and revocation registries, which might be
-required to use <a>verifiable credentials</a>. Some configurations might
-require correlatable identifiers for <a>subjects</a>
 <a>verifiable credential</a> schemas, revocation registries, issuer public keys,
-and so on. Some registries, such as ones for UUIDs and public keys, just act as
-namespaces for identifiers.
+and so on, which might be required to use <a>verifiable credentials</a>. Some
+configurations might require correlatable identifiers for <a>subjects</a>. Some
+registries, such as ones for UUIDs and public keys, may just act as namespaces
+for identifiers.
   </dd>
   <dt><dfn data-lt="verification|verify|verified|verifying|verifiable">verification</dfn></dt>
   <dd>

--- a/terms.html
+++ b/terms.html
@@ -65,10 +65,11 @@ to other <a>subjects</a> or data.
   </dd>
   <dt><dfn data-lt="holders|holder's">holder</dfn></dt>
   <dd>
-A role an <a>entity</a> can perform by possessing one or more
-<a>verifiable credentials</a>. A holder is usually, but not always,
-the <a>subject</a> of the <a>verifiable credentials</a> they are holding.
-Holders store their <a>credentials</a> in <a>credential repositories</a>.
+A role an <a>entity</a> might perform by possessing one or more
+<a>verifiable credentials</a> and generating <a>presentations</a> from them.
+A holder is usually, but not always, a <a>subject</a> of the <a>verifiable
+credentials</a> they are holding. Holders store their <a>credentials</a> in
+<a>credential repositories</a>.
   </dd>
   <dt><dfn data-lt="identities|identity's">identity</dfn></dt>
   <dd>
@@ -142,10 +143,14 @@ their usage. Validating <a>verifiable credentials</a> or
   </dd>
   <dt><dfn data-lt="verifiable data registries">verifiable data registry</dfn></dt>
   <dd>
-A role a system might perform by mediating the creation and verification of
-<a>subject</a> identifiers, <a>verifiable credential</a> schemas, revocation
-registries, issuer public keys, and so on. Some registries, such as ones for
-UUIDs and public keys, just act as namespaces for identifiers.
+A role a system might perform by mediating the creation and <a>verification</a>
+of identifiers, keys, and other relevant data, such as
+<a>verifiable credential</a> schemas and revocation registries, which might be
+required to use <a>verifiable credentials</a>. Some configurations might
+require correlatable identifiers for <a>subjects</a>
+<a>verifiable credential</a> schemas, revocation registries, issuer public keys,
+and so on. Some registries, such as ones for UUIDs and public keys, just act as
+namespaces for identifiers.
   </dd>
   <dt><dfn data-lt="verification|verify|verified|verifying|verifiable">verification</dfn></dt>
   <dd>

--- a/terms.html
+++ b/terms.html
@@ -158,7 +158,8 @@ The evaluation of whether or not a <a>verifiable credential</a> or
   </dd>
   <dt><dfn data-lt="verifier|verifiers|verifier's|credential verifiers|credential verifier's">verifier</dfn></dt>
 A role an <a>entity</a> might perform by receiving one or more
-<a>verifiable presentations</a> for processing.  Other specifications might
+<a>verifiable credentials</a>, optionally inside a
+<a>verifiable presentation</a> for processing.  Other specifications might
 refer to this concept as a <dfn data-lt="relying parties">relying party</dfn>.
   </dd>
   <dt><dfn data-lt="URI|URIs">URI</dfn></dt>

--- a/terms.html
+++ b/terms.html
@@ -158,8 +158,7 @@ The evaluation of whether or not a <a>verifiable credential</a> or
   </dd>
   <dt><dfn data-lt="verifier|verifiers|verifier's|credential verifiers|credential verifier's">verifier</dfn></dt>
 A role an <a>entity</a> might perform by receiving one or more
-<a>verifiable credentials</a>, optionally inside a
-<a>verifiable presentations</a>, for processing.  Other specifications might
+<a>verifiable presentations</a> for processing.  Other specifications might
 refer to this concept as a <dfn data-lt="relying parties">relying party</dfn>.
   </dd>
   <dt><dfn data-lt="URI|URIs">URI</dfn></dt>

--- a/terms.html
+++ b/terms.html
@@ -157,9 +157,9 @@ The evaluation of whether or not a <a>verifiable credential</a> or
 <a>verifiable presentation</a> complies with this specification.
   </dd>
   <dt><dfn data-lt="verifier|verifiers|verifier's|credential verifiers|credential verifier's">verifier</dfn></dt>
-  <dd>
 A role an <a>entity</a> might perform by receiving one or more
-<a>verifiable presentations</a> for processing. Other specifications might
+<a>verifiable credentials</a>, optionally inside a
+<a>verifiable presentations</a>, for processing.  Other specifications might
 refer to this concept as a <dfn data-lt="relying parties">relying party</dfn>.
   </dd>
   <dt><dfn data-lt="URI|URIs">URI</dfn></dt>


### PR DESCRIPTION
This PR unifies the language used in the ecosystem overview (section 1.2) and terminology definitions (section 2) to partially addres issue #481


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/508.html" title="Last updated on Apr 2, 2019, 2:25 AM UTC (ede9787)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/508/1ad7698...brentzundel:ede9787.html" title="Last updated on Apr 2, 2019, 2:25 AM UTC (ede9787)">Diff</a>