### PR TITLE
add note to 3.2 for issue 481

### DIFF
--- a/index.html
+++ b/index.html
@@ -709,6 +709,11 @@ It is possible to have a <a>credential</a>, such as a marriage certificate,
 containing multiple <a>claims</a> about different <a>subjects</a> that are
 not required to be related.
         </p>
+        <p class="note">
+It is possible to have a <a>credential</a> that does not contain any claims
+about the entity to which the credential was issued. An example is a credential
+that only contains claims about a specific dog, but is issued to its owner.
+        </p>
       </section>
 
       <section class="informative">


### PR DESCRIPTION
Adds a note to the end of section 3.2 that clarifies that a credential may be issued to a holder who is not the subject of the credential. This addresses issue #481 
Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/509.html" title="Last updated on Mar 27, 2019, 9:59 PM UTC (c160065)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/509/1ad7698...brentzundel:c160065.html" title="Last updated on Mar 27, 2019, 9:59 PM UTC (c160065)">Diff</a>