### PR TITLE
Fixing "the subject of the credential" (issue #464)

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,9 +854,9 @@ that will be stored in Pat's digital wallet.
   "issuanceDate": "2010-01-01T19:73:24Z",
   <span class='comment'>// claims about the subjects of the credential</span>
   "credentialSubject": {
-    <span class='comment'>// identifier for the first subject of the credential</span>
+    <span class='comment'>// identifier for the only subject of the credential</span>
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    <span class='comment'>// assertion about the first subject of the credential</span>
+    <span class='comment'>// assertion about the only subject of the credential</span>
     "alumniOf": "&lt;span lang='en'>Example University&lt;/span>"
   },
   <span class='comment'>// digital proof that makes the credential tamper-evident</span>

--- a/index.html
+++ b/index.html
@@ -852,11 +852,11 @@ that will be stored in Pat's digital wallet.
   "issuer": "https://example.edu/issuers/565049",
   <span class='comment'>// when the credential was issued</span>
   "issuanceDate": "2010-01-01T19:73:24Z",
-  <span class='comment'>// claims about the subject of the credential</span>
+  <span class='comment'>// claims about the subjects of the credential</span>
   "credentialSubject": {
-    <span class='comment'>// identifier for the subject of the credential</span>
+    <span class='comment'>// identifier for the first subject of the credential</span>
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    <span class='comment'>// assertion about the subject of the credential</span>
+    <span class='comment'>// assertion about the first subject of the credential</span>
     "alumniOf": "&lt;span lang='en'>Example University&lt;/span>"
   },
   <span class='comment'>// digital proof that makes the credential tamper-evident</span>
@@ -1067,9 +1067,9 @@ containing machine-readable information about the identifier.
         </pre>
 
         <p>
-The example above uses two types of identifiers. The first identifier is for
+The example above uses two types of identifier. The first identifier is for
 the <a>credential</a> and uses an HTTP-based URL. The second identifier is for
-the <a>subject</a> of the <a>credential</a> (the thing the <a>claims</a> are
+the only <a>subject</a> of this <a>credential</a> (the thing the <a>claims</a> are
 about) and uses a <a>decentralized identifier</a>, also known as a <a>DID</a>.
         </p>
 
@@ -1749,7 +1749,7 @@ determine:
 
         <ul>
           <li>
-Whether the <a>holder</a> is the <a>subject</a> of a
+Whether the <a>holder</a> is a <a>subject</a> of a
 <a>verifiable credential</a>.
           </li>
           <li>
@@ -2719,7 +2719,7 @@ security number for an <a>entity</a>.
         </ul>
 
         <p>
-Only the <a>subject</a> of a <a>verifiable credential</a> is entitled to issue
+Only a <a>subject</a> of a <a>verifiable credential</a> is entitled to issue
 a <code>DisputeCredential</code>. A <code>DisputeCredential</code> issued by
 anyone other than the <a>subject</a> should be disregarded by the
 <a>verifier</a>, unless the <a>verifier</a> has some other way of determining
@@ -3923,7 +3923,7 @@ individual across services. In this case, using information from other sources
 <a>verifiers</a> can use information inside the <a>credential</a> to correlate
 the individual with an existing profile. For example, if a <a>holder</a>
 presents <a>credentials</a> that include postal code, age, and gender, a
-<a>verifier</a> can potentially correlate the <a>subject</a> of that
+<a>verifier</a> can potentially correlate a <a>subject</a> of that
 <a>credential</a> with an established profile. For more information,
 see [[DEMOGRAPHICS]].
         </li>
@@ -5022,7 +5022,7 @@ into the <a>subject's</a> <a>credential</a>.
     </p>
 
         <pre class="example nohighlight" title="A credential issued to a
-holder who is not the subject of the credential, who has no relationship with
+holder who is not the (only) subject of the credential, who has no relationship with
 the subject of the credential, but who has a relationship with the issuer">
 
 {


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/512.html" title="Last updated on Mar 28, 2019, 10:55 PM UTC (10c0494)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/512/1ad7698...10c0494.html" title="Last updated on Mar 28, 2019, 10:55 PM UTC (10c0494)">Diff</a>