### PR TITLE
Suggested editorial updates to Introduction and Terminology sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@ physical world.
 
       <p>
 This specification provides a standard way to express <a>credentials</a> on the
-Web, a way that is cryptographically secure, privacy respecting, and
+Web in a way that is cryptographically secure, privacy respecting, and
 machine-verifiable.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@ physical world.
 
       <p>
 This specification provides a standard way to express <a>credentials</a> on the
-Web in a way that is cryptographically secure, privacy respecting, and
+Web, a way that is cryptographically secure, privacy respecting, and
 machine-verifiable.
       </p>
 
@@ -274,8 +274,8 @@ Information related to the issuing authority (for example, a city government,
 national agency, or certification body)
           </li>
           <li>
-Information related to the specific attribute(s) or properties being asserted by
-issuing authority about the <a>subject</a>
+Information related to the specific attributes or properties being asserted by
+the issuing authority about the <a>subject</a>
           </li>
           <li>
 Evidence related to how the <a>credential</a> was derived
@@ -289,14 +289,22 @@ Information related to expiration dates.
 A <a>verifiable credential</a> can represent all of the same information that a
 physical <a>credential</a> represents. The addition of technologies, such as
 digital signatures, makes <a>verifiable credentials</a> more tamper-evident and
-more trustworthy than their physical counterparts. <a>Holders</a> of
-<a>verifiable credentials</a> can generate <a>presentations</a> and then share
-these <a>presentations</a> with <a>verifiers</a> to prove they possess
-<a>verifiable credentials</a> with certain characteristics. Both
-<a>verifiable credentials</a> and <a>verifiable presentations</a> can be
+more trustworthy than their physical counterparts.
+        </p>
+
+        <p>
+<a>Holders</a> of <a>verifiable credentials</a> can generate
+<a>verifiable presentations</a> and then share these
+<a>verifiable presentations</a> with <a>verifiers</a> to prove they possess
+<a>verifiable credentials</a> with certain characteristics.
+        </p>
+
+        <p>
+Both <a>verifiable credentials</a> and <a>verifiable presentations</a> can be
 transmitted rapidly, making them more convenient than their physical
 counterparts when trying to establish trust at a distance.
         </p>
+
         <p>
 While this specification attempts to improve the ease of expressing digital
 <a>credentials</a>, it also attempts to balance this goal with a number of
@@ -327,8 +335,8 @@ specification:
           <dt><a>holder</a></dt>
           <dd>
 A role an <a>entity</a> might perform by possessing one or more
-<a>verifiable credentials</a> and generating <a>presentations</a> from them.
-Example holders include students, employees, and customers.
+<a>verifiable credentials</a> and generating <a>verifiable presentations</a>
+from them. Example holders include students, employees, and customers.
           </dd>
           <dt><a>issuer</a></dt>
           <dd>
@@ -341,14 +349,14 @@ individuals.
           <dt><a>subject</a></dt>
           <dd>
 A role an <a>entity</a> might perform by having one or more
-<a>verifiable credentials</a> asserted about it. Example subjects include
-human beings, animals, and things. While in many cases the <a>holder</a> of
-a <a>verifiable credential</a> is the subject, in certain cases it is not. For
+<a>verifiable credentials</a> associated with it. Example subjects include
+human beings, animals, and things. In many cases the <a>holder</a> of a
+<a>verifiable credential</a> is the subject, but in certain cases it is not. For
 example, a parent (the <a>holder</a>) might hold the
 <a>verifiable credentials</a> of a child (the <a>subject</a>), or a pet owner
 (the <a>holder</a>) might hold the <a>verifiable credentials</a> of their pet
 (the <a>subject</a>). For more information about these special cases, see
-Appendix <a href="#subject-holder-relationships"></a>
+Appendix <a href="#subject-holder-relationships"></a>.
           </dd>
           <dt><a>verifier</a></dt>
           <dd>
@@ -370,7 +378,7 @@ verifiable data registry utilized in an ecosystem.
           </dd>
         </dl>
 
-        <figure>
+        <figure id="roles">
           <img style="margin: auto; display: block; width: 75%;"
 	       src="diagrams/ecosystem.svg" alt="diagram showing how
 	       credentials flow from issuer to holder and
@@ -383,10 +391,10 @@ verifiable data registry utilized in an ecosystem.
         </figure>
 
         <p class="note">
-The ecosystem above is provided as an example to ground the rest of the
-concepts in this specification. Other ecosystems exist, such as protected
-environments or proprietary systems, where <a>verifiable credentials</a> also
-provide benefit.
+<a href="#roles"></a> above provides an example ecosystem in which to ground the
+rest of the concepts in this specification. Other ecosystems exist, such as
+protected environments or proprietary systems, where
+<a>verifiable credentials</a> also provide benefit.
         </p>
       </section>
 
@@ -394,7 +402,7 @@ provide benefit.
         <h3>Use Cases and Requirements</h3>
 
         <p>
-The Verifiable Credentials Use Cases [[VC-USECASES]] document outlines a number
+The Verifiable Credentials Use Cases document [[VC-USECASES]] outlines a number
 of key topics that readers might find useful, including:
         </p>
 
@@ -434,8 +442,9 @@ desirable ecosystem characteristics were identified for this specification:
 a tamper-evident and privacy-respecting manner.
           </li>
           <li>
-<a>Holders</a> assemble collections of <a>credentials</a> from different
-<a>issuers</a> into a single artifact, a <a>verifiable presentation</a>.
+<a>Holders</a> assemble collections of <a>verifiable credentials</a> from
+different <a>issuers</a> into a single artifact, a
+<a>verifiable presentation</a>.
           </li>
           <li>
 <a>Issuers</a> can issue <a>verifiable credentials</a> about any <a>subject</a>.
@@ -446,7 +455,7 @@ registration nor approval by any authority.
           </li>
           <li>
 <a>Verifiable presentations</a> allow any <a>verifier</a> to <a>verify</a> the
-authenticity of <a>credentials</a> from any <a>issuer</a>.
+authenticity of <a>verifiable credentials</a> from any <a>issuer</a>.
           </li>
           <li>
 <a>Holders</a> can receive <a>verifiable credentials</a> from anyone.
@@ -462,7 +471,7 @@ through any user agent.
           </li>
           <li>
 <a>Holders</a> can store <a>verifiable credentials</a> in any location, without
-affecting their verifiability and without the <a>issuer</a> knowing
+affecting their <a>verifiability</a> and without the <a>issuer</a> knowing
 anything about where they are stored or when they are accessed.
           </li>
           <li>
@@ -497,8 +506,10 @@ If a single <a>verifiable credential</a> supports selective disclosure, then
 <a>verifiable credential</a>.
           </li>
           <li>
-<a>Presentations</a> can either disclose the attributes of a <a>credential</a>,
-or satisfy <a>derived predicates</a> requested by the <a>verifier</a>. <a>Derived predicates</a> are Boolean conditions, such as greater than, less than, equal to, is in set, and so on.
+<a>Verifiable presentations</a> can either disclose the attributes of a
+<a>verifiable credential</a>, or satisfy <a>derived predicates</a> requested by
+the <a>verifier</a>. <a>Derived predicates</a> are Boolean conditions, such as
+greater than, less than, equal to, is in set, and so on.
           </li>
           <li>
 <a>Issuers</a> can issue revocable <a>verifiable credentials</a>.
@@ -511,8 +522,7 @@ serializable in one or more interoperable machine-readable data formats.
 The data model and serialization must be extendable with minimal coordination.
           </li>
           <li>
-Revocation by the <a>issuer</a> should not reveal 
-any identifying information
+Revocation by the <a>issuer</a> should not reveal any identifying information
 about the <a>subject</a>, the <a>holder</a>, the specific
 <a>verifiable credential</a>, or the <a>verifier</a>.
           </li>
@@ -522,7 +532,8 @@ about the <a>subject</a>, the <a>holder</a>, the specific
           <li>
 <a>Issuers</a> revoking <a>verifiable credentials</a> should distinguish between
 revocation for cryptographic integrity (for example, the signing key is
-compromised) versus revocation for a status change (for example, the driver’s license is suspended).
+compromised) versus revocation for a status change (for example, the driver’s
+license is suspended).
           </li>
           <li>
 <a>Issuers</a> can provide a service for refreshing a

--- a/terms.html
+++ b/terms.html
@@ -25,10 +25,10 @@ necessary in order to successfully accomplish a task or goal.
   <dd>
 A portable URL-based identifier, also known as a <strong><em>DID</em></strong>,
 associated with an <a>entity</a>. These identifiers are most often used in a
-<a>credential</a> and are associated with <a>subjects</a> such that a
-<a>credential</a> itself can be easily ported from one <a>repository</a> to
-another without the need to reissue the <a>credential</a>. An example of a DID
-is <code>did:example:123456abcdef</code>.
+<a>verifiable credential</a> and are associated with <a>subjects</a> such that a
+<a>verifiable credential</a> itself can be easily ported from one
+<a>repository</a> to another without the need to reissue the <a>credential</a>.
+An example of a DID is <code>did:example:123456abcdef</code>.
   </dd>
   <dt><dfn data-lt="decentralized identifier documents|DID document|DID documents">decentralized identifier document</dfn></dt>
   <dd>
@@ -40,13 +40,13 @@ such as the associated <a>repository</a> and public key information.
   <dd>
 A verifiable, boolean assertion about the value of another attribute in a
 <a>verifiable credential</a>. These are useful in zero-knowledge-proof-style
-<a>presentations</a> because they can limit information disclosure. For
-example, if a <a>verifiable credential</a> contains an attribute
+<a>verifiable presentations</a> because they can limit information disclosure.
+For example, if a <a>verifiable credential</a> contains an attribute
 for expressing a specific height in centimeters, a derived predicate
-might reference the height attribute in the <a>credential</a> demonstrating
-that the <a>issuer</a> attests to a height value meeting the minimum height
-requirement, without actually disclosing the specific height value. For example,
-the <a>subject</a> is taller than 150 centimeters.
+might reference the height attribute in the <a>verifiable credential</a>
+demonstrating that the <a>issuer</a> attests to a height value meeting the
+minimum height requirement, without actually disclosing the specific height
+value. For example, the <a>subject</a> is taller than 150 centimeters.
   </dd>
   <dt><dfn>digital signature</dfn></dt>
   <dd>
@@ -56,19 +56,20 @@ A mathematical scheme for demonstrating the authenticity of a digital message.
   <dd>
 A thing with distinct and independent existence, such as a person,
 organization, concept, or device. An entity can perform one or more roles in
-the ecosystem.
+the <a>verifiable credentials</a> ecosystem.
   </dd>
   <dt><dfn data-lt="graphs">graph</dfn></dt>
   <dd>
 A network of information composed of <a>subjects</a> and their relationship
 to other <a>subjects</a> or data.
   </dd>
-  <dt><dfn data-lt="holders|holder's">holder</dfn></dt>
+  <dt><dfn data-lt="holders|holder's|holders'">holder</dfn></dt>
   <dd>
 A role an <a>entity</a> can perform by possessing one or more
 <a>verifiable credentials</a>. A holder is usually, but not always,
 the <a>subject</a> of the <a>verifiable credentials</a> they are holding.
-Holders store their <a>credentials</a> in <a>credential repositories</a>.
+Holders store their <a>verifiable credentials</a> in
+<a>credential repositories</a>.
   </dd>
   <dt><dfn data-lt="identities|identity's">identity</dfn></dt>
   <dd>
@@ -86,12 +87,12 @@ for creating, maintaining, and managing identity information for
 <a>holders</a>, while providing authentication services to
 <a>relying party</a> applications within a federation or distributed network.
 In this case the <a>holder</a> is always the <a>subject</a>. Even if the
-<a>credentials</a> are bearer <a>credentials</a>, it is assumed the
-<a>credentials</a> remain with the <a>subject</a>, and if they are not, they
-were stolen by an attacker. This specification does not use this term unless
-comparing or mapping the concepts in this document to other specifications.
-This specification decouples the <a>identity provider</a> concept into two
-distinct concepts: the <a>issuer</a> and the <a>holder</a>.
+<a>verifiable credentials</a> are bearer <a>credentials</a>, it is assumed the
+<a>verifiable credentials</a> remain with the <a>subject</a>, and if they are
+not, they were stolen by an attacker. This specification does not use this term
+unless comparing or mapping the concepts in this document to other
+specifications. This specification decouples the <a>identity provider</a>
+concept into two distinct concepts: the <a>issuer</a> and the <a>holder</a>.
   </dd>
   <dt><dfn data-lt="issuers|issuer's">issuer</dfn></dt>
   <dd>
@@ -102,8 +103,8 @@ more <a>subjects</a>, creating a <a>verifiable credential</a> from these
   </dd>
   <dt><dfn data-lt="presentations">presentation</dfn></dt>
   <dd>
-Data derived from one or more <a>credentials</a>, issued by one or more
-<a>issuers</a>, that is shared with a specific <a>verifier</a>. A
+Data derived from one or more <a>verifiable credentials</a>, issued by one or
+more <a>issuers</a>, that is shared with a specific <a>verifier</a>. A
 <dfn data-lt="verifiable presentations">verifiable presentation</dfn>
 is a tamper-evident presentation encoded in such a way that authorship of the
 data can be trusted after a process of cryptographic verification. Certain
@@ -114,8 +115,8 @@ zero-knowledge proofs).
   <dt><dfn data-lt="credential repository|credential repositories|repositories">repository</dfn></dt>
   <dd>
 A program, such as a storage vault or personal <a>verifiable credential</a>
-wallet, that stores and protects access to <a>holder</a>
-<a>credentials</a>.
+wallet, that stores and protects access to <a>holders'</a>
+<a>verifiable credentials</a>.
   </dd>
   <dt><dfn>selective disclosure</dfn></dt>
   <dd>
@@ -142,14 +143,14 @@ their usage. Validating <a>verifiable credentials</a> or
   </dd>
   <dt><dfn data-lt="verifiable data registries">verifiable data registry</dfn></dt>
   <dd>
-A role a system might perform by mediating the creation and verification of
-<a>subject</a> identifiers, <a>verifiable credential</a> schemas, revocation
+A role a system might perform by mediating the creation and <a>verification</a>
+of <a>subject</a> identifiers, <a>verifiable credential</a> schemas, revocation
 registries, issuer public keys, and so on. Some registries, such as ones for
 UUIDs and public keys, just act as namespaces for identifiers.
   </dd>
-  <dt><dfn data-lt="verification|verify|verified|verifying|verifiable">verification</dfn></dt>
+  <dt><dfn data-lt="verify|verified|verifying|verifiable|verifiability">verification</dfn></dt>
   <dd>
-The evaluation of whether or not a <a>verifiable credential</a> or
+The evaluation of whether a <a>verifiable credential</a> or 
 <a>verifiable presentation</a> complies with this specification.
   </dd>
   <dt><dfn data-lt="verifier|verifiers|verifier's|credential verifiers|credential verifier's">verifier</dfn></dt>


### PR DESCRIPTION
A few instances of "verifiable credential" or "verifiable presentation" instead of just "credential" or "presentation".
Some grammar suggestions too.
And some suggested terminology changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/grantnoble/vc-data-model/pull/514.html" title="Last updated on Apr 1, 2019, 4:51 AM UTC (cfe63e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/514/1ad7698...grantnoble:cfe63e3.html" title="Last updated on Apr 1, 2019, 4:51 AM UTC (cfe63e3)">Diff</a>