### PR TITLE
Limit refreshing of verifiable credentials to holders fixes "Refreshing questions" #458

### DIFF
--- a/index.html
+++ b/index.html
@@ -470,7 +470,8 @@ serializable in one or more interoperable machine-readable data formats.
 The data model and serialization must be extendable with minimal coordination.
           </li>
           <li>
-Revocation by the <a>issuer</a> should not reveal any identifying information
+Revocation by the <a>issuer</a> should not reveal 
+any identifying information
 about the <a>subject</a>, the <a>holder</a>, the specific
 <a>verifiable credential</a>, or the <a>verifier</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -470,7 +470,7 @@ serializable in one or more interoperable machine-readable data formats.
 The data model and serialization must be extendable with minimal coordination.
           </li>
           <li>
-Revocation should not reveal to the <a>issuer</a> any identifying information
+Revocation by the <a>issuer</a> should not reveal any identifying information
 about the <a>subject</a>, the <a>holder</a>, the specific
 <a>verifiable credential</a>, or the <a>verifier</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -2092,17 +2092,16 @@ specification enables an <a>issuer</a> to include a link to a refresh service.
         </p>
         <p>
 The <a>issuer</a> can include the refresh service as an element inside the
-<a>verifiable credential</a> if it is intended for either the <a>verifier</a>
-or the <a>holder</a> (or both), or inside the <a>verifiable presentation</a>
-if it is intended for the <a>holder</a> only.
+<a>verifiable credential</a> where it enables the <a>holder</a> to refresh the
+<a>verifiable credential</a> details before creating a
+<a>verifiable presentation</a> to share with a <a>verifier</a>.
         </p>
         <p>
-Including the refresh reference inside the <a>verifiable presentation</a>
-enables the <a>holder</a> to refresh the <a>credential</a> details before
-creating a <a>presentation</a> to share with a <a>verifier</a>, while
-including the refresh reference inside the <a>verifiable credential</a>
-enables both the <a>holder</a> and the <a>verifier</a> to perform future
-updates of the <a>credential</a>.
+The <a>holder</a> can include the refresh service as an element inside the
+<a>verifiable presentation</a> where it enables the <a>verifier</a> to 
+request the <a>holder</a> to refresh the <a>verifiable credential</a> details
+before creating a new <a>verifiable presentation</a> to share with the
+<a>verifier</a>.
         </p>
         <p>
 This specification defines the following <a>property</a> for expressing
@@ -2113,11 +2112,11 @@ a refresh service:
           <dt><var>refreshService</var></dt>
           <dd>
 The value of the <code>refreshService</code> <a>property</a> MUST be one or
-more refresh services that provides enough information to the recipient's
-software such that the recipient can refresh the credential. Each
-<code>refreshService</code> value MUST specify its <code>type</code> (for
-example, <code>ManualRefreshService2018</code>) and its
-<code>id</code>, which is the URL of the service. The precise content of each
+more refresh services that provides enough information to the <a>holder</a>'s
+software such that the <a>holder</a> can refresh the <a>verifiable credential</a>.
+Each <code>refreshService</code> value MUST specify its <code>type</code> (for
+example, <code>ManualRefreshService2018</code>) and its <code>id</code>,
+which is the URL of the service. The precise content of each
 refresh service is determined by
 the specific <code>refreshService</code> <a>type</a> definition.
           </dd>
@@ -2150,8 +2149,8 @@ the specific <code>refreshService</code> <a>type</a> definition.
 
         <p>
 In the example above, the <a>issuer</a> specifies a manual
-<code>refreshService</code> that can be used by directing the <a>holder</a> or
-the <a>verifier</a> to <code>https://example.edu/refresh/3732</code>.
+<code>refreshService</code> that can be used by directing the <a>holder</a>
+to <code>https://example.edu/refresh/3732</code>.
         </p>
 
         <p class="issue atrisk">


### PR DESCRIPTION
Allowing Verifiers to bypass holders during a refresh removes control of credentials from the holder. If Verifiers need an updated presentation, they must request the update from the holder.