### PR TITLE
minor rearrangements of words (issue 558)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,9 +1022,9 @@ The value of the <code>@context</code> <a>property</a> MUST be an ordered set
 where the first item is a <a>URI</a> with the value
 <code>https://www.w3.org/2018/credentials/v1</code>. Subsequent items in the
 array MUST be composed of any combination of <a>URIs</a> or objects that
-express context information. If a <code>@context</code> <a>URI</a> is
-dereferenced, it is RECOMMENDED that results in a document containing
-machine-readable information about the context.
+express context information. It is RECOMMENDED that each <a>URI</a> in the
+<code>@context</code> be one which, if dereferenced, results in a document
+containing machine-readable information about the <code>@context</code>.
           </dd>
         </dl>
         <p class="note">
@@ -1114,8 +1114,9 @@ such scenarios. Where privacy is a strong consideration, the <code>id</code>
           <dt><dfn>id</dfn></dt>
           <dd>
 The value of the <code>id</code> <a>property</a> MUST be a single <a>URI</a>.
-It is RECOMMENDED that dereferencing the <a>URI</a> results in a document
-containing machine-readable information about the identifier.
+It is RECOMMENDED that the <a>URI</a> in the <code>id</code> be one which, if
+dereferenced, results in a document containing machine-readable information
+about the <code>id</code>.
           </dd>
         </dl>
 
@@ -1183,9 +1184,9 @@ The value of the <code>type</code> <a>property</a> MUST be, or map to (via
 interpretation of the <code>@context</code> property), one or more <a>URIs</a>.
 If more than one <a>URI</a> is provided, the <a>URIs</a> MUST be interpreted
 as an unordered set. Syntactic conveniences, such as JSON-LD terms, SHOULD
-be used to ease developer usage. It is RECOMMENDED that dereferencing the
-<a>URIs</a> results in a document containing machine-readable information
-about the type.
+be used to ease developer usage. It is RECOMMENDED that each <a>URI</a> in the
+<code>type</code> be one which, if dereferenced, results in a document
+containing machine-readable information about the <code>type</code>.
           </dd>
         </dl>
 
@@ -1408,11 +1409,11 @@ the following <a>property</a>:
           <dt><var>issuer</var></dt>
           <dd>
 The value of the <code>issuer</code> <a>property</a> MUST either be a
-<a>URI</a> or an object containing a <code>id</code> property. It is
-RECOMMENDED that dereferencing the <a>URI</a>, or the <code>id</code> property,
-results in a document containing machine-readable information about the
-<a>issuer</a> that can be used to <a>verify</a> the information expressed in
-the <a>credential</a>.
+<a>URI</a> or an object containing a <code>id</code> property. It is RECOMMENDED
+that the <a>URI</a> in the <code>issuer</code> or its <code>id</code> be one
+which, if dereferenced, results in a document containing machine-readable
+information about the <a>issuer</a> that can be used to <a>verify</a> the
+information expressed in the <a>credential</a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -1022,9 +1022,9 @@ The value of the <code>@context</code> <a>property</a> MUST be an ordered set
 where the first item is a <a>URI</a> with the value
 <code>https://www.w3.org/2018/credentials/v1</code>. Subsequent items in the
 array MUST be composed of any combination of <a>URIs</a> or objects that
-express context information. It is RECOMMENDED that dereferencing the
-<a>URIs</a> results in a document containing machine-readable information about
-the context.
+express context information. If a <code>@context</code> <a>URI</a> is
+dereferenced, it is RECOMMENDED that results in a document containing
+machine-readable information about the context.
           </dd>
         </dl>
         <p class="note">


### PR DESCRIPTION
This PR rearranges the words in one sentence to clarify that it is not recommended to dereference a context URI. May help clear up #558
Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/564.html" title="Last updated on Apr 23, 2019, 7:47 PM UTC (f023501)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/564/acec79f...brentzundel:f023501.html" title="Last updated on Apr 23, 2019, 7:47 PM UTC (f023501)">Diff</a>