### PR TITLE
(editorial) deleted redundant word "when"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2334,7 +2334,7 @@ the <a>holder</a> and the <a>verifier</a> to perform future updates of the crede
         </p>
         <p>
 The refresh service is only expected to be used when either 1) the <a>credential</a>
-has expired, or 2) when the <a>issuer</a> does not publish <a>credential</a> status
+has expired, or 2) the <a>issuer</a> does not publish <a>credential</a> status
 information. <a>Issuers</a> are advised not to put the <code>refreshService</code>
 in a <a>verifiable credential</a> that does not contain public information, or
 whose refresh service is not protected in some way.


### PR DESCRIPTION
it should either 1) be in both numbered options (and not precede the `1)`) or 2) be in neither numbered option (and precede the `1)`)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/570.html" title="Last updated on Apr 24, 2019, 2:39 PM UTC (931fc4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/570/420639f...931fc4d.html" title="Last updated on Apr 24, 2019, 2:39 PM UTC (931fc4d)">Diff</a>