### PR TITLE
(editorial) phrasing around either

### DIFF
--- a/index.html
+++ b/index.html
@@ -1412,7 +1412,7 @@ the following <a>property</a>:
         <dl>
           <dt><var>issuer</var></dt>
           <dd>
-The value of the <code>issuer</code> <a>property</a> MUST either be a
+The value of the <code>issuer</code> <a>property</a> MUST be either a
 <a>URI</a> or an object containing a <code>id</code> property. It is RECOMMENDED
 that the <a>URI</a> in the <code>issuer</code> or its <code>id</code> be one
 which, if dereferenced, results in a document containing machine-readable
@@ -3242,8 +3242,8 @@ these encoding rules.
             </p>
 
             <p>
-If the JWS is present, the digital signature either refers to the <a>issuer</a>
-of the <a>verifiable credential</a>, or in the case of a
+If the JWS is present, the digital signature refers to either the <a>issuer</a>
+of the <a>verifiable credential</a> or, in the case of a
 <a>verifiable presentation</a>, the <a>holder</a> of the
 <a>verifiable credential</a>. The JWS proves that the <a>issuer</a> of the JWT
 signed the contained JWT payload and therefore, the <code>proof</code>
@@ -4110,7 +4110,7 @@ same individual.
         </li>
         <li>
 The same <a>verifiable credential</a> is presented to different
-<a>verifiers</a>, and either those <a>verifiers</a> collude, or a third party
+<a>verifiers</a>, and either those <a>verifiers</a> collude or a third party
 has access to transaction records from both <a>verifiers</a>. An observant
 party could infer that the individual presenting the
 <a>verifiable credential</a> is the same person at both services. That is, the
@@ -4430,7 +4430,7 @@ signatures or proofs of any kind. These types of <a>credentials</a> are often
 useful for intermediate storage, or self-asserted information, which is
 analogous to filling out a form on a web page. Implementers should be aware that
 these types of <a>credentials</a> are not <a>verifiable</a> because the
-authorship is either not known or cannot be trusted.
+authorship either is not known or cannot be trusted.
       </p>
     </section>
 


### PR DESCRIPTION
The verb must either be in each alternative clause (and follow the "either"), or precede the "either" (and be in none of the alternative clauses).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/572.html" title="Last updated on Apr 24, 2019, 4:27 PM UTC (ab9b85e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/572/420639f...ab9b85e.html" title="Last updated on Apr 24, 2019, 4:27 PM UTC (ab9b85e)">Diff</a>