### PR TITLE
"final holder" may not be "final"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1820,24 +1820,24 @@ The <a>verifier</a> defines its policies for accepting
 <a>verifiable credentials</a> from <a>holders</a> for its supported actions.
           </li>
           <li>
-The <a>issuer</a> issues a <a>verifiable credential</a> to the <a>holder</a>.
+The <a>issuer</a> issues some <a>verifiable credential(s)</a> to the <a>holder</a>.
           </li>
           <li>
-The <a>holder</a> might pass on its <a>verifiable credentials</a> to another
+The <a>holder</a> might pass on its <a>verifiable credential(s)</a> to another
 <a>holder</a>.
           </li>
           <li>
-The final <a>holder</a> presents its <a>verifiable credentials</a> to the
+The <a>holder</a> presents its <a>verifiable credential(s)</a> to the
 <a>verifier</a> in a <a>verifiable presentation</a>, requesting a supported
 action.
           </li>
           <li>
 The <a>verifier</a> <a>verifies</a> the authenticity of the
-<a>verifiable presentation</a> and <a>verifiable credentials</a>.
+<a>verifiable presentation</a> and <a>verifiable credential(s)</a>.
           </li>
           <li>
 The <a>verifier</a> <a>verifies</a> that the <a>holder</a> possesses the
-<a>verifiable credentials</a>.
+<a>verifiable credential(s)</a>.
           </li>
           <li>
 The <a>verifier</a> decides whether to accept the <a>verifiable credentials</a>

--- a/index.html
+++ b/index.html
@@ -1816,37 +1816,39 @@ how the ecosystem is envisaged to operate, as follows:
 
         <ol>
           <li>
-The <a>verifier</a> defines its policies for accepting
+A <a>verifier</a> defines its own policies for accepting
 <a>verifiable credentials</a> from <a>holders</a> for its supported actions.
           </li>
           <li>
-The <a>issuer</a> issues some <a>verifiable credential(s)</a> to the <a>holder</a>.
+An <a>issuer</a> issues one or more <a>verifiable credentials</a> to 
+a <a>holder</a>.
           </li>
           <li>
-The <a>holder</a> might pass on its <a>verifiable credential(s)</a> to another
-<a>holder</a>.
+A <a>holder</a> might pass on one or more of its <a>verifiable credentials</a> 
+to another <a>holder</a>.
           </li>
           <li>
-The <a>holder</a> presents its <a>verifiable credential(s)</a> to the
-<a>verifier</a> in a <a>verifiable presentation</a>, requesting a supported
+A <a>holder</a> presents one or more of its <a>verifiable credential(s)</a> 
+to a <a>verifier</a> in a <a>verifiable presentation</a>, requesting a supported
 action.
           </li>
           <li>
-The <a>verifier</a> <a>verifies</a> the authenticity of the
-<a>verifiable presentation</a> and <a>verifiable credential(s)</a>.
+A <a>verifier</a> <a>verifies</a> the authenticity of a <a>verifiable presentation</a> 
+and the <a>verifiable credential(s)</a> contained therein.
           </li>
           <li>
-The <a>verifier</a> <a>verifies</a> that the <a>holder</a> possesses the
-<a>verifiable credential(s)</a>.
+A <a>verifier</a> <a>verifies</a> that the <a>holder</a> that made the 
+<a>verifiable presentation</a> possesses the <a>verifiable credential(s)</a>
+contained therein.
           </li>
           <li>
-The <a>verifier</a> decides whether to accept the <a>verifiable credentials</a>
-for the requested action, taking into account its policy, the <a>holder</a>,
-and the contents of the <a>verifiable credentials</a>.
+A <a>verifier</a> decides whether to accept the <a>verifiable credentials</a> 
+for the requested action, taking into account its policy, the presenting 
+<a>holder</a>, and the contents of the <a>verifiable credentials</a>.
           </li>
           <li>
-The <a>verifier</a> either performs the requested action or rejects the
-request.
+A <a>verifier</a> either performs a requested action or rejects the request
+for that action.
           </li>
         </ol>
 


### PR DESCRIPTION
revisiting #363 - I think this deserves changing. "Final holder" suggests that the VC cannot be passed to another holder after this one -- but that's not so. As any step in the lifecycle can recur, and the order of those steps may vary, "final" has no place in it. (I also think this is editorial, but others may have differing opinion.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/577.html" title="Last updated on Apr 24, 2019, 9:54 PM UTC (b1f6df9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/577/6207410...b1f6df9.html" title="Last updated on Apr 24, 2019, 9:54 PM UTC (b1f6df9)">Diff</a>