### PR TITLE
(editorial) attempt to clarify ...

### DIFF
--- a/index.html
+++ b/index.html
@@ -4352,8 +4352,8 @@ ensure the long term viability of systems processing <a>credentials</a>.
 
       <p>
 <a>Verifiable credentials</a> often contain URLs to data that resides
-outside of the <a>verifiable credential</a> itself. Content that exists outside
-a <a>verifiable credential</a>, such as links to images, JSON-LD Contexts, and
+outside of the <a>verifiable credential</a> itself. Linked content that exists 
+outside a <a>verifiable credential</a>, such as images, JSON-LD Contexts, and
 other machine-readable data, are often not protected against tampering because
 the data resides outside of the protection of the
 <a href="#proofs-signatures">proof</a> on the <a>verifiable credential</a>.


### PR DESCRIPTION
"Content that exists outside" is retrieved by dereferencing the "links to" it, which links are found within the VC.  It's not the *links* that exist outside of the VC.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/579.html" title="Last updated on Apr 24, 2019, 8:54 PM UTC (9e5a750)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/579/6207410...9e5a750.html" title="Last updated on Apr 24, 2019, 8:54 PM UTC (9e5a750)">Diff</a>