### PR TITLE
Move Disputes section to Implementation Guidance.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1025,7 +1025,7 @@ related to specific <a>verifiable credentials</a> or
 The value of the <code>@context</code> <a>property</a> MUST be an ordered set
 where the first item is a <a>URI</a> with the value
 <code>https://www.w3.org/2018/credentials/v1</code>. Subsequent items in the
-array MUST express context information and be composed of any combination 
+array MUST express context information and be composed of any combination
 of <a>URIs</a> and/or objects. It is RECOMMENDED that each <a>URI</a> in the
 <code>@context</code> be one which, if dereferenced, results in a document
 containing machine-readable information about the <code>@context</code>.
@@ -2896,116 +2896,18 @@ Recommendation phase.
 
       </section>
 
-      <section>
+      <section class="informative">
         <h3>Disputes</h3>
 
         <p>
-There are at least two different cases to consider for an <a>entity</a>
-wanting to dispute a <a>credential</a> issued by an <a>issuer</a>:
+There are a variety of reasons that an <a>entity</a> might want to dispute
+some or all of the <a>claims</a> made by an existing <a>credential</a>.
+This particular area of study is rapidly evolving and developers that are
+interested in publishing <a>credentials</a> that dispute the veracity of
+other <a>credentials</a> are urged to read the section related to
+disputes in the Verifiable Credentials Implementation Guidance
+[[VC-IMP-GUIDE]].
         </p>
-
-        <ul>
-          <li>
-A <a>subject</a> disputes a claim made by the <a>issuer</a>. For example, the
-<code>address</code> <a>property</a> is incorrect or out of date.
-          </li>
-          <li>
-An <a>entity</a> disputes a potentially false claim made by the <a>issuer</a>
-about a different <a>subject</a>. For example, an imposter claims the social
-security number for an <a>entity</a>.
-          </li>
-        </ul>
-
-        <p>
-Only a <a>subject</a> of a <a>verifiable credential</a> is entitled to issue
-a <code>DisputeCredential</code>. A <code>DisputeCredential</code> issued by
-anyone other than the <a>subject</a> should be disregarded by the
-<a>verifier</a>, unless the <a>verifier</a> has some other way of determining
-the truth of the dispute. This is to prevent denial of service attacks whereby
-an attacker falsely disputes a true claim.
-        </p>
-
-        <p>
-The mechanism for issuing a <code>DisputeCredential</code> is the same as
-for a regular <a>credential</a> except that the <code>credentialSubject</code>
-identifier in the <code>DisputeCredential</code> property is the identifier of
-the disputed <a>credential</a>.
-        </p>
-
-        <p>
-For example, if a <a>credential</a> with an identifier of
-<code>https://example.org/credentials/245</code> is disputed, an <a>entity</a>
-can issue one of the <a>credentials</a> shown below. In the first example, the
-<a>subject</a> might present this to the <a>verifier</a> along with the disputed
-<a>credential</a>. In the second example, the <a>entity</a> might publish the
-<code>DisputeCredential</code> in a public venue to make it known that the
-<a>credential</a> is disputed.
-        </p>
-
-        <pre class="example nohighlight" title="A subject disputes a credential">
-{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
-  ],
-  "id": "http://example.com/credentials/123",
-  "type": ["VerifiableCredential", "DisputeCredential"],
-  <span class="highlight">"credentialSubject": {
-    "id": "http://example.com/credentials/245",
-    "currentStatus": "Disputed",
-    "statusReason": {
-      "@value": "Address is out of date",
-      "@language": "en"
-    },
-  }</span>,
-  "issuer": "https://example.com/people#me",
-  "issuanceDate": "2017-12-05T14:27:42Z",
-  "proof": { ... }
-}
-        </pre>
-
-
-        <pre class="example nohighlight" title="Another entity disputes a credential">
-{
-  "@context": "https://w3id.org/credentials/v1",
-  "id": "http://example.com/credentials/321",
-  "type": ["VerifiableCredential", "DisputeCredential"],
-  <span class="highlight">"credentialSubject": {
-    "id": "http://example.com/credentials/245",
-    "currentStatus": "Disputed",
-    "statusReason": {
-      "@value": "Credential contains disputed statements",
-      "@language": "en"
-    },
-    "disputedClaim": {
-      "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-      "address": "Is Wrong"
-    }
-  }</span>,
-  "issuer": "https://example.com/people#me",
-  "issuanceDate": "2017-12-05T14:27:42Z",
-  "proof": { ... }
-}
-        </pre>
-
-<p> In the above <a>verifiable credential</a> the <a>issuer</a> is claiming that
-the address in the disputed <a>verifiable credential</a> is wrong. For example,
-the <a>subject</a> might wrongly be claiming to have the same address as that of
-the <a>issuer</a>.
-</p>
-        <p class="note">
-If a <a>credential</a> does not have an identifier, a content-addressed
-identifier can be used to identify the disputed <a>credential</a>. Similarly,
-content-addressed identifiers can be used to uniquely identify individual
-claims.
-        </p>
-
-        <p class="issue atrisk">
-The dispute feature may change significantly during the W3C Candidate
-Recommendation process including possibly being removed if there is not enough
-support from implementations for the feature.
-        </p>
-
       </section>
 
       <section class="informative">


### PR DESCRIPTION
Related to #545.

The Disputes section now exists in the implementation guidance here: https://w3c.github.io/vc-imp-guide/#disputes


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/599.html" title="Last updated on May 7, 2019, 4:06 AM UTC (8046ce0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/599/5577f77...8046ce0.html" title="Last updated on May 7, 2019, 4:06 AM UTC (8046ce0)">Diff</a>