### PR TITLE
clarify when type property is required

### DIFF
--- a/index.html
+++ b/index.html
@@ -1276,7 +1276,7 @@ objects that MUST have a <a>type</a> specified.
 <a>verifiable credential</a>&nbsp;object <br />(a subclass of <a href="#credentials">Credential</a>&nbsp;object)
               </td>
               <td>
-<code>VerifiableCredential</code> and a more specific
+<code>VerifiableCredential</code> and, optionally, a more specific
 <a>verifiable credential</a> <a>type</a>. For example,<br>
 <code>"type": ["VerifiableCredential", "UniversityDegreeCredential"]</code>
               </td>

--- a/index.html
+++ b/index.html
@@ -1219,7 +1219,10 @@ expression of type information.
 
         <p>
 <a>Verifiable credentials</a> and <a>verifiable presentations</a> MUST have a
-<code>type</code> <a>property</a>.
+<code>type</code> <a>property</a>; in other words, any <a>credential</a> or 
+<a>presentation</a> that lacks a <code>type</code> <a>property</a> <em>is not 
+verifiable<em>, so is not a <a>verifiable credential</a> nor a 
+<a>verifiable presentation</a>.
         </p>
 
         <dl>
@@ -1228,9 +1231,9 @@ expression of type information.
 The value of the <code>type</code> <a>property</a> MUST be, or map to (via
 interpretation of the <code>@context</code> property), one or more <a>URIs</a>.
 If more than one <a>URI</a> is provided, the <a>URIs</a> MUST be interpreted
-as an unordered set. Syntactic conveniences, such as JSON-LD terms, SHOULD
-be used to ease developer usage. It is RECOMMENDED that each <a>URI</a> in the
-<code>type</code> be one which, if dereferenced, results in a document
+as an unordered set. Syntactic conveniences SHOULD be used to ease developer usage; 
+such conveniences may include JSON-LD terms. It is RECOMMENDED that each <a>URI</a> 
+in the <code>type</code> be one which, if dereferenced, results in a document
 containing machine-readable information about the <code>type</code>.
           </dd>
         </dl>
@@ -1255,7 +1258,7 @@ containing machine-readable information about the <code>type</code>.
         </pre>
 
         <p>
-With respect to this specification, the following table lists examples of
+With respect to this specification, the following table lists the
 objects that MUST have a <a>type</a> specified.
         </p>
 
@@ -1270,12 +1273,34 @@ objects that MUST have a <a>type</a> specified.
           <tbody>
             <tr>
               <td>
+<a>verifiable credential</a>&nbsp;object <br />(a subclass of <a href="#credentials">Credential</a>&nbsp;object)
+              </td>
+              <td>
+<code>VerifiableCredential</code> and a more specific
+<a>verifiable credential</a> <a>type</a>. For example,<br>
+<code>"type": ["VerifiableCredential", "UniversityDegreeCredential"]</code>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
 <a href="#credentials">Credential</a>&nbsp;object
               </td>
               <td>
 <code>VerifiableCredential</code> and a more specific
 <a>verifiable credential</a> <a>type</a>. For example,<br>
 <code>"type": ["VerifiableCredential", "UniversityDegreeCredential"]</code>
+              </td>
+            </tr>
+
+            <tr>
+              <td>
+<a>verifiable presentation</a>&nbsp;object <br />(a subclass of <a href="#presentations">Presentation</a>&nbsp;object)
+              </td>
+              <td>
+<code>VerifiablePresentation</code> and a more specific
+<a>verifiable presentation</a> <a>type</a>. For example,<br>
+<code>"type": ["VerifiablePresentation", "CredentialManagerPresentation"]</code>
               </td>
             </tr>
 

--- a/index.html
+++ b/index.html
@@ -1298,7 +1298,7 @@ objects that MUST have a <a>type</a> specified.
 <a>verifiable presentation</a>&nbsp;object <br />(a subclass of <a href="#presentations">Presentation</a>&nbsp;object)
               </td>
               <td>
-<code>VerifiablePresentation</code> and a more specific
+<code>VerifiablePresentation</code> and, optionally, a more specific
 <a>verifiable presentation</a> <a>type</a>. For example,<br>
 <code>"type": ["VerifiablePresentation", "CredentialManagerPresentation"]</code>
               </td>


### PR DESCRIPTION
to address #608


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/631.html" title="Last updated on May 16, 2019, 3:25 PM UTC (9bfd788)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/631/66e81c7...9bfd788.html" title="Last updated on May 16, 2019, 3:25 PM UTC (9bfd788)">Diff</a>