### PR TITLE
Zkp section clarifying language

### DIFF
--- a/index.html
+++ b/index.html
@@ -2926,11 +2926,11 @@ credentials in a ZKP <a>presentation</a>.
         </figure>
 
         <p class="note">
-Important details regarding the format for the <a>verifiable credential</a>
-definition and of the proofs are omitted on purpose because they are outside of
-the scope of this document. The purpose of this section is to guide implementers
-wanting to extend <a>verifiable credentials</a> and
-<a>verifiable presentations</a> to support zero-knowledge proof systems.
+Important details regarding the format for the credential definition and of the
+proofs are omitted on purpose because they are outside of the scope of this
+document. The purpose of this section is to guide implementers who want to
+extend <a>verifiable credentials</a> and <a>verifiable presentations</a> to
+support zero-knowledge proof systems.
         </p>
 
         <p class="issue atrisk">

--- a/index.html
+++ b/index.html
@@ -2770,14 +2770,16 @@ MUST contain a:
 
         <ul>
           <li>
-<a>Verifiable credential</a> definition that can be used by all parties to
-perform various cryptographic operations in zero-knowledge.
+Credential definition, using the <code>credentialSchema</code> <a>property</a>,
+that can be used by all parties to perform various cryptographic operations in
+zero-knowledge.
           </li>
           <li>
-Proof that enables <a>verifiable presentations</a> to be derived that prove
-information contained in the original <a>verifiable credential</a> in
-zero-knowledge. The zero-knowledge <a>verifiable presentation</a> must not
-reveal any information not intended to be revealed by the <a>holder</a>.
+Proof, using the <code>proof</code> <a>property</a>, that can be used to derive
+<a>verifiable presentations</a> that present information contained in the
+original <a>verifiable credential</a> in zero-knowledge. The zero-knowledge
+<a>verifiable presentation</a> must not reveal any information not intended to
+be revealed by the <a>holder</a>.
           </li>
         </ul>
 
@@ -2811,7 +2813,7 @@ of the <a>verifiable credential</a> in a way that supports the privacy of the
     }
   },
   <span class="highlight">"proof": {
-    "type": "AnonCredv1",
+    "type": "CLSignature2019",
     "issuerData": "5NQ4TgzNfSQxoLzf2d5AV3JNiCdMaTgm...BXiX5UggB381QU7ZCgqWivUmy4D",
     "attributes": "pPYmqDvwwWBDPNykXVrBtKdsJDeZUGFA...tTERiLqsZ5oxCoCSodPQaggkDJy",
     "signature": "8eGWSiTiWtEA8WnBwX4T259STpxpRKuk...kpFnikqqSP3GMW7mVxC4chxFhVs",

--- a/index.html
+++ b/index.html
@@ -2839,20 +2839,22 @@ when they are to be used in zero-knowledge systems:
 
         <ul>
           <li>
-All derived <a>verifiable credentials</a> MUST contain a reference to the
-<a>verifiable credential</a> definition used to generate the derived proof.
+Each derived <a>verifiable credential</a> within a
+<a>verifiable presentation</a> MUST have a <code>credentialSchema</code>
+<a>property</a>. This allows the derived <a>verifiable credential</a> reference
+the credential definition used to generate the derived proof.
           </li>
           <li>
-All derived proofs in <a>verifiable credentials</a> MUST NOT leak information
-that would enable the <a>verifier</a> to correlate the <a>holder</a> presenting
-the <a>verifiable credential</a>.
+A <a>verifiable presentation</a> MUST NOT leak information that would enable
+the <a>verifier</a> to correlate the <a>holder</a> across multiple
+<a>verifiable presentations</a>.
           </li>
           <li>
-The <a>verifiable presentation</a> MUST contain a proof enabling the
-<a>verifier</a> to ascertain that all <a>verifiable credentials</a> in the
-<a>verifiable presentation</a> were issued to the same <a>holder</a> without
-leaking personally identifiable information that the <a>holder</a> did not
-intend to share.
+The <a>verifiable presentation</a> MUST contain a <code>proof</code>
+<a>property</a> to enable the <a>verifier</a> to ascertain that all derived
+<a>verifiable credentials</a> in the <a>verifiable presentation</a> were issued
+to the same <a>holder</a> without leaking personally identifiable information
+that the <a>holder</a> did not intend to share.
           </li>
         </ul>
 


### PR DESCRIPTION
This PR addresses issue #639 

It makes the following changes:

- At some some point the term `credential definition` was changed to `verifiable credential definition`. This was incorrect and has been reverted.
- The verifiable credential example proof type was changed to one that may be found in the example context.
- The normative language in this section was quite fuzzy. Language was added to the normative statements to clarify which data model elements are required in order to enable zero-knowledge proof mechanisms.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/640.html" title="Last updated on May 24, 2019, 7:32 PM UTC (e5933d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/640/66e81c7...brentzundel:e5933d3.html" title="Last updated on May 24, 2019, 7:32 PM UTC (e5933d3)">Diff</a>