### PR TITLE
Add multiple subjects example.

### DIFF
--- a/contexts/credentials/examples/v1
+++ b/contexts/credentials/examples/v1
@@ -28,6 +28,7 @@
     "referenceId": "ex:referenceId",
     "documentPresence": "ex:documentPresence",
     "evidenceDocument": "ex:evidenceDocument",
+    "spouse": "schema:spouse",
     "subjectPresence": "ex:subjectPresence",
     "verifier": {"@id": "ex:verifier", "@type": "@id"}
   }]

--- a/index.html
+++ b/index.html
@@ -1467,9 +1467,8 @@ a set of objects that contain one or more properties that are each related to a
 
         <p>
 It is possible to express information related to multiple <a>subjects</a> in a
-<a>verifiable credential</a>. The example below specifies two subjects,
-the first is a recipient of a Bachelor Degree, the second is the university
-that granted the degree. Note the use of array notation to associate
+<a>verifiable credential</a>. The example below specifies two subjects that are
+spouses. Note the use of array notation to associate
 multiple subjects with the <code>credentialSubject</code> property.
         </p>
 
@@ -1483,14 +1482,12 @@ multiple subjects with the <code>credentialSubject</code> property.
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "credentialSubject": <span class="highlight">[{
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "alumniOf": "did:example:c276e12ec21ebfeb1f712ebc6f1",
-    "degree": {
-      "type": "BachelorDegree",
-      "name": "Bachelor of Science And Arts"
-    }
+    "name": "Jayden Doe",
+    "spouse": "did:example:c276e12ec21ebfeb1f712ebc6f1"
   }, {
     "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
-    "name": "Example University"
+    "name": "Morgan Doe",
+    "spouse": "did:example:ebfeb1f712ebc6f1c276e12ec21"
   }]</span>,
   "proof": { ... }
 }

--- a/index.html
+++ b/index.html
@@ -1479,7 +1479,7 @@ multiple subjects with the <code>credentialSubject</code> property.
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "http://example.edu/credentials/3732",
-  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "type": ["VerifiableCredential", "RelationshipCredential"],
   "credentialSubject": <span class="highlight">[{
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "name": "Jayden Doe",

--- a/index.html
+++ b/index.html
@@ -1465,6 +1465,37 @@ a set of objects that contain one or more properties that are each related to a
 }
         </pre>
 
+        <p>
+It is possible to express information related to multiple <a>subjects</a> in a
+<a>verifiable credential</a>. The example below specifies two subjects,
+the first is a recipient of a Bachelor Degree, the second is the university
+that granted the degree. Note the use of array notation to associate
+multiple subjects with the <code>credentialSubject</code> property.
+        </p>
+
+        <pre class="example nohighlight" title="Specifying multiple subjects in a verifiable credential">
+{
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "credentialSubject": <span class="highlight">[{
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "alumniOf": "did:example:c276e12ec21ebfeb1f712ebc6f1",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science And Arts"
+    }
+  }, {
+    "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
+    "name": "Example University"
+  }]</span>,
+  "proof": { ... }
+}
+        </pre>
+
       </section>
 
       <section>


### PR DESCRIPTION
Add an example demonstrating how multiple subjects can be associated with the `credentialSubject` property.

Related to #518.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/644.html" title="Last updated on Jun 8, 2019, 3:50 PM UTC (ac18b4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/644/446c421...ac18b4d.html" title="Last updated on Jun 8, 2019, 3:50 PM UTC (ac18b4d)">Diff</a>