### PR TITLE
Fix TR links to point to new vc-data-model URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         specStatus: "CR",
 
         // the specification's short name, as in http://www.w3.org/TR/short-name/
-        shortName: "verifiable-claims-data-model",
+        shortName: "vc-data-model",
 
         // subtitle for the spec
         subtitle: "Expressing verifiable information on the Web",
@@ -418,24 +418,24 @@ of key topics that readers might find useful, including:
         <ul>
           <li>
 A more thorough explanation of the
-<a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-roles">roles</a>
+<a href="https://www.w3.org/TR/vc-use-cases/#user-roles">roles</a>
 introduced above
           </li>
           <li>
 The
-<a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-needs">needs</a>
+<a href="https://www.w3.org/TR/vc-use-cases/#user-needs">needs</a>
 identified in market verticals, such as education, finance, healthcare, retail,
 professional licensing, and government
           </li>
           <li>
 Common
-<a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-tasks">tasks</a>
+<a href="https://www.w3.org/TR/vc-use-cases/#user-tasks">tasks</a>
 performed by the roles in the ecosystem, as well as their associated
 requirements
           </li>
           <li>
 Common
-<a href="https://www.w3.org/TR/verifiable-claims-use-cases/#user-sequences">sequences
+<a href="https://www.w3.org/TR/vc-use-cases/#user-sequences">sequences
 and flows</a> identified by the Working Group.
           </li>
         </ul>

--- a/vocab/credentials.html
+++ b/vocab/credentials.html
@@ -20,7 +20,7 @@ var respecConfig = {
     },
     specStatus:  "base",
     shortName:   "vc-vocab",
-    publishDate: "2019-03-23",
+    publishDate: "2019-05-26",
     thisVersion: "https://w3.org/2018/credentials",
     doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
@@ -102,11 +102,11 @@ var respecConfig = {
         <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2019-03-23</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2019-05-26</time></dd>
         <dt>Version Info:</dt>
         <dd><a href="" property="owl:versionInfo"></a></dd>
         <dt>See Also:</dt>
-          <dd><a href="https://www.w3.org/TR/verifiable-claims-data-model/" property="rdfs:seeAlso">https://www.w3.org/TR/verifiable-claims-data-model/</a></dd>
+          <dd><a href="https://www.w3.org/TR/vc-data-model/" property="rdfs:seeAlso">https://www.w3.org/TR/vc-data-model/</a></dd>
       </dl>
     </section>
     <section id="sotd">

--- a/vocab/credentials.jsonld
+++ b/vocab/credentials.jsonld
@@ -148,9 +148,9 @@
     "dc:description": {
       "en": "This document describes the RDFS vocabulary description used for Verifiable Credentials [[VERIFIABLE-CREDENTIALS]] along with the default JSON-LD Context."
     },
-    "dc:date": "2019-03-23",
+    "dc:date": "2019-05-26",
     "rdfs:seeAlso": [
-      "https://www.w3.org/TR/verifiable-claims-data-model/"
+      "https://www.w3.org/TR/vc-data-model/"
     ],
     "rdfs_classes": [
       {

--- a/vocab/credentials.ttl
+++ b/vocab/credentials.ttl
@@ -10,9 +10,9 @@
 cred: a owl:Ontology;
   dc:title "Verifiable Credentials Vocabulary"@en;
   dc:description """This document describes the RDFS vocabulary description used for Verifiable Credentials [[VERIFIABLE-CREDENTIALS]] along with the default JSON-LD Context."""@en;
-  dc:date "2019-03-23"^^xsd:date;
+  dc:date "2019-05-26"^^xsd:date;
   dc:imports ;
-  rdfs:seeAlso <https://www.w3.org/TR/verifiable-claims-data-model/>;
+  rdfs:seeAlso <https://www.w3.org/TR/vc-data-model/>;
 
 # Class definitions
 cred:JsonSchemaValidator2018 a rdfs:Class;

--- a/vocab/vocab.csv
+++ b/vocab/vocab.csv
@@ -3,7 +3,7 @@ id,type,label,subClassOf,domain,range,@type,@container,comment
 cred,prefix,,https://w3.org/2018/credentials#,,,,,
 odrl,prefix,,http://www.w3.org/ns/odrl/2/,,,,,
 xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,
-,rdfs:seeAlso,,https://www.w3.org/TR/verifiable-claims-data-model/,,,,,
+,rdfs:seeAlso,,https://www.w3.org/TR/vc-data-model/,,,,,
 JsonSchemaValidator2018,rdfs:Class,,,,,,,A type of validator that can be used to syntactically validate JSON documents using the JSON Schema language.
 ManualRefreshService2018,rdfs:Class,,cred:RefreshService,,,,,A type of refresh service that must be interacted with in a manual fashion.
 RefreshService,rdfs:Class,Refresh Service,,,,,,A refresh service is a mechanism that can be utilized by software agents to retrieve an updated copy of a `verifiable credential`.


### PR DESCRIPTION
Updates links to point to the appropriate location after a rename from `verifiable-claims-data-model` to `vc-data-model`.

Related to #526.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/645.html" title="Last updated on May 26, 2019, 6:41 PM UTC (f5cb934)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/645/446c421...f5cb934.html" title="Last updated on May 26, 2019, 6:41 PM UTC (f5cb934)">Diff</a>