### PR TITLE
Add "@context" in verifiable credentials embedded in verifiable presentation examples 

### DIFF
--- a/index.html
+++ b/index.html
@@ -958,7 +958,11 @@ which is then composed into a <a>verifiable presentation</a>. The
   ],
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
   <span class='comment'>// the verifiable credential issued in the previous example</span>
-  "verifiableCredential": [{
+    "verifiableCredential": [{
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+    ],
     "id": "http://example.edu/credentials/1872",
     "type": ["VerifiableCredential", "AlumniCredential"],
     "issuer": "https://example.edu/issuers/565049",
@@ -2613,6 +2617,10 @@ in an archive.
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
   "verifiableCredential": [{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
+    ],
     "id": "http://example.edu/credentials/3732",
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
     "issuer": "https://example.edu/issuers/14",
@@ -2912,25 +2920,25 @@ that the <a>holder</a> did not intend to share.
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
   "verifiableCredential": [
     {
-        "@context": [
-          "https://www.w3.org/2018/credentials/v1",
-          "https://www.w3.org/2018/credentials/examples/v1"
-        ],
-        "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-        <span class="highlight">"credentialSchema": {
-            "id": "did:example:cdf:35LB7w9ueWbagPL94T9bMLtyXDj9pX5o",
-            "type": "did:example:schema:22KpkXgecryx9k7N6XN1QoN3gXwBkSU8SfyyYQG"
-        }</span>,
-    "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
-    "credentialSubject": {
+      "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
+      ],
+      "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+      <span class="highlight">"credentialSchema": {
+        "id": "did:example:cdf:35LB7w9ueWbagPL94T9bMLtyXDj9pX5o",
+        "type": "did:example:schema:22KpkXgecryx9k7N6XN1QoN3gXwBkSU8SfyyYQG"
+      }</span>,
+      "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
+      "credentialSubject": {
         "degreeType": "BachelorDegree",
         "degreeSchool": "College of Engineering"
       },
       <span class="highlight">"proof": {
-      "type": "AnonCredDerivedCredentialv1",
-      "primaryProof": "cg7wLNSi48K5qNyAVMwdYqVHSMv1Ur8i...Fg2ZvWF6zGvcSAsym2sgSk737",
-      "nonRevocationProof": "mu6fg24MfJPU1HvSXsf3ybzKARib4WxG...RSce53M6UwQCxYshCuS3d2h"
-    }</span>
+        "type": "AnonCredDerivedCredentialv1",
+        "primaryProof": "cg7wLNSi48K5qNyAVMwdYqVHSMv1Ur8i...Fg2ZvWF6zGvcSAsym2sgSk737",
+        "nonRevocationProof": "mu6fg24MfJPU1HvSXsf3ybzKARib4WxG...RSce53M6UwQCxYshCuS3d2h"
+      }</span>
   }],
   <span class="highlight">"proof": {
     "type": "AnonCredPresentationProofv1",
@@ -5515,8 +5523,8 @@ verifiable credential that was passed to it by the subject">
     },
     {
       "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://www.w3.org/2018/credentials/examples/v1"
+        "https://www.w3.org/2018/credentials/v1",
+        "https://www.w3.org/2018/credentials/examples/v1"
       ],
       "id": "https://example.com/VC/123456789",
       "type": ["VerifiableCredential", "PrescriptionCredential"],

--- a/index.html
+++ b/index.html
@@ -958,10 +958,10 @@ which is then composed into a <a>verifiable presentation</a>. The
   ],
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
   <span class='comment'>// the verifiable credential issued in the previous example</span>
-    "verifiableCredential": [{
-      "@context": [
-        "https://www.w3.org/2018/credentials/v1",
-        "https://www.w3.org/2018/credentials/examples/v1"
+  "verifiableCredential": [{
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/examples/v1"
     ],
     "id": "http://example.edu/credentials/1872",
     "type": ["VerifiableCredential", "AlumniCredential"],


### PR DESCRIPTION
Addresses examples of verifiable presentations raised in issue #654.
This pull request does not change the base context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ken-ebert/vc-data-model/pull/655.html" title="Last updated on May 29, 2019, 7:59 PM UTC (07e6311)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/655/d18642b...ken-ebert:07e6311.html" title="Last updated on May 29, 2019, 7:59 PM UTC (07e6311)">Diff</a>