### PR TITLE
Clarify type description

### DIFF
--- a/index.html
+++ b/index.html
@@ -956,7 +956,7 @@ which is then composed into a <a>verifiable presentation</a>. The
     "https://www.w3.org/2018/credentials/v1",
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
-  "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
+  "type": "VerifiablePresentation",
   <span class='comment'>// the verifiable credential issued in the previous example</span>
   "verifiableCredential": [{
     "id": "http://example.edu/credentials/1872",
@@ -1377,7 +1377,8 @@ of this specification who want to support interoperable extensibility, do.
         </p>
 
         <p>
-All <a>credentials</a>, <a>presentations</a>, and encapsulated objects MUST
+If <a>credentials</a>, <a>presentations</a>, and encapsulated objects have
+properties beyond those contained in their respective base types, they MUST
 specify, or be associated with, additional more narrow <a>types</a> (like
 <code>UniversityDegreeCredential</code>, for example) so software systems can
 process this additional information.
@@ -2611,7 +2612,7 @@ in an archive.
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-  "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
+  "type": ["VerifiablePresentation", "TermsOfUsePresentation"],
   "verifiableCredential": [{
     "id": "http://example.edu/credentials/3732",
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -2909,7 +2910,7 @@ that the <a>holder</a> did not intend to share.
     "https://www.w3.org/2018/credentials/v1",
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
-  "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
+  "type": "VerifiablePresentation",
   "verifiableCredential": [
     {
         "@context": [
@@ -3583,7 +3584,7 @@ header parameter.
       "https://www.w3.org/2018/credentials/v1",
       "https://www.w3.org/2018/credentials/examples/v1"
     ],
-    "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
+    "type": ["VerifiablePresentation"],
     <span class="comment">// base64url-encoded JWT as string</span>
     "verifiableCredential": ["..."]
   }
@@ -5492,8 +5493,8 @@ verifiable credential that was passed to it by the subject">
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "did:example:76e12ec21ebhyu1f712ebc6f1z2",
-  "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
-  "credential": [
+  "type": ["VerifiablePresentation"],
+  "verifiableCredential": [
     {
      "@context": [
        "https://www.w3.org/2018/credentials/v1",

--- a/index.html
+++ b/index.html
@@ -1377,11 +1377,14 @@ of this specification who want to support interoperable extensibility, do.
         </p>
 
         <p>
-If <a>credentials</a>, <a>presentations</a>, and encapsulated objects have
-properties beyond those described in their respective base types, they MUST
-specify, or be associated with, additional more narrow <a>types</a> (such as
+All <a>credentials</a>, <a>presentations</a>, and encapsulated objects MUST
+specify, or be associated with, additional more narrow <a>types</a> (like
 <code>UniversityDegreeCredential</code>, for example) so software systems can
-process this additional information.
+process this additional information. The specification of these additional more
+narrow types could be done in the object within which the additional information
+is found, rather than at a higher level such as the <code>type</code>
+<a>property</a> of the <a>credential</a> or <a>presentation</a>. It is also
+possible for the additional more narrow types to be implicit.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -2615,7 +2615,7 @@ in an archive.
     "https://www.w3.org/2018/credentials/examples/v1"
   ],
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-  "type": ["VerifiablePresentation", "TermsOfUsePresentation"],
+  "type": ["VerifiablePresentation"],
   "verifiableCredential": [{
     "id": "http://example.edu/credentials/3732",
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/index.html
+++ b/index.html
@@ -1378,8 +1378,8 @@ of this specification who want to support interoperable extensibility, do.
 
         <p>
 If <a>credentials</a>, <a>presentations</a>, and encapsulated objects have
-properties beyond those contained in their respective base types, they MUST
-specify, or be associated with, additional more narrow <a>types</a> (like
+properties beyond those described in their respective base types, they MUST
+specify, or be associated with, additional more narrow <a>types</a> (such as
 <code>UniversityDegreeCredential</code>, for example) so software systems can
 process this additional information.
         </p>


### PR DESCRIPTION
Added text clarifying when more than base types are needed for verifiable credentials, verifiable presentations, and embedded objects; and fixed examples of verifiable presentations.
Resolves issue #653 

Signed-off-by: Brent <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/658.html" title="Last updated on Jun 11, 2019, 4:44 PM UTC (12681f9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/658/d18642b...brentzundel:12681f9.html" title="Last updated on Jun 11, 2019, 4:44 PM UTC (12681f9)">Diff</a>