### PR TITLE
Property-scope schema and refresh types.

### DIFF
--- a/contexts/credentials/v1
+++ b/contexts/credentials/v1
@@ -6,9 +6,6 @@
     "id": "@id",
     "type": "@type",
 
-    "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018",
-    "ManualRefreshService2018": "cred:ManualRefreshService2018",
-
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
       "@context": {
@@ -22,7 +19,13 @@
         "sec": "https://w3id.org/security#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
 
-        "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
+        "credentialSchema": {
+          "@id": "cred:credentialSchema",
+          "@type": "@id",
+          "@context": {
+            "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018"
+          }
+        },
         "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
         "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
         "evidence": {"@id": "cred:evidence", "@type": "@id"},
@@ -31,7 +34,13 @@
         "issuer": {"@id": "cred:issuer", "@type": "@id"},
         "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
         "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
-        "refreshService": {"@id": "cred:refreshService", "@type": "@id"},
+        "refreshService": {
+          "@id": "cred:refreshService",
+          "@type": "@id",
+          "@context": {
+            "ManualRefreshService2018": "cred:ManualRefreshService2018"
+          }
+        },
         "termsOfUse": {"@id": "cred:termsOfUse", "@type": "@id"},
         "validFrom": {"@id": "cred:validFrom", "@type": "xsd:dateTime"},
         "validUntil": {"@id": "cred:validUntil", "@type": "xsd:dateTime"}
@@ -75,7 +84,8 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,
@@ -113,7 +123,8 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,
@@ -151,7 +162,8 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,
@@ -183,7 +195,8 @@
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,

--- a/index.html
+++ b/index.html
@@ -4957,7 +4957,7 @@ franchise. Policy information expressed by the <a>issuer</a> in the
   <section class="appendix informative">
     <h2>Base Context</h2>
       The base context located at <code>https://www.w3.org/2018/credentials/v1</code> with SHA-256 digest
-<strong><code>cb38e23820de73d2e84ff507d75da540bd423636453af198b319c1ca01ee7b1e</code></strong>
+<strong><code>80deba1fd48ae51249f49299870f9b2632017c5ec4cb57bb614f6991fb19d9c3</code></strong>
 can be used to implement a local cached copy.  The aforementioned context is provided in this section for convenience.
 
 <pre class="informative">
@@ -4968,9 +4968,6 @@ can be used to implement a local cached copy.  The aforementioned context is pro
 
     "id": "@id",
     "type": "@type",
-
-    "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018",
-    "ManualRefreshService2018": "cred:ManualRefreshService2018",
 
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
@@ -4985,7 +4982,13 @@ can be used to implement a local cached copy.  The aforementioned context is pro
         "sec": "https://w3id.org/security#",
         "xsd": "http://www.w3.org/2001/XMLSchema#",
 
-        "credentialSchema": {"@id": "cred:credentialSchema", "@type": "@id"},
+        "credentialSchema": {
+          "@id": "cred:credentialSchema",
+          "@type": "@id",
+          "@context": {
+            "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018"
+          }
+        },
         "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
         "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
         "evidence": {"@id": "cred:evidence", "@type": "@id"},
@@ -4994,7 +4997,13 @@ can be used to implement a local cached copy.  The aforementioned context is pro
         "issuer": {"@id": "cred:issuer", "@type": "@id"},
         "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
         "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
-        "refreshService": {"@id": "cred:refreshService", "@type": "@id"},
+        "refreshService": {
+          "@id": "cred:refreshService",
+          "@type": "@id",
+          "@context": {
+            "ManualRefreshService2018": "cred:ManualRefreshService2018"
+          }
+        },
         "termsOfUse": {"@id": "cred:termsOfUse", "@type": "@id"},
         "validFrom": {"@id": "cred:validFrom", "@type": "xsd:dateTime"},
         "validUntil": {"@id": "cred:validUntil", "@type": "xsd:dateTime"}
@@ -5038,7 +5047,8 @@ can be used to implement a local cached copy.  The aforementioned context is pro
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,
@@ -5076,7 +5086,8 @@ can be used to implement a local cached copy.  The aforementioned context is pro
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,
@@ -5114,7 +5125,8 @@ can be used to implement a local cached copy.  The aforementioned context is pro
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,
@@ -5146,7 +5158,8 @@ can be used to implement a local cached copy.  The aforementioned context is pro
         "jws": "sec:jws",
         "nonce": "sec:nonce",
         "proofPurpose": {
-          "@id": "sec:proofPurpose", "@type": "@vocab",
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
           "@context": {
             "@version": 1.1,
             "@protected": true,


### PR DESCRIPTION
This PR modifies the VC v1 context to property-scope the core types for `credentialSchema` and `refreshService`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/660.html" title="Last updated on Jun 6, 2019, 5:24 PM UTC (407f756)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/660/d18642b...407f756.html" title="Last updated on Jun 6, 2019, 5:24 PM UTC (407f756)">Diff</a>