### PR TITLE
fix subclass/superclass typing requirement mismatch

### DIFF
--- a/index.html
+++ b/index.html
@@ -1349,7 +1349,7 @@ objects that MUST have a <a>type</a> specified.
 <a href="#credentials">Credential</a>&nbsp;object
               </td>
               <td>
-<code>VerifiableCredential</code> and a more specific
+<code>VerifiableCredential</code> and, optionally, a more specific
 <a>verifiable credential</a> <a>type</a>. For example,<br>
 <code>"type": ["VerifiableCredential", "UniversityDegreeCredential"]</code>
               </td>
@@ -1371,7 +1371,7 @@ objects that MUST have a <a>type</a> specified.
 <a href="#presentations">Presentation</a>&nbsp;object
               </td>
               <td>
-<code>VerifiablePresentation</code> and a more specific
+<code>VerifiablePresentation</code> and, optionally, a more specific
 <a>verifiable presentation</a> <a>type</a>. For example,<br>
 <code>"type": ["VerifiablePresentation", "CredentialManagerPresentation"]</code>
               </td>


### PR DESCRIPTION
*In the summary table,* change the type requirements of the superclasses (`Credential` and `Presentation`) to match the type requirements of the subclasses (`VerifiableCredential` and `VerifiablePresentation`).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/685.html" title="Last updated on Jul 11, 2019, 2:55 PM UTC (e158b5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/685/96dc09e...e158b5c.html" title="Last updated on Jul 11, 2019, 2:55 PM UTC (e158b5c)">Diff</a>