### PR TITLE
Implement VCWG Resolution wrt. implicit types. Related to #682.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1464,7 +1464,7 @@ representation.
 
         <p class="note">
 The type system used in the data model described in this specification allows
-for multiple ways to associate types with data, implementers and authors are
+for multiple ways to associate types with data. Implementers and authors are
 urged to read the section on typing in the Verifiable Credentials
 Implementation Guide [[?VC-IMP-GUIDE]].
         </p>

--- a/index.html
+++ b/index.html
@@ -1422,11 +1422,7 @@ of this specification who want to support interoperable extensibility, do.
 All <a>credentials</a>, <a>presentations</a>, and encapsulated objects MUST
 specify, or be associated with, additional more narrow <a>types</a> (like
 <code>UniversityDegreeCredential</code>, for example) so software systems can
-process this additional information. The specification of these additional more
-narrow types could be done in the object within which the additional information
-is found, rather than at a higher level such as the <code>type</code>
-<a>property</a> of the <a>credential</a> or <a>presentation</a>. It is also
-possible for the additional more narrow types to be implicit.
+process this additional information.
         </p>
 
         <p>
@@ -1464,6 +1460,13 @@ This enables implementers to rely on values associated with the
 <a>types</a> and their associated properties should be documented in at least a
 human-readable specification, and preferably, in an additional machine-readable
 representation.
+        </p>
+
+        <p class="note">
+The type system used in the data model described in this specification allows
+for multiple ways to associate types with data, implementers and authors are
+urged to read the section on typing in the Verifiable Credentials
+Implementation Guide [[?VC-IMP-GUIDE]].
         </p>
 
       </section>


### PR DESCRIPTION
This implements the following WG resolution:

RESOLVED: The Working Group has decided to revert the type section related to implicit typing to the text of the March 28 2019 Candidate Recommendation, and in addition we add a sentence which can be wordsmithed later, but the intention is to say "typing is complex so we refer readers to the implementation guide which contains more details.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/702.html" title="Last updated on Jul 17, 2019, 2:57 AM UTC (1b49722)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/702/d92ceaf...1b49722.html" title="Last updated on Jul 17, 2019, 2:57 AM UTC (1b49722)">Diff</a>