### PR TITLE
Prevent copying of comments in examples. Use a11y friendly colors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
     <style>
 pre .highlight {
   font-weight: bold;
-  color: green;
+  color: Green;
 }
 pre .subject {
   font-weight: bold;
@@ -107,7 +107,8 @@ pre .property {
 }
 pre .comment {
   font-weight: bold;
-  color: Gray;
+  color: SteelBlue;
+  user-select: none;
 }
 .color-text {
   font-weight: bold;
@@ -1134,7 +1135,7 @@ processors that support JSON-LD can process the <code>@context</code>
       }]
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1231,7 +1232,7 @@ about the <code>id</code>.
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1305,7 +1306,7 @@ in a document containing machine-readable information about the
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1519,7 +1520,7 @@ a set of objects that contain one or more properties that are each related to a
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1547,7 +1548,7 @@ who are spouses. Note the use of array notation to associate multiple
     "name": "Morgan Doe",
     "spouse": "did:example:ebfeb1f712ebc6f1c276e12ec21"
   }]</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1594,7 +1595,7 @@ machine-readable information about the <a>issuer</a> that can be used to
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1644,7 +1645,7 @@ becomes valid.
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1786,7 +1787,7 @@ date and time the <a>credential</a> ceases to be valid.
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1858,7 +1859,7 @@ privacy-enhancing.
     "id": "https://example.edu/status/24",
     "type": "CredentialStatusList2017"
   }</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -1936,8 +1937,8 @@ The example below shows a <a>verifiable presentation</a> that embeds
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
-  <span class="highlight">"verifiableCredential": [{ ... }],
-  "proof": [{ ... }]</span>
+  <span class="highlight">"verifiableCredential": [{ <span class="comment">...</span> }],
+  "proof": [{ <span class="comment">...</span> }]</span>
 }
         </pre>
 
@@ -2273,7 +2274,7 @@ Let us assume we start with the <a>verifiable credential</a> shown below.
     "id": "did:example:abcdef1234567",
     "name": "Jane Doe"
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -2329,7 +2330,7 @@ example by including the context and adding the new <a>properties</a> and
     "name": "Jane Doe",
     <span class="highlight">"favoriteFood": "Papaya"</span>
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -2499,7 +2500,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
     "id": "https://example.org/examples/degree.json",
     "type": "JsonSchemaValidator2018"
   }</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -2544,7 +2545,7 @@ see Section <a href="#zero-knowledge-proofs"></a>.
     "id": "https://example.org/examples/degree.zkp",
     "type": "ZkpExampleSchema2018"
   }</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -2629,7 +2630,7 @@ determined by the specific <code>refreshService</code> <a>type</a> definition.
     "id": "https://example.edu/refresh/3732"
     "type": "ManualRefreshService2018",
   }</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -2715,7 +2716,7 @@ by the specific <code>termsOfUse</code> <a>type</a> definition.
       "action": ["Archival"]
     }]
   }</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -2749,7 +2750,7 @@ in an archive.
       "name": "Bachelor of Science and Arts"
     }
     },
-    "proof": { ... }
+    "proof": { <span class="comment">...</span> }
   }],
   <span class="highlight">"termsOfUse": [{
     "type": "HolderPolicy",
@@ -2865,7 +2866,7 @@ Verifiable Credentials Implementation Guidance [[VC-IMP-GUIDE]] document.
     "subjectPresence": "Digital",
     "documentPresence": "Digital"
   }]</span>,
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -3163,7 +3164,7 @@ can issue the <a>credential</a> shown below and present it to the
   }</span>,
   "issuer": "https://example.com/people#me",
   "issuanceDate": "2017-12-05T14:27:42Z",
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -4165,7 +4166,7 @@ possible by not specifying the <a>subject</a> identifier, expressed using the
       "name": "Bachelor of Science and Arts"
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
       </pre>
 
@@ -4627,7 +4628,7 @@ probably should be:
       }]
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
       </pre>
 
@@ -4663,7 +4664,7 @@ protection to the image by using an [[IPFS]] link.
       }]
     }
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
       </pre>
 
@@ -5524,7 +5525,7 @@ and the <a>holder</a>.
     "birthDate": "1989-03-15"
     ...
   },
-  "proof": { ... }
+  "proof": { <span class="comment">...</span> }
 }
         </pre>
 
@@ -5611,7 +5612,7 @@ outside the scope of this specification.
       "type": "Mother"
     }
   },
-  "proof": { ... } // the proof is generated by the DMV
+  "proof": { <span class="comment">...</span> }  <span class="comment">// the proof is generated by the DMV</span>
 }
         </pre>
 
@@ -5637,7 +5638,7 @@ child and the parent such that a <a>verifier</a> would most likely accept the
       "type": "Child"
     }
   },
-  "proof": { ... } // the proof is generated by the DMV
+  "proof": { <span class="comment">...</span> } <span class="comment">// the proof is generated by the DMV</span>
 }
         </pre>
 
@@ -5665,7 +5666,7 @@ provided with any of the child's <a>credentials</a>.
       "type": "Mother"
     }
   },
-  "proof": { ... } // the proof is generated by the child
+  "proof": { <span class="comment">...</span> } <span class="comment">// the proof is generated by the child</span>
 }
         </pre>
 

--- a/index.html
+++ b/index.html
@@ -108,6 +108,9 @@ pre .property {
 pre .comment {
   font-weight: bold;
   color: SteelBlue;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 }
 .color-text {

--- a/index.html
+++ b/index.html
@@ -618,6 +618,15 @@ Conformance to this specification does not depend on the details of a particular
 proof mechanism; it requires clearly identifying the mechanism a
 <a>verifiable credential</a> uses.
         </p>
+
+        <p>
+This document also contains examples that contain JSON and JSON-LD content.
+Some of these examples contain characters that are invalid JSON, such as
+inline comments (<code>//</code>) and the use of ellipsis (<code>...</code>)
+to denote information that adds little value to the example. Implementers are
+cautioned to remove this content if they desire to use the information as
+valid JSON or JSON-LD.
+        </p>
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -3740,7 +3740,7 @@ header parameter.
     ],
     "type": ["VerifiablePresentation"],
     <span class="comment">// base64url-encoded JWT as string</span>
-    "verifiableCredential": ["..."]
+    "verifiableCredential": ["<span class="comment">...</span>"]
   }
 }
             </pre>


### PR DESCRIPTION
This addresses #704 by:

* Adding a statement noting the use of comments and ellipsis in the examples.
* Making it not possible to select the comments in all the examples via the use of CSS magic.
* Ensuring that we're using a11y friendly colors (high contrast) for comments and highlights in the examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/708.html" title="Last updated on Aug 6, 2019, 6:04 PM UTC (84250cd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/708/6d8c996...84250cd.html" title="Last updated on Aug 6, 2019, 6:04 PM UTC (84250cd)">Diff</a>