### PR TITLE
Fix typos in JWT encoding decoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -3478,7 +3478,7 @@ Contained in the JWS signature part.
             <p>
 If no explicit rule is specified, <a>properties</a> are encoded in the same way
 as with a standard <a>verifiable credential</a>, and are added to the
-<code>vc</code> <a>property</a> of the JWT. As with all JWTs, the JWS-based
+<code>vc</code> <a>claim</a> of the JWT. As with all JWTs, the JWS-based
 signature of a <a>verifiable credential</a> represented in the JWT syntax is
 calculated against the literal JWT string value as presented across the wire,
 before any decoding or transformation rules are applied. The following
@@ -3562,18 +3562,11 @@ the Presenter to receive and verify the <a>verifiable presentation</a>).
 
             <p>
 Other JOSE header parameters and <a>claim</a> names not specified herein can be
-used if their use is not explicitly discouraged. Implementers should not use JOSE
+used if their use is not explicitly discouraged. Implementers should not use JWT
 claim names for claims about the <code>credentialSubject</code> such as 
-email, birthdate, etc.
-There are no transformation rules for these and they would get lost after
-transformation. Instead, implementers MUST leave claims about the <a>subject</a> in the
-<code>credentialSubject</code> property of the <code>vc</code> claim, and 
-properties of the
-<a>verifiable credential<a> in
-the <code>vc</code> claim. Additional JOSE claim names such as <code>iat</code>,
-<code>nonce</code>, etc. are
-allowed but they will get lost after transformation unless there is an encoding/decoding
-rule defined. 
+email, birthdate, etc. There are no transformation rules for these and they 
+would get lost after decoding. Instead, implementers MUST add claims about the <a>subject</a> to the <code>credentialSubject</code> property of the JWT
+<code>vc</code> claim. 
             </p>
 
             <p>
@@ -3582,7 +3575,7 @@ the concepts outlined in Section
 <a href="#advanced-concepts">Advanced Concepts</a> (for example,
 <code>refreshService</code>, <code>termsOfUse</code>, and
 <code>evidence</code>). These concepts can be encoded as they are without any
-transformation, and can be added to the <code>vc</code> <a>property</a> of the
+transformation, and can be added to the <code>vc</code> <a>claim</a> of the
 JWT.
             </p>
 

--- a/index.html
+++ b/index.html
@@ -3562,9 +3562,18 @@ the Presenter to receive and verify the <a>verifiable presentation</a>).
 
             <p>
 Other JOSE header parameters and <a>claim</a> names not specified herein can be
-used if their use is not explicitly discouraged. Additional <a>verifiable 
-credential</a> <a>claims</a> MUST
-be added to the <code>credentialSubject</code> <a>property</a> of the JWT.
+used if their use is not explicitly discouraged. Implementers should not use JOSE
+claim names for claims about the <code>credentialSubject</code> such as 
+email, birthdate, etc.
+There are no transformation rules for these and they would get lost after
+transformation. Instead, implementers MUST leave claims about the <a>subject</a> in the
+<code>credentialSubject</code> property of the <code>vc</code> claim, and 
+properties of the
+<a>verifiable credential<a> in
+the <code>vc</code> claim. Additional JOSE claim names such as <code>iat</code>,
+<code>nonce</code>, etc. are
+allowed but they will get lost after transformation unless there is an encoding/decoding
+rule defined. 
             </p>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -3561,12 +3561,16 @@ the Presenter to receive and verify the <a>verifiable presentation</a>).
             </ul>
 
             <p>
-Other JOSE header parameters and <a>claim</a> names not specified herein can be
-used if their use is not explicitly discouraged. Implementers should not use JWT
-claim names for claims about the <code>credentialSubject</code> such as 
-email, birthdate, etc. There are no transformation rules for these and they 
-would get lost after decoding. Instead, implementers MUST add claims about the <a>subject</a> to the <code>credentialSubject</code> property of the JWT
-<code>vc</code> claim. 
+Other JOSE header parameters and JWT <a>claim</a> names not specified herein can be
+used if their use is not explicitly discouraged. Implementers MUST add claims about
+the <a>subject</a> to the <code>credentialSubject</code> property of the JWT
+<code>vc</code> <a>claim</a>, and <a>properties</a> of the
+<a>verifiable credential<a> to the <code>vc</code> <a>claim</a>. Implementers
+are advised not to use JWT <a>claim</a> names (e.g. (<code>birthdate</code>,
+<code>nickname</code>, <code>email</code>, etc.) for <a>claims</a> about the
+<code>credentialSubject</code> because these would be lost after decoding
+unless there are encoding/decoding transformation rules defined for them in
+a subsequent standard or other document available to the implementers. 
             </p>
 
             <p>

--- a/index.html
+++ b/index.html
@@ -3554,14 +3554,15 @@ timestamp (<code>NumericDate</code>).
 in the <a>verifiable credential</a> <a>subject</a>.
               </li>
               <li>
-<code>aud</code> MUST represent the <code>subject</code> <a>property</a> of the
-consumer of the <a>verifiable presentation</a>.
+<code>aud</code> MUST represent the
+consumer of the <a>verifiable presentation</a> (i.e. the verifier).
               </li>
             </ul>
 
             <p>
 Other JOSE header parameters and <a>claim</a> names not specified herein can be
-used if their use is not explicitly discouraged. Additional <a>claims</a> MUST
+used if their use is not explicitly discouraged. Additional <a> verifiable 
+credential </a> <a>claims</a> MUST
 be added to the <code>credentialSubject</code> <a>property</a> of the JWT.
             </p>
 
@@ -3618,8 +3619,7 @@ done:
               <li>
 If <code>exp</code> is present, the UNIX timestamp MUST be converted to an
 [[!RFC3339]] <code>date-time</code>, and MUST be used to set the value
-of the <code>expirationDate</code> <a>property</a> of
-<code>credentialSubject</code> of the new JSON object.
+of the <code>expirationDate</code> <a>property</a> of the new JSON object.
               </li>
               <li>
 If <code>iss</code> is present, the value MUST be used to set the

--- a/index.html
+++ b/index.html
@@ -3565,13 +3565,11 @@ Other JOSE header parameters and JWT <a>claim</a> names not specified herein can
 used if their use is not explicitly discouraged. Implementers MUST add claims about
 the <a>subject</a> to the <code>credentialSubject</code> property of the JWT
 <code>vc</code> <a>claim</a>, and <a>properties</a> of the
-<a>verifiable credential<a> to the <code>vc</code> <a>claim</a>. Implementers
-are advised not to use JWT <a>claim</a> names (e.g. (<code>birthdate</code>,
-<code>nickname</code>, <code>email</code>, etc.) for <a>claims</a> about the
-<code>credentialSubject</code> because these would be lost after decoding
-unless there are encoding/decoding transformation rules defined for them in
-a subsequent standard or other document available to the implementers. 
-            </p>
+<a>verifiable credential<a> to the <code>vc</code> <a>claim</a>. Such <a>claims</a>
+about the <a>subject</a> and <a>properties</a> of the <a>verifiable credential<a>
+MAY be echoed/repeated, but should not be placed solely in the JOSE header parameters
+or JWT <a>claim</a> names not specified herein. 
+           </p>
 
             <p>
 This version of the specification defines no JWT-specific encoding rules for

--- a/index.html
+++ b/index.html
@@ -3554,15 +3554,16 @@ timestamp (<code>NumericDate</code>).
 in the <a>verifiable credential</a> <a>subject</a>.
               </li>
               <li>
-<code>aud</code> MUST represent the
-consumer of the <a>verifiable presentation</a> (i.e. the verifier).
+<code>aud</code> MUST represent (i.e., identify) the intended audience
+of the <a>verifiable presentation</a> (i.e., the Verifier(s) intended by
+the Presenter to receive and verify the <a>verifiable presentation</a>).
               </li>
             </ul>
 
             <p>
 Other JOSE header parameters and <a>claim</a> names not specified herein can be
-used if their use is not explicitly discouraged. Additional <a> verifiable 
-credential </a> <a>claims</a> MUST
+used if their use is not explicitly discouraged. Additional <a>verifiable 
+credential</a> <a>claims</a> MUST
 be added to the <code>credentialSubject</code> <a>property</a> of the JWT.
             </p>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/711.html" title="Last updated on Aug 15, 2019, 7:15 AM UTC (2540dfb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/711/6d8c996...2540dfb.html" title="Last updated on Aug 15, 2019, 7:15 AM UTC (2540dfb)">Diff</a>