### PR TITLE
Fixed dead link to CL paper

### DIFF
--- a/common.js
+++ b/common.js
@@ -78,7 +78,7 @@ var vcwg = {
     },
     "CL-SIGNATURES": {
       title: "A Signature Scheme with Efficient Protocols",
-      href: "http://groups.csail.mit.edu/cis/pubs/lysyanskaya/cl02b.pdf",
+      href: "https://www.researchgate.net/publication/220922101_A_Signature_Scheme_with_Efficient_Protocols",
       authors: [
         "Jan Camenisch",
         "Anna Lysyanskaya"


### PR DESCRIPTION
The [old link](https://groups.csail.mit.edu/cis/pubs/lysyanskaya/cl02b.pdf) to the CL signature paper is dead, so I have replaced it with a link to [the paper at researchgate.net](https://www.researchgate.net/publication/220922101_A_Signature_Scheme_with_Efficient_Protocols).