### PR TITLE
Fix bug in `rdfs:range` of `verifiableCredential` property.

### DIFF
--- a/vocab/credentials.html
+++ b/vocab/credentials.html
@@ -20,7 +20,7 @@ var respecConfig = {
     },
     specStatus:  "base",
     shortName:   "vc-vocab",
-    publishDate: "2019-05-26",
+    publishDate: "2021-03-27",
     thisVersion: "https://w3.org/2018/credentials",
     doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
@@ -99,10 +99,10 @@ var respecConfig = {
         <a rel="alternate" href="credentials.ttl">Turtle</a> and
         <a rel="alternate" href="credentials.jsonld">JSON-LD</a>,
         which also includes the <code>@context</code> required for metadata descriptions.
-        <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
+        <!--These versions may also be retrieved from <code>FIXME</code> using an appropriate HTTP <em>Accept</em> header.-->
       </p>
       <dl>
-        <dt>Published:</dt><dd><time property="dc:date">2019-05-26</time></dd>
+        <dt>Published:</dt><dd><time property="dc:date">2021-03-27</time></dd>
         <dt>Version Info:</dt>
         <dd><a href="" property="owl:versionInfo"></a></dd>
         <dt>See Also:</dt>
@@ -153,6 +153,13 @@ report</a>.
       <h2>Class Definitions</h2>
       <p>The following are class definitions in the <code>cred</code> namespace:</p>
       <table class="rdfs-definition">
+        <tr><td class="bold">CredentialGraph</td>
+          <td resource="cred:CredentialGraph" typeof="rdfs:Class">
+            <em property="rdfs:label">Credential graph labels</em>
+            <p property="rdfs:comment">Instances of this class serve as labels for RDF Graphs. Any Graph labeled by these instances must include exactly one Resource of type VerifiableCredential.</p>
+            <span property="rdfs:isDefinedBy" resource="cred:"></span>
+          </td>
+        </tr>
         <tr><td class="bold">JsonSchemaValidator2018</td>
           <td resource="cred:JsonSchemaValidator2018" typeof="rdfs:Class">
             <em property="rdfs:label"></em>
@@ -325,11 +332,11 @@ report</a>.
         <tr><td class="bold">verifiableCredential</td>
           <td resource="cred:verifiableCredential" typeof="rdf:Property">
             <em property="rdfs:label">verifiable credential</em>
-            <p property="rdfs:comment">The value of the verifiableCredential property MUST describe a VerifiableCredential.</p>
+            <p property="rdfs:comment">The value of the verifiableCredential property MUST describe a graph containing a VerifiableCredential.</p>
             <span property="rdfs:isDefinedBy" resource="cred:"></span>
               <dl class="terms">
                   <dt>rdfs:range</dt>
-                      <dd property="rdfs:range" resource="cred:VerifiableCredential">cred:VerifiableCredential</dd>
+                      <dd property="rdfs:range" resource="cred:CredentialGraph">cred:CredentialGraph</dd>
                   <dt>rdfs:domain</dt>
                       <dd property="rdfs:domain" resource="cred:VerifiablePresentation">cred:VerifiablePresentation</dd>
               </dl>
@@ -340,6 +347,10 @@ report</a>.
     <section>
       <h2>Term Definitions</h2>
       <dl class="terms">
+        <dt>CredentialGraph</dt>
+        <dd>
+            cred:CredentialGraph
+        </dd>
         <dt>JsonSchemaValidator2018</dt>
         <dd>
             cred:JsonSchemaValidator2018

--- a/vocab/credentials.jsonld
+++ b/vocab/credentials.jsonld
@@ -154,6 +154,16 @@
     ],
     "rdfs_classes": [
       {
+        "@id": "cred:CredentialGraph",
+        "@type": "rdfs:Class",
+        "rdfs:label": {
+          "en": "Credential graph labels"
+        },
+        "rdfs:comment": {
+          "en": "Instances of this class serve as labels for RDF Graphs. Any Graph labeled by these instances must include exactly one Resource of type VerifiableCredential."
+        }
+      },
+      {
         "@id": "cred:JsonSchemaValidator2018",
         "@type": "rdfs:Class",
         "rdfs:label": {
@@ -330,10 +340,10 @@
           "en": "verifiable credential"
         },
         "rdfs:comment": {
-          "en": "The value of the verifiableCredential property MUST describe a VerifiableCredential."
+          "en": "The value of the verifiableCredential property MUST describe a graph containing a VerifiableCredential."
         },
         "rdfs:domain": "cred:VerifiablePresentation",
-        "rdfs:range": "cred:VerifiableCredential"
+        "rdfs:range": "cred:CredentialGraph"
       }
     ]
   }

--- a/vocab/credentials.ttl
+++ b/vocab/credentials.ttl
@@ -15,6 +15,10 @@ cred: a owl:Ontology;
   rdfs:seeAlso <https://www.w3.org/TR/vc-data-model/>;
 
 # Class definitions
+cred:CredentialGraph a rdfs:Class;
+  rdfs:label "Credential graph labels"@en;
+  rdfs:comment """Instances of this class serve as labels for RDF Graphs. Any Graph labeled by these instances must include exactly one Resource of type VerifiableCredential."""@en;
+  rdfs:isDefinedBy cred: .
 cred:JsonSchemaValidator2018 a rdfs:Class;
   rdfs:label ""@en;
   rdfs:comment """A type of validator that can be used to syntactically validate JSON documents using the JSON Schema language."""@en;
@@ -97,7 +101,7 @@ cred:termsOfUse a rdf:Property;
   rdfs:isDefinedBy cred: .
 cred:verifiableCredential a rdf:Property;
   rdfs:label "verifiable credential"@en;
-  rdfs:comment """The value of the verifiableCredential property MUST describe a VerifiableCredential."""@en;
+  rdfs:comment """The value of the verifiableCredential property MUST describe a graph containing a VerifiableCredential."""@en;
   rdfs:domain cred:VerifiablePresentation;
-  rdfs:range cred:VerifiableCredential;
+  rdfs:range cred:CredentialGraph;
   rdfs:isDefinedBy cred: .

--- a/vocab/vocab.csv
+++ b/vocab/vocab.csv
@@ -4,6 +4,7 @@ cred,prefix,,https://w3.org/2018/credentials#,,,,,
 odrl,prefix,,http://www.w3.org/ns/odrl/2/,,,,,
 xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,
 ,rdfs:seeAlso,,https://www.w3.org/TR/vc-data-model/,,,,,
+CredentialGraph,rdfs:Class,Credential graph labels,,,,,,"Instances of this class serve as labels for RDF Graphs. Any Graph labeled by these instances must include exactly one Resource of type VerifiableCredential."
 JsonSchemaValidator2018,rdfs:Class,,,,,,,A type of validator that can be used to syntactically validate JSON documents using the JSON Schema language.
 ManualRefreshService2018,rdfs:Class,,cred:RefreshService,,,,,A type of refresh service that must be interacted with in a manual fashion.
 RefreshService,rdfs:Class,Refresh Service,,,,,,A refresh service is a mechanism that can be utilized by software agents to retrieve an updated copy of a `verifiable credential`.
@@ -19,4 +20,4 @@ issuer,rdf:Property,issuer,,VerifiableCredential,,@id,,The value of the issuer p
 refreshService,rdf:Property,refresh service,,VerifiableCredential,cred:RefreshService,@id,,The value of the refreshService property MUST be one or more refresh services that provides enough information to the holder's software such that the holder can refresh the credential.
 serviceEndpoint,rdf:Property,service endpoint,,RefreshService,,@id,,The value of the serviceEndpoint property MUST be a URL to the service endpoint associated with the subject.
 termsOfUse,rdf:Property,terms of use,,VerifiableCredential,odrl:Policy,@id,,"If specified, the value of the termsOfUse property MUST specify one or more terms of use policies under which the creator issued the credential or presentation. If the recipient (a holder or verifier) is not willing to adhere to the specified terms of use, then they do so on their own responsibility and might incur legal liability if they violate the stated Terms of Use. Each termsOfUse MUST specify its type, for example, IssuerPolicy, and optionally, its instance id. The precise contents of each term of use is determined by the specific TermsOfUse type definition."
-verifiableCredential,rdf:Property,verifiable credential,,VerifiablePresentation,cred:VerifiableCredential,@id,@graph,The value of the verifiableCredential property MUST describe a VerifiableCredential.
+verifiableCredential,rdf:Property,verifiable credential,,VerifiablePresentation,cred:CredentialGraph,@id,@graph,The value of the verifiableCredential property MUST describe a graph containing a VerifiableCredential.


### PR DESCRIPTION
Handles the bug described in #770


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/771.html" title="Last updated on Nov 14, 2021, 6:00 PM UTC (25a5c5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/771/5d4e2b5...25a5c5e.html" title="Last updated on Nov 14, 2021, 6:00 PM UTC (25a5c5e)">Diff</a>