### PR TITLE
adds properties for AlumniCredential and DisputeCredential for valid JSON-LD examples

### DIFF
--- a/contexts/credentials/examples/v1
+++ b/contexts/credentials/examples/v1
@@ -18,6 +18,8 @@
     "Mother": "ex:Mother",
     "RelationshipCredential": "ex:RelationshipCredential",
     "UniversityDegreeCredential": "ex:UniversityDegreeCredential",
+    "AlumniCredential": "ex:AlumniCredential",
+    "DisputeCredential": "ex:DisputeCredential",
     "ZkpExampleSchema2018": "ex:ZkpExampleSchema2018",
 
     "issuerData": "ex:issuerData",
@@ -42,6 +44,8 @@
     "evidenceDocument": "ex:evidenceDocument",
     "spouse": "schema:spouse",
     "subjectPresence": "ex:subjectPresence",
-    "verifier": {"@id": "ex:verifier", "@type": "@id"}
+    "verifier": {"@id": "ex:verifier", "@type": "@id"},
+    "currentStatus": "ex:currentStatus",
+    "statusReason": "ex:statusReason",
   }]
 }

--- a/contexts/credentials/examples/v1
+++ b/contexts/credentials/examples/v1
@@ -46,6 +46,6 @@
     "subjectPresence": "ex:subjectPresence",
     "verifier": {"@id": "ex:verifier", "@type": "@id"},
     "currentStatus": "ex:currentStatus",
-    "statusReason": "ex:statusReason",
+    "statusReason": "ex:statusReason"
   }]
 }


### PR DESCRIPTION
This is an addition to the example context file which is consider non-normative so that the examples in example 2 and example 26 produce valid JSON-LD.

This PR closes #769 and closes #750 