### PR TITLE
merge main which includes process changes into v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,33 @@ mailing list as well.
 
 ### Other useful links
 * [Public group email archive](https://lists.w3.org/Archives/Public/public-vc-wg/)
+
+## Process Overview for VC Data Model Pull Requests
+1. For now, we will focus only on merging new errata PRs into this repository,
+but encourage activity related to new features.
+2. Once a PR is opened, chairs and editors make judgement call on whether
+changes are substantive or editorial.
+<dl>
+  <dt>Editorial</dt>
+  <dd>Mark with "editorial" tag, merge into branch "v1.1"</dd>
+  <dt>Substantive</dt>
+  <dd>Mark with "substantial" tag. Bugfixes are merged into separate branch "v1.2". New Features stay around as an open PR.</dd>
+</dl>
+3. W3C CCG is notified of PRs that will be merged in the next 14 days if there
+are no objections.
+4. When it's determined a new reccomendation should go out, the W3C Verifiable
+Credentials Working Group members meet, review all the PRs that have been
+merged, and make a formal recommendation if agreement is reached.
+
+### Roadmap for 2021
+- 1 editorial update (v1.1?)
+- 1 substantive update (v1.2?)
+- VC Test Suite Refactoring
+- Start planning VC v2 Work, request a rechartering 3-6 months before end of
+  year to keep VC WG functioning.
+
+### Focus areas
+- [v1] Fixing a specific bug
+- [v1] Update examples in the spec to make them modern
+- [v2] VC `@context` needs updating, possibly with security vocab modularized
+  into smaller components instead of all included into a large context file.


### PR DESCRIPTION
This PR is here to bring main and v1.1 back in alignment. The specific commit I'm looking to bring into V1.1 is the changes to the readme which are defining the process of how we will go about handling changes in the maintenance WG as agreed to via the CCG and merged already in main.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/784.html" title="Last updated on Jul 29, 2021, 4:47 AM UTC (bca9e00)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/784/6c429cf...bca9e00.html" title="Last updated on Jul 29, 2021, 4:47 AM UTC (bca9e00)">Diff</a>