### PR TITLE
update reference links to CCG and LDP Registries

### DIFF
--- a/common.js
+++ b/common.js
@@ -48,33 +48,24 @@ var vcwg = {
     },
     "LD-PROOFS": {
       title: "Linked Data Proofs",
-      href: "https://w3c-dvcg.github.io/ld-proofs/",
+      href: "https://w3c-ccg.github.io/ld-proofs/",
       authors: [
         "Manu Sporny",
         "Dave Longley"
       ],
       status: "CG-DRAFT",
-      publisher: "Digital Verification Community Group"
+      publisher: "Credentials Community Group"
     },
-    "LD-SIGNATURES": {
-      title: "Linked Data Signatures",
-      href: "https://w3c-dvcg.github.io/ld-signatures/",
+    "LDP-REGISTRY": {
+      title: "Linked Data Cryptographic Suite Registry",
+      href: "https://w3c-ccg.github.io/ld-cryptosuite-registry/",
       authors: [
         "Manu Sporny",
-        "Dave Longley"
+        "Drummond Reed",
+        "Orie Steele"
       ],
       status: "CG-DRAFT",
-      publisher: "Digital Verification Community Group"
-    },
-    "LDS-RSA2018": {
-      title: "The 2018 RSA Linked Data Signature Suite",
-      href: "https://w3c-dvcg.github.io/lds-rsa2018/",
-      authors: [
-        "Manu Sporny",
-        "Dave Longley"
-      ],
-      status: "CG-DRAFT",
-      publisher: "Digital Verification Community Group"
+      publisher: "Credentials Community Group"
     },
     "CL-SIGNATURES": {
       title: "A Signature Scheme with Efficient Protocols",

--- a/index.html
+++ b/index.html
@@ -589,7 +589,7 @@ At the time of publication, Working Group members had implemented
 JSON Web Tokens [[RFC7519]] secured using JSON Web Signatures [[RFC7515]]
           </li>
           <li>
-Linked Data Signatures [[?LD-SIGNATURES]]
+Linked Data Proofs [[?LD-PROOFS]]
           </li>
           <li>
 Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
@@ -1035,13 +1035,12 @@ the <a>verifier</a> and <a>verified</a>.
 
         <p class="note">
 Implementers that are interested in understanding more about the
-<code>proof</code> mechanism used above can learn more in
-Section <a href="#proofs-signatures"></a> and by reading the
-following specifications: Linked Data Proofs [[LD-PROOFS]], Linked Data
-Signatures [[LD-SIGNATURES]], 2018 RSA Signature Suite [[LDS-RSA2018]], and
-JSON Web Signature (JWS) Unencoded Payload Option [[RFC7797]]. A list
-of proof mechanisms is available in the Verifiable Credentials
-Extension Registry [[VC-EXTENSION-REGISTRY]].
+<code>proof</code> mechanism used above can learn more in Section <a
+href="#proofs-signatures"></a> and by reading the following specifications:
+Linked Data Proofs [[?LD-PROOFS]], Linked Data Cryptographic Suites
+Registry[[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded Payload Option
+[[RFC7797]]. A list of proof mechanisms is available in the Verifiable
+Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
         </p>
       </section>
     </section>
@@ -1771,11 +1770,10 @@ As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
 single proof mechanism for use with <a>verifiable credentials</a>. For more
 information about the <code>proof</code> mechanism, see the following
-specifications: Linked Data Proofs [[LD-PROOFS]], Linked Data Signatures
-[[LD-SIGNATURES]], 2018 RSA Signature Suite [[LDS-RSA2018]], and JSON Web
-Signature (JWS) Unencoded Payload Option [[RFC7797]]. A list of proof mechanisms
-is available in the Verifiable Credentials Extension Registry
-[[VC-EXTENSION-REGISTRY]].
+specifications: Linked Data Proofs [[?LD-PROOFS]], Linked Data Cryptographic
+Suites Registries [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded
+Payload Option [[RFC7797]]. A list of proof mechanisms is available in the
+Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
         </p>
 
       </section>
@@ -2259,9 +2257,9 @@ data model, without the use of a centralized system for doing so, through the
 use of [[?LINKED-DATA]].
           </li>
           <li>
-Support multiple types of cryptographic proof formats through the use of Linked
-Data Proofs [[?LD-PROOFS]], Linked Data Signatures [[?LD-SIGNATURES]], and a
-variety of signature suites.
+Support multiple types of cryptographic proof formats through the use of
+Linked Data Proofs [[?LD-PROOFS]] and a variety of signature suites listed
+in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
           </li>
           <li>
 Provide all of the extensibility mechanisms outlined above in a data format that
@@ -3865,10 +3863,10 @@ other related information can be easily discovered and new information can be
 easily merged into the existing graph of knowledge. Linked Data is
 extensible in a decentralized way, greatly reducing barriers to large scale
 integration. The data model in this specification works well with the
-<a href="https://w3c-dvcg.github.io/ld-proofs/">Linked Data Proofs</a>,
-<a href="https://w3c-dvcg.github.io/ld-signatures/">Linked Data Signatures</a>,
-and the associated
-<a href="https://w3c-ccg.github.io/ld-cryptosuite-registry/">Linked Data Cryptographic Suites</a>,
+<a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs</a> and
+the associated <a
+  href="https://w3c-ccg.github.io/ld-cryptosuite-registry/">Linked Data
+  Cryptographic Suites</a>
 which are designed to protect the data model as described by this specification.
           </p>
 


### PR DESCRIPTION
closes #746

This updates the text to no longer point to DVCG work items and instead points to the active versions in the CCG where possible. In the case of LD-Signatures and LDS-RS2018 I've updated the text to instead point to the LDP-Registries which includes links of all of the registered LD Proofs that could be used with proofs.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/801.html" title="Last updated on Sep 9, 2021, 1:44 AM UTC (81d4ac2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/801/ea2a3ab...81d4ac2.html" title="Last updated on Sep 9, 2021, 1:44 AM UTC (81d4ac2)">Diff</a>