### PR TITLE
update evidence example and add note for explanation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2909,18 +2909,21 @@ Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]] document.
     "verifier": "https://example.edu/issuers/14",
     "evidenceDocument": "DriversLicense",
     "subjectPresence": "Physical",
-    "documentPresence": "Physical"
-  },{
-    "id": "https://example.edu/evidence/f2aeec97-fc0d-42bf-8ca7-0548192dxyzab",
-    "type": ["SupportingActivity"],
-    "verifier": "https://example.edu/issuers/14",
-    "evidenceDocument": "Fluid Dynamics Focus",
-    "subjectPresence": "Digital",
-    "documentPresence": "Digital"
+    "documentPresence": "Physical",
+    "licenseNumber": "123AB4567"
   }]</span>,
   "proof": { <span class="comment">...</span> }
 }
         </pre>
+
+        <p class="note">
+In this <code>evidence</code> example, the <a>issuer</a> is asserting that they
+physically matched the <a>subject</a> of the <a>credential</a> to a physical
+copy of a driver's license with the stated license number. This driver's license
+was used in the issuance process to verify that "Example University" verified
+the subject before issuance of the credential and how they did so (physical
+verification).
+        </p>
 
         <p class="note">
 The <code>evidence</code> <a>property</a> provides different and complementary


### PR DESCRIPTION
I reviewed issue #405 and PR #418 to get a better understanding of what was trying to be conveyed in this example. This is an attempt to update the example to close #754 and provide a bit of additional details about what's being conveyed with the evidence property in a note. It would be good to show this with a LoA type use case like was originally considered in #405 but couldn't think of any clear examples where LoA would be used with the example University Credential which is common throughout the spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/802.html" title="Last updated on Aug 30, 2021, 2:27 AM UTC (0a19a1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/802/ea2a3ab...0a19a1b.html" title="Last updated on Aug 30, 2021, 2:27 AM UTC (0a19a1b)">Diff</a>