### PR TITLE
clarify that credentialStatus isn't required without normative changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1841,7 +1841,8 @@ This specification defines the following <code>credentialStatus</code>
         <dl>
           <dt><var>credentialStatus</var></dt>
           <dd>
-The value of the <code>credentialStatus</code> <a>property</a> MUST include the:
+If present, the value of the <code>credentialStatus</code> <a>property</a> MUST
+include the following:
 
             <ul>
               <li>


### PR DESCRIPTION
closes #768

This updates the text in [section 4.9](https://w3c.github.io/vc-data-model/#status) where `credentialStatus` is defined to align with [section 4.8](https://w3c.github.io/vc-data-model/#expiration) to make it more clear that the `credentialStatus` property is optional without making any normative statement changes. If we want to update this to explicitly say it MAY be used then it would fall under a V1.2 change (which I'll be getting to here soon).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/804.html" title="Last updated on Aug 30, 2021, 3:56 AM UTC (2067db0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/804/ea2a3ab...2067db0.html" title="Last updated on Aug 30, 2021, 3:56 AM UTC (2067db0)">Diff</a>