### PR TITLE
add issuer and issuanceDate to examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -1121,6 +1121,8 @@ processors that support JSON-LD can process the <code>@context</code>
   ]</span>,
   "id": "http://example.edu/credentials/58473",
   "type": ["VerifiableCredential", "AlumniCredential"],
+  "issuer": "https://example.edu/issuers/565049",
+  "issuanceDate": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "alumniOf": {
@@ -1224,6 +1226,8 @@ about the <code>id</code>.
   ],
   <span class="highlight">"id": "http://example.edu/credentials/3732"</span>,
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "https://example.edu/issuers/565049",
+  "issuanceDate": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     <span class="highlight">"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"</span>,
     "degree": {
@@ -1298,6 +1302,8 @@ in a document containing machine-readable information about the
   ],
   "id": "http://example.edu/credentials/3732",
   <span class="highlight">"type": ["VerifiableCredential", "UniversityDegreeCredential"]</span>,
+  "issuer": "https://example.edu/issuers/565049",
+  "issuanceDate": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1512,6 +1518,8 @@ a set of objects that contain one or more properties that are each related to a
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "https://example.edu/issuers/565049",
+  "issuanceDate": "2010-01-01T19:23:24Z",
   <span class="highlight">"credentialSubject"</span>: {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1538,6 +1546,8 @@ who are spouses. Note the use of array notation to associate multiple
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "RelationshipCredential"],
+  "issuer": "https://example.com/issuer/123",
+  "issuanceDate": "2010-01-01T19:23:24Z",
   "credentialSubject": <span class="highlight">[{
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "name": "Jayden Doe",

--- a/index.html
+++ b/index.html
@@ -1303,7 +1303,7 @@ in a document containing machine-readable information about the
   "id": "http://example.edu/credentials/3732",
   <span class="highlight">"type": ["VerifiableCredential", "UniversityDegreeCredential"]</span>,
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "issuanceDate": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/index.html
+++ b/index.html
@@ -1122,7 +1122,7 @@ processors that support JSON-LD can process the <code>@context</code>
   "id": "http://example.edu/credentials/58473",
   "type": ["VerifiableCredential", "AlumniCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "issuanceDate": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "alumniOf": {

--- a/index.html
+++ b/index.html
@@ -1519,7 +1519,7 @@ a set of objects that contain one or more properties that are each related to a
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "issuanceDate": "2010-01-01T00:00:00Z",
   <span class="highlight">"credentialSubject"</span>: {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/index.html
+++ b/index.html
@@ -1547,7 +1547,7 @@ who are spouses. Note the use of array notation to associate multiple
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "RelationshipCredential"],
   "issuer": "https://example.com/issuer/123",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "issuanceDate": "2010-01-01T00:00:00Z",
   "credentialSubject": <span class="highlight">[{
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "name": "Jayden Doe",

--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,7 @@ about the <code>id</code>.
   <span class="highlight">"id": "http://example.edu/credentials/3732"</span>,
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "issuanceDate": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     <span class="highlight">"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"</span>,
     "degree": {


### PR DESCRIPTION
closes #729

Originally it was pointed out that only the `issuer` should be added to this example. However, in order to remain consistent with all examples including all the require properties I added `issuanceDate` as well since it's also a required property.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/805.html" title="Last updated on Sep 1, 2021, 10:08 PM UTC (fecfb89)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/805/ea2a3ab...fecfb89.html" title="Last updated on Sep 1, 2021, 10:08 PM UTC (fecfb89)">Diff</a>