### PR TITLE
update normative statements in ZKP section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2982,11 +2982,11 @@ how the data model can be used to issue, present, and verify zero-knowledge
         </p>
 
         <p>
-To use zero-knowledge <a>verifiable credentials</a>, the <a>issuer</a> must
-issue a <a>verifiable credential</a> in a manner that enables
-the <a>holder</a> to derive a proof from the originally issued <a>verifiable
-credential</a>, so that the <a>holder</a> can present the information to a
-<a>verifier</a> in a privacy-enhancing manner.
+For a <a>holder</a> to use a zero-knowledge <a>verifiable presentation</a>,
+the <a>issuer</a> must have issued a <a>verifiable credential</a> in a manner
+that enables the <a>holder</a> to derive a proof from the originally issued
+<a>verifiable credential</a>, so that the <a>holder</a> can present the
+information to a <a>verifier</a> in a privacy-enhancing manner.
 This implies that the <a>holder</a> can prove the validity of the
 <a>issuer's</a> signature without revealing the values that were signed, or when
 only revealing certain selected values. The standard practice is to do so by

--- a/index.html
+++ b/index.html
@@ -2985,8 +2985,8 @@ how the data model can be used to issue, present, and verify zero-knowledge
         <p>
 To use zero-knowledge <a>verifiable credentials</a>, the <a>issuer</a> must
 issue a <a>verifiable credential</a> in a manner that enables
-the <a>holder</a> to derive a proof from the original issued <a>verifiable
-credential</a> so that the <a>holder</a> can present the information to a
+the <a>holder</a> to derive a proof from the originally issued <a>verifiable
+credential</a>, so that the <a>holder</a> can present the information to a
 <a>verifier</a> in a privacy-enhancing manner.
 This implies that the <a>holder</a> can prove the validity of the
 <a>issuer's</a> signature without revealing the values that were signed, or when

--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,7 @@ how the data model can be used to issue, present, and verify zero-knowledge
         </p>
 
         <p>
-To use zero-knowledge <a>verifiable credentials</a> the <a>issuer</a> must
+To use zero-knowledge <a>verifiable credentials</a>, the <a>issuer</a> must
 issue a <a>verifiable credential</a> in a manner that enables
 the <a>holder</a> to derive a proof from the original issued <a>verifiable
 credential</a> so that the <a>holder</a> can present the information to a

--- a/index.html
+++ b/index.html
@@ -2942,8 +2942,7 @@ information about the <code>proof</code> <a>property</a>, see Section
         <p>
 A zero-knowledge proof is a cryptographic method where an entity can prove to
 another entity that they know a certain value without disclosing the actual
-value. This is sometimes referred to as selective disclosure in attribute based
-credential systems. A real-world example is proving that an accredited university has
+value. A real-world example is proving that an accredited university has
 granted a degree to you without revealing your identity or any other personally
 identifiable information contained on the degree.
         </p>
@@ -2993,10 +2992,23 @@ This implies that the <a>holder</a> can prove the validity of the
 only revealing certain selected values. The standard practice is to do so by
 proving knowledge of the signature, without revealing the signature itself.
 There are two requirements for <a>verifiable credentials</a> when they are to be
-used in zero-knowledge proof systems. The <a>verifiable credential</a> MUST
-contain a Proof, using the <code>proof</code> <a>property</a>, so that the
-<a>holder</a> can derive a <a>verifiable presentation</a> that reveals only
-the information than they intend to reveal.
+used in zero-knowledge proof systems.
+        </p>
+
+        <ul>
+          <li>
+The <a>verifiable credential</a> MUST contain a Proof, using the
+<code>proof</code> <a>property</a>, so that the <a>holder</a> can derive a
+<a>verifiable presentation</a> that reveals only the information than the
+<a>holder</a> intends to reveal.
+          </li>
+          <li>
+If a <a>Credential</a> definition is being used, the <a>Credential</a>
+definition MUST be defined in the <code>credentialSchema</code> <a>property</a>,
+so that it can be used by all parties to perform various cryptographic
+operations in zero-knowledge.
+          </li>
+        </ul>
 
         <p>
 The following example shows one method of using <a>verifiable credentials</a> in

--- a/index.html
+++ b/index.html
@@ -3058,9 +3058,9 @@ expected to be met:
         <ul>
           <li>
 Each derived <a>verifiable credential</a> within a <a>verifiable
-presentation</a> MUST contain all necessary information to verify the
-<a>verifiable credential</a> either by including it directly within the
-credential or by referencing the necessary information.
+presentation</a> MUST contain all information necessary to verify the
+<a>verifiable credential</a>, either by including it directly within the
+credential, or by referencing the necessary information.
           </li>
           <li>
 A <a>verifiable presentation</a> MUST NOT leak information that would enable

--- a/index.html
+++ b/index.html
@@ -3003,7 +3003,7 @@ The <a>verifiable credential</a> MUST contain a Proof, using the
 <a>holder</a> intends to reveal.
           </li>
           <li>
-If a <a>Credential</a> definition is being used, the <a>Credential</a>
+If a <a>credential</a> definition is being used, the <a>credential</a>
 definition MUST be defined in the <code>credentialSchema</code> <a>property</a>,
 so that it can be used by all parties to perform various cryptographic
 operations in zero-knowledge.

--- a/index.html
+++ b/index.html
@@ -3004,9 +3004,9 @@ zero-knowledge. It makes use of a Camenisch-Lysyanskaya Signature
 [[?CL-SIGNATURES]], which allows the presentation of the <a>verifiable
 credential</a> in a way that supports the privacy of the
 <a>holder</a> and <a>subject</a> through the use of selective disclosure of the
-<a>verifiable credential</a> values. Some other crypto systems which rely upon
-the usage of zero-knowledge proofs in order to selective disclose attributes can
-be found in the [[?LDP-REGISTRY]] as well.
+<a>verifiable credential</a> values. Some other cryptographic systems which rely
+upon zero-knowledge proofs to selectively disclose attributes can be found in the
+[[?LDP-REGISTRY]] as well.
         </p>
 
         <pre class="example nohighlight" title="A verifiable credential that supports CL Signatures">

--- a/index.html
+++ b/index.html
@@ -2942,8 +2942,9 @@ information about the <code>proof</code> <a>property</a>, see Section
         <p>
 A zero-knowledge proof is a cryptographic method where an entity can prove to
 another entity that they know a certain value without disclosing the actual
-value. A real-world example is proving that an accredited university has granted
-a degree to you without revealing your identity or any other personally
+value. This is sometimes referred to as selective disclosure in attribute based
+credential systems. A real-world example is proving that an accredited university has
+granted a degree to you without revealing your identity or any other personally
 identifiable information contained on the degree.
         </p>
         <p>
@@ -2975,45 +2976,38 @@ their issued <a>verifiable credentials</a>.
         </ul>
 
         <p>
-This specification describes a data model that supports zero-knowledge proof
-mechanisms. The examples below highlight how the data model can be used to
-issue, present, and verify zero-knowledge <a>verifiable credentials</a>.
+This specification describes a data model that supports selective disclosure
+with the use of a zero-knowledge proof mechanisms. The examples below highlight
+how the data model can be used to issue, present, and verify zero-knowledge
+<a>verifiable credentials</a>.
         </p>
 
         <p>
 To use zero-knowledge <a>verifiable credentials</a> the <a>issuer</a> must
-issue a <a>verifiable credential</a> in a manner that enables the <a>holder</a>
-to present the information to a <a>verifier</a> in a privacy-enhancing manner.
+issue a <a>verifiable credential</a> in a manner that enables
+the <a>holder</a> to derive a proof from the original issued <a>verifiable
+credential</a> so that the <a>holder</a> can present the information to a
+<a>verifier</a> in a privacy-enhancing manner.
 This implies that the <a>holder</a> can prove the validity of the
 <a>issuer's</a> signature without revealing the values that were signed, or when
 only revealing certain selected values. The standard practice is to do so by
 proving knowledge of the signature, without revealing the signature itself.
 There are two requirements for <a>verifiable credentials</a> when they are to be
 used in zero-knowledge proof systems. The <a>verifiable credential</a> MUST
-contain a:
-        </p>
-
-        <ul>
-          <li>
-<a>Credential</a> definition, using the <code>credentialSchema</code>
-<a>property</a>, that can be used by all parties to perform various
-cryptographic operations in zero-knowledge.
-          </li>
-          <li>
-Proof, using the <code>proof</code> <a>property</a>, that can be used to derive
-<a>verifiable presentations</a> that present information contained in the
-original <a>verifiable credential</a> in zero-knowledge. The zero-knowledge
-<a>verifiable presentation</a> must not reveal any information not intended to
-be revealed by the <a>holder</a>.
-          </li>
-        </ul>
+contain a Proof, using the <code>proof</code> <a>property</a>, in the
+<a>verifiable credential</a> so that the <a>holder</a> can derive a
+<a>verifiable presentation</a> that reveals no more information than they intend
+to.
 
         <p>
 The following example shows one method of using <a>verifiable credentials</a> in
-zero-knowledge. It makes use of a CL Signature, which allows the presentation of
-the <a>verifiable credential</a> in a way that supports the privacy of the
+zero-knowledge. It makes use of a Camenisch-Lysyanskaya Signature
+[[?CL-SIGNATURES]], which allows the presentation of the <a>verifiable
+credential</a> in a way that supports the privacy of the
 <a>holder</a> and <a>subject</a> through the use of selective disclosure of the
-<a>verifiable credential</a> values.
+<a>verifiable credential</a> values. Some other crypto systems which rely upon
+the usage of zero-knowledge proofs in order to selective disclose attributes can
+be found in the [[?LDP-REGISTRY]] as well.
         </p>
 
         <pre class="example nohighlight" title="A verifiable credential that supports CL Signatures">
@@ -3046,7 +3040,6 @@ the <a>verifiable credential</a> in a way that supports the privacy of the
   }</span>
 }
         </pre>
-
         <p>
 The example above provides the <a>verifiable credential</a> definition by using
 the <code>credentialSchema</code> <a>property</a> and a specific proof that is
@@ -3057,17 +3050,18 @@ usable in the Camenisch-Lysyanskaya Zero-Knowledge Proof system.
 The next example utilizes the <a>verifiable credential</a> above to generate a
 new derived <a>verifiable credential</a> with a privacy-preserving proof. The
 derived <a>verifiable credential</a> is then placed in a
-<a>verifiable presentation</a>, which further proves that the entire assertion
-is valid. There are three requirements of most <a>verifiable presentations</a>
-when they are to be used in zero-knowledge systems:
+<a>verifiable presentation</a>, so that the <a>verifiable credential</a>
+discloses only the intended <a>claims</a> and additional credential
+metadata that the <a>holder</a> intended. In order to do this all of the
+following requirements are expected be met:
         </p>
 
         <ul>
           <li>
-Each derived <a>verifiable credential</a> within a
-<a>verifiable presentation</a> MUST have a <code>credentialSchema</code>
-<a>property</a>. This allows the derived <a>verifiable credential</a> to
-reference the credential definition used to generate the derived proof.
+Each derived <a>verifiable credential</a> within a <a>verifiable
+presentation</a> MUST contain all necessary information to verify the
+<a>verifiable credential</a> either by including it directly within the
+credential or by referencing the necessary information.
           </li>
           <li>
 A <a>verifiable presentation</a> MUST NOT leak information that would enable
@@ -3075,8 +3069,8 @@ the <a>verifier</a> to correlate the <a>holder</a> across multiple
 <a>verifiable presentations</a>.
           </li>
           <li>
-The <a>verifiable presentation</a> MUST contain a <code>proof</code>
-<a>property</a> to enable the <a>verifier</a> to ascertain that all derived
+The <a>verifiable presentation</a> SHOULD contain a <code>proof</code>
+<a>property</a> to enable the <a>verifier</a> to check that all derived
 <a>verifiable credentials</a> in the <a>verifiable presentation</a> were issued
 to the same <a>holder</a> without leaking personally identifiable information
 that the <a>holder</a> did not intend to share.

--- a/index.html
+++ b/index.html
@@ -2994,10 +2994,9 @@ only revealing certain selected values. The standard practice is to do so by
 proving knowledge of the signature, without revealing the signature itself.
 There are two requirements for <a>verifiable credentials</a> when they are to be
 used in zero-knowledge proof systems. The <a>verifiable credential</a> MUST
-contain a Proof, using the <code>proof</code> <a>property</a>, in the
-<a>verifiable credential</a> so that the <a>holder</a> can derive a
-<a>verifiable presentation</a> that reveals no more information than they intend
-to.
+contain a Proof, using the <code>proof</code> <a>property</a>, so that the
+<a>holder</a> can derive a <a>verifiable presentation</a> that reveals only
+the information than they intend to reveal.
 
         <p>
 The following example shows one method of using <a>verifiable credentials</a> in

--- a/index.html
+++ b/index.html
@@ -3050,9 +3050,9 @@ The next example utilizes the <a>verifiable credential</a> above to generate a
 new derived <a>verifiable credential</a> with a privacy-preserving proof. The
 derived <a>verifiable credential</a> is then placed in a
 <a>verifiable presentation</a>, so that the <a>verifiable credential</a>
-discloses only the intended <a>claims</a> and additional credential
-metadata that the <a>holder</a> intended. In order to do this all of the
-following requirements are expected be met:
+discloses only the <a>claims</a> and additional credential metadata that the
+<a>holder</a> intended. To do this, all of the following requirements are
+expected to be met:
         </p>
 
         <ul>

--- a/index.html
+++ b/index.html
@@ -2977,7 +2977,7 @@ their issued <a>verifiable credentials</a>.
 
         <p>
 This specification describes a data model that supports selective disclosure
-with the use of a zero-knowledge proof mechanisms. The examples below highlight
+with the use of zero-knowledge proof mechanisms. The examples below highlight
 how the data model can be used to issue, present, and verify zero-knowledge
 <a>verifiable credentials</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,7 @@ how the data model can be used to issue, present, and verify zero-knowledge
 
         <p>
 For a <a>holder</a> to use a zero-knowledge <a>verifiable presentation</a>,
-the <a>issuer</a> must have issued a <a>verifiable credential</a> in a manner
+the <a>issuer</a> needs to have issued a <a>verifiable credential</a> in a manner
 that enables the <a>holder</a> to derive a proof from the originally issued
 <a>verifiable credential</a>, so that the <a>holder</a> can present the
 information to a <a>verifier</a> in a privacy-enhancing manner.

--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,7 @@ how the data model can be used to issue, present, and verify zero-knowledge
 
         <p>
 For a <a>holder</a> to use a zero-knowledge <a>verifiable presentation</a>,
-the <a>issuer</a> needs to have issued a <a>verifiable credential</a> in a manner
+they need an <a>issuer</a> to have issued a <a>verifiable credential</a> in a manner
 that enables the <a>holder</a> to derive a proof from the originally issued
 <a>verifiable credential</a>, so that the <a>holder</a> can present the
 information to a <a>verifier</a> in a privacy-enhancing manner.


### PR DESCRIPTION
This PR is intended to be a first cut attempt to address the concerns raised in #726 in a way that generalizes the normative language in the ZKP section of the spec. I've attempted to keep all aspects of CL-Signatures system within the scope so that it's not going to exclude the usage of that system, while also trying to call out the more generic patterns of ZKP systems that are shared by BBS+-Sigs and CL-Sigs. 

@brentzundel definitely looking to get your eyes across this soon so that we can hopefully get this in within the allotted time of the charter.

Also worth calling out that because I referenced the LDP-REGISTRY here this PR won't reference the Biblio section properly until #801 is merged onto V1.1 and I can rebase those changes in here. I intentionally left the Biblio portion out and didn't build on #801 in order to keep this PR focused on the content for now. Once we get that other PR through the link should work properly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/818.html" title="Last updated on Sep 29, 2021, 11:50 PM UTC (c750517)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/818/ea2a3ab...c750517.html" title="Last updated on Sep 29, 2021, 11:50 PM UTC (c750517)">Diff</a>