### PR TITLE
Use URI id for credentialStatus and refreshService

### DIFF
--- a/index.html
+++ b/index.html
@@ -1872,7 +1872,7 @@ include the following:
 
             <ul>
               <li>
-<code>id</code> <a>property</a>, which MUST be a URL.
+<code>id</code> <a>property</a>, which MUST be a URI.
               </li>
               <li>
 <code>type</code> <a>property</a>, which expresses the <a>credential</a> status
@@ -2659,7 +2659,7 @@ more refresh services that provides enough information to the recipient's
 software such that the recipient can refresh the <a>verifiable credential</a>.
 Each <code>refreshService</code> value MUST specify its <code>type</code> (for
 example, <code>ManualRefreshService2018</code>) and its <code>id</code>, which
-is the URL of the service. The precise content of each refresh service is
+is the URI of the service. The precise content of each refresh service is
 determined by the specific <code>refreshService</code> <a>type</a> definition.
           </dd>
         </dl>


### PR DESCRIPTION
Fix #748. This changes the *MUST* requirement for [credentialStatus](https://www.w3.org/TR/vc-data-model/#status) id and
[refreshService](https://www.w3.org/TR/vc-data-model/#refreshing) id to be URI instead of URL. The purpose of this change is to
improve consistency with the rest of the data model, where `id`s are expected
to be URIs (but not necessarily URLs). This should help implementers who want to ensure conformance with the VC Data Model without feeling compelled to check whether or not certain values are URLs, which may be a difficult determination to make without further specification by extensions. For example, there the VC Test Suite doesn't check URL-ness of refresh service ids: https://github.com/w3c/vc-test-suite/blob/593d5a5fb83f89ba60f32c0443d01fced5b4a3db/test/vc-data-model-1.0/21-refresh.js#L59 . Also, this specification doesn't seem to define URL or directly reference [RFC 1738 - Uniform Resource Locators (URL)](https://datatracker.ietf.org/doc/html/rfc1738), although it does have a definition for URI and identifier, and cites [RFC 3986 - Uniform Resource Identifier (URI): Generic Syntax](https://datatracker.ietf.org/doc/html/rfc3986).

The other use of URL, in [evidence](https://www.w3.org/TR/vc-data-model/#evidence) `ids`, I have not changed in this PR, as that is a *SHOULD*, so I understand it would not be necessary to check for strict conformance. Maybe it is more useful to leave that part in to indicate the intended use of it?

As discussed on the [2021-09-08 VCWG call](https://github.com/w3c/vc-data-model/issues/748#issuecomment-915839459), these changes may be substantive, since it changes *MUST*s, but also might not be, if it is considered that checking whether it is a URL might not by programatically possible as currently specified.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/819.html" title="Last updated on Sep 30, 2021, 11:55 AM UTC (c52a913)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/819/41baf90...c52a913.html" title="Last updated on Sep 30, 2021, 11:55 AM UTC (c52a913)">Diff</a>