### PR TITLE
address inconsistencies in date-time strings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,11 +1648,11 @@ expressing the date and time when a <a>credential</a> becomes valid.
           <dd>
 A <a>credential</a> MUST have an <code>issuanceDate</code> <a>property</a>. The
 value of the <code>issuanceDate</code> <a>property</a> MUST be a string value of
-an [[!RFC3339]] combined date and time string representing the date and time the
-<a>credential</a> becomes valid, which could be a date and time in the future.
-Note that this value represents the earliest point in time at which the
-information associated with the <code>credentialSubject</code> <a>property</a>
-becomes valid.
+an [[!XMLSCHEMA11-2]] combined <code>date-time</code> string representing the
+date and time the <a>credential</a> becomes valid, which could be a date and
+time in the future. Note that this value represents the earliest point in time
+at which the information associated with the <code>credentialSubject</code>
+<a>property</a> becomes valid.
           </dd>
         </dl>
 
@@ -1682,9 +1682,9 @@ It is expected that the next version of this specification will add the
 <code>validFrom</code> <a>property</a> and will deprecate the
 <code>issuanceDate</code> <a>property</a> in favor of a new <code>issued</code>
 <a>property</a>. The range of values for both properties are expected to remain
-as [[?RFC3339]] combined date and time strings. Implementers are advised that
-the <code>validFrom</code> and <code>issued</code> <a>properties</a> are
-reserved and use for any other purpose is discouraged.
+as [[?XMLSCHEMA11-2]] combined <code>date-time</code> strings. Implementers are
+advised that the <code>validFrom</code> and <code>issued</code>
+<a>properties</a> are reserved and use for any other purpose is discouraged.
         </p>
 
       </section>
@@ -1792,7 +1792,7 @@ the expression of <a>credential</a> expiration information.
           <dt><var>expirationDate</var></dt>
           <dd>
 If present, the value of the <code>expirationDate</code> <a>property</a> MUST be
-a string value of an [[!RFC3339]] combined date and time string representing the
+a string value of an [[!XMLSCHEMA11-2]] <code>date-time</code> representing the
 date and time the <a>credential</a> ceases to be valid.
           </dd>
         </dl>
@@ -3679,7 +3679,7 @@ done:
             <ul>
               <li>
 If <code>exp</code> is present, the UNIX timestamp MUST be converted to an
-[[!RFC3339]] <code>date-time</code>, and MUST be used to set the value
+[[!XMLSCHEMA11-2]] <code>date-time</code>, and MUST be used to set the value
 of the <code>expirationDate</code> <a>property</a> of
 <code>credentialSubject</code> of the new JSON object.
               </li>
@@ -3690,7 +3690,7 @@ If <code>iss</code> is present, the value MUST be used to set the
                   </li>
                   <li>
 If <code>nbf</code> is present, the UNIX timestamp MUST be converted to an
-[[!RFC3339]] <code>date-time</code>, and MUST be used to set the value
+[[!XMLSCHEMA11-2]] <code>date-time</code>, and MUST be used to set the value
 of the <code>issuanceDate</code> <a>property</a> of the new JSON object.
                   </li>
                   <li>

--- a/index.html
+++ b/index.html
@@ -1648,9 +1648,10 @@ expressing the date and time when a <a>credential</a> becomes valid.
           <dd>
 A <a>credential</a> MUST have an <code>issuanceDate</code> <a>property</a>. The
 value of the <code>issuanceDate</code> <a>property</a> MUST be a string value of
-an [[!XMLSCHEMA11-2]] combined <code>date-time</code> string representing the
-date and time the <a>credential</a> becomes valid, which could be a date and
-time in the future. Note that this value represents the earliest point in time
+an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>] combined
+<code>date-time</code> string representing the date and time the
+<a>credential</a> becomes valid, which could be a date and time in the future.
+Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>
 <a>property</a> becomes valid.
           </dd>
@@ -1682,9 +1683,10 @@ It is expected that the next version of this specification will add the
 <code>validFrom</code> <a>property</a> and will deprecate the
 <code>issuanceDate</code> <a>property</a> in favor of a new <code>issued</code>
 <a>property</a>. The range of values for both properties are expected to remain
-as [[?XMLSCHEMA11-2]] combined <code>date-time</code> strings. Implementers are
-advised that the <code>validFrom</code> and <code>issued</code>
-<a>properties</a> are reserved and use for any other purpose is discouraged.
+as [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>] combined
+<code>date-time</code> strings. Implementers are advised that the
+<code>validFrom</code> and <code>issued</code> <a>properties</a> are reserved
+and use for any other purpose is discouraged.
         </p>
 
       </section>
@@ -1792,8 +1794,9 @@ the expression of <a>credential</a> expiration information.
           <dt><var>expirationDate</var></dt>
           <dd>
 If present, the value of the <code>expirationDate</code> <a>property</a> MUST be
-a string value of an [[!XMLSCHEMA11-2]] <code>date-time</code> representing the
-date and time the <a>credential</a> ceases to be valid.
+a string value of an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
+<code>date-time</code> representing the date and time the <a>credential</a>
+ceases to be valid.
           </dd>
         </dl>
 
@@ -3678,10 +3681,10 @@ done:
 
             <ul>
               <li>
-If <code>exp</code> is present, the UNIX timestamp MUST be converted to an
-[[!XMLSCHEMA11-2]] <code>date-time</code>, and MUST be used to set the value
-of the <code>expirationDate</code> <a>property</a> of
-<code>credentialSubject</code> of the new JSON object.
+If <code>exp</code> is present, the UNIX timestamp MUST be converted to an [<a
+data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>] <code>date-time</code>,
+and MUST be used to set the value of the <code>expirationDate</code> 
+<a>property</a> of <code>credentialSubject</code> of the new JSON object.
               </li>
               <li>
 If <code>iss</code> is present, the value MUST be used to set the
@@ -3690,8 +3693,9 @@ If <code>iss</code> is present, the value MUST be used to set the
                   </li>
                   <li>
 If <code>nbf</code> is present, the UNIX timestamp MUST be converted to an
-[[!XMLSCHEMA11-2]] <code>date-time</code>, and MUST be used to set the value
-of the <code>issuanceDate</code> <a>property</a> of the new JSON object.
+[<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
+<code>date-time</code>, and MUST be used to set the value of the
+<code>issuanceDate</code> <a>property</a> of the new JSON object.
                   </li>
                   <li>
 If <code>sub</code> is present, the value MUST be used to set the value of the


### PR DESCRIPTION
This closes #782 by changing the normative reference of how date-time strings are expected to represented


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/822.html" title="Last updated on Sep 30, 2021, 12:08 PM UTC (0db4216)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/822/ea2a3ab...0db4216.html" title="Last updated on Sep 30, 2021, 12:08 PM UTC (0db4216)">Diff</a>