### PR TITLE
add section in privacy considerations about issuer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4606,7 +4606,35 @@ solutions accordingly.
       </p>
     </section>
 
+    <section class="informative">
+      <h3>Issuer Cooperation Impacts on Privacy</h3>
 
+      <p>
+It cannot be understated that <a>verifiable credentials</a> rely on a high
+degree of trust in <a>issuers</a>. The degree to which a <a>holder</a> may take
+advantage of possible privacy protections often depends strongly on the support
+an <a>issuer</a> provides for such features. In many cases, privacy protections
+which make use of zero-knowledge proofs, data minimization techniques, bearer
+credentials, abstract claims, and protections against signature-based
+correlation, require the <a>issuer</a> to actively support such capabilities and
+incorporate them into the <a>verifiable credential</a> they issue.
+      </p>
+      <p>
+It should also be noted that, in addition to a reliance on <a>issuers</a>
+participation to provide <a>verifiable credentials</a> capabilities that help
+preserve <a>holder</a> and <a>subject</a> privacy, <a>holders</a> rely on
+<a>issuers</a> to not deliberately subvert privacy protections. For example, an
+<a>issuer</a> may sign <a>verifiable credentials</a> using a signature scheme
+that protects against signature-based correlation. This would protect the
+<a>holder</a> from being correlated by the signature value as it is shared among
+<a>verifiers</a>. However, if the <a>issuer</a> creates a unique key for each
+issued <a>credential</a>, it may be possible for the <a>issuer</a> to track
+<a>presentations</a> of the <a>credential</a>, regardless of a <a>verifier</a>'s
+inability to do so.
+      </p>
+    </section>
+
+    
   </section>
 
   <section class="informative">

--- a/index.html
+++ b/index.html
@@ -4611,13 +4611,13 @@ solutions accordingly.
 
       <p>
 It cannot be overstated that <a>verifiable credentials</a> rely on a high
-degree of trust in <a>issuers</a>. The degree to which a <a>holder</a> may take
+degree of trust in <a>issuers</a>. The degree to which a <a>holder</a> might take
 advantage of possible privacy protections often depends strongly on the support
 an <a>issuer</a> provides for such features. In many cases, privacy protections
 which make use of zero-knowledge proofs, data minimization techniques, bearer
 credentials, abstract claims, and protections against signature-based
 correlation, require the <a>issuer</a> to actively support such capabilities and
-incorporate them into the <a>verifiable credential</a> they issue.
+incorporate them into the <a>verifiable credentials</a> they issue.
       </p>
       <p>
 It should also be noted that, in addition to a reliance on <a>issuer</a>
@@ -4628,7 +4628,7 @@ preserve <a>holder</a> and <a>subject</a> privacy, <a>holders</a> rely on
 that protects against signature-based correlation. This would protect the
 <a>holder</a> from being correlated by the signature value as it is shared among
 <a>verifiers</a>. However, if the <a>issuer</a> creates a unique key for each
-issued <a>credential</a>, it may be possible for the <a>issuer</a> to track
+issued <a>credential</a>, it might be possible for the <a>issuer</a> to track
 <a>presentations</a> of the <a>credential</a>, regardless of a <a>verifier</a>'s
 inability to do so.
       </p>

--- a/index.html
+++ b/index.html
@@ -4610,7 +4610,7 @@ solutions accordingly.
       <h3>Issuer Cooperation Impacts on Privacy</h3>
 
       <p>
-It cannot be understated that <a>verifiable credentials</a> rely on a high
+It cannot be overstated that <a>verifiable credentials</a> rely on a high
 degree of trust in <a>issuers</a>. The degree to which a <a>holder</a> may take
 advantage of possible privacy protections often depends strongly on the support
 an <a>issuer</a> provides for such features. In many cases, privacy protections
@@ -4620,11 +4620,11 @@ correlation, require the <a>issuer</a> to actively support such capabilities and
 incorporate them into the <a>verifiable credential</a> they issue.
       </p>
       <p>
-It should also be noted that, in addition to a reliance on <a>issuers</a>
-participation to provide <a>verifiable credentials</a> capabilities that help
+It should also be noted that, in addition to a reliance on <a>issuer</a>
+participation to provide <a>verifiable credential</a> capabilities that help
 preserve <a>holder</a> and <a>subject</a> privacy, <a>holders</a> rely on
 <a>issuers</a> to not deliberately subvert privacy protections. For example, an
-<a>issuer</a> may sign <a>verifiable credentials</a> using a signature scheme
+<a>issuer</a> might sign <a>verifiable credentials</a> using a signature scheme
 that protects against signature-based correlation. This would protect the
 <a>holder</a> from being correlated by the signature value as it is shared among
 <a>verifiers</a>. However, if the <a>issuer</a> creates a unique key for each


### PR DESCRIPTION
This PR fixes #209 by adding a section to privacy considerations about the issuers role in providing and not violating privacy protections.

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/830.html" title="Last updated on Nov 22, 2021, 10:32 PM UTC (5b88bf3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/830/f01cdd3...brentzundel:5b88bf3.html" title="Last updated on Nov 22, 2021, 10:32 PM UTC (5b88bf3)">Diff</a>