### PR TITLE
Add Verifiable Credential digital signature views for multiple examples.

### DIFF
--- a/index.html
+++ b/index.html
@@ -933,7 +933,7 @@ discount from a university. In the example below, Pat receives an alumni
     <span class='comment'>// purpose of this proof</span>
     "proofPurpose": "assertionMethod",
     <span class='comment'>// the identifier of the public key that can verify the signature</span>
-    "verificationMethod": "https://example.edu/issuers/565049/keys/1",
+    "verificationMethod": "https://example.edu/issuers/565049#key-1",
     <span class='comment'>// the digital signature value</span>
     "jws": "eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TCYt5X
       sITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUc
@@ -989,7 +989,7 @@ the <a>verifier</a> and <a>verified</a>.
       "type": "RsaSignature2018",
       "created": "2017-06-18T21:19:10Z",
       "proofPurpose": "assertionMethod",
-      "verificationMethod": "https://example.edu/issuers/565049/keys/1",
+      "verificationMethod": "https://example.edu/issuers/565049#key-1",
       "jws": "eyJhbGciOiJSUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..TCYt5X
         sITJX1CxPCT8yAV-TVkIEq_PbChOMqsLfRoPsnsgw5WEuts01mq-pQy7UJiN5mgRxD-WUc
         X16dUEMGlv50aqzpqh4Qktb3rk-BuQy72IFLOqV0G_zS245-kronKb78cPN25DGlcTwLtj
@@ -1199,7 +1199,7 @@ about the <code>id</code>.
         </dl>
 
         <pre class="example nohighlight vc" title="Usage of the id property"
-          data-vc-verification-method="https://example.edu/issuers/565049/keys/1">
+          data-vc-verification-method="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1274,7 +1274,8 @@ in a document containing machine-readable information about the
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the type property">
+        <pre class="example nohighlight vc" title="Usage of the type property"
+          data-vc-verification-method="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1290,8 +1291,7 @@ in a document containing machine-readable information about the
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -1490,7 +1490,9 @@ a set of objects that contain one or more properties that are each related to a
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the credentialSubject property">
+        <pre class="example nohighlight vc"
+          title="Usage of the credentialSubject property"
+          data-vc-verification-method="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1506,8 +1508,7 @@ a set of objects that contain one or more properties that are each related to a
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -1518,7 +1519,8 @@ who are spouses. Note the use of array notation to associate multiple
 <a>subjects</a> with the <code>credentialSubject</code> property.
         </p>
 
-        <pre class="example nohighlight" title="Specifying multiple subjects in a verifiable credential">
+        <pre class="example nohighlight"
+          title="Specifying multiple subjects in a verifiable credential">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1536,8 +1538,7 @@ who are spouses. Note the use of array notation to associate multiple
     "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
     "name": "Morgan Doe",
     "spouse": "did:example:ebfeb1f712ebc6f1c276e12ec21"
-  }]</span>,
-  "proof": { <span class="comment">...</span> }
+  }]</span>
 }
         </pre>
 
@@ -1567,7 +1568,8 @@ machine-readable information about the <a>issuer</a> that can be used to
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of issuer property">
+        <pre class="example nohighlight vc" title="Usage of issuer property"
+          data-vc-verification-method="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1583,8 +1585,7 @@ machine-readable information about the <a>issuer</a> that can be used to
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -1593,7 +1594,9 @@ It is also possible to express additional information about the issuer by
 associating an object with the issuer property:
         </p>
 
-        <pre class="example nohighlight" title="Usage of issuer expanded property">
+        <pre class="example nohighlight vc"
+          title="Usage of issuer expanded property"
+          data-vc-verification-method="did:example:76e12ec712ebc6f1c221ebfeb1f#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1612,8 +1615,7 @@ associating an object with the issuer property:
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -1647,7 +1649,9 @@ at which the information associated with the <code>credentialSubject</code>
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of issuanceDate property">
+        <pre class="example nohighlight vc"
+          title="Usage of issuanceDate property"
+          data-vc-verification-method="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1663,8 +1667,7 @@ at which the information associated with the <code>credentialSubject</code>
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -1743,17 +1746,12 @@ the signing date. The example below uses RSA digital signatures.
     }
   },
   <span class="highlight">"proof": {
-    "type": "RsaSignature2018",
-    "created": "2018-06-18T21:19:10Z",
+    "type": "Ed25519Signature2020",
+    "created": "2021-11-13T18:19:39Z",
+    "verificationMethod": "https://example.edu/issuers/14#key-1",
     "proofPurpose": "assertionMethod",
-    "verificationMethod": "https://example.com/jdoe/keys/1",
-    "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19
-      ..DJBMvvFAIC00nSGB6Tn0XKbbF9XrsaJZREWvR2aONYTQQxnyXirtXnlewJMB
-      Bn2h9hfcGZrvnC1b6PgWmukzFJ1IiH1dWgnDIS81BH-IxXnPkbuYDeySorc4
-      QU9MJxdVkY5EL4HYbcIfwKj6X4LBQ2_ZHZIu1jdqLcRZqHcsDF5KKylKc1TH
-      n5VRWy5WhYg_gBnyWny8E6Qkrze53MR7OuAmmNJ1m1nN8SxDrG6a08L78J0-
-      Fbas5OjAQz3c17GY8mVuDPOBIOVjMEghBlgl3nOi1ysxbRGhHLEK4s0KKbeR
-      ogZdgt1DkQxDFxxn41QWDw_mmMCjs9qxg0zcZzqEJw"
+    "proofValue": "z58DAdFfa9SkqZMVPxAQpic7ndSayn1PzZs6ZjWp1CktyGesjuTSwRdo
+                   WhAfGFCF5bppETSTojQCrfFPP2oumHKtz"
   }</span>
 }
         </pre>
@@ -1789,7 +1787,9 @@ ceases to be valid.
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the expirationDate property">
+        <pre class="example nohighlight vc"
+          title="Usage of the expirationDate property"
+          data-vc-verification-method="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1806,8 +1806,7 @@ ceases to be valid.
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -1859,7 +1858,9 @@ depending on factors such as whether it is simple to implement or if it is
 privacy-enhancing.
         </p>
 
-        <pre class="example nohighlight" title="Usage of the status property">
+        <pre class="example nohighlight vc"
+          title="Usage of the status property"
+          data-vc-verification-method="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1879,8 +1880,7 @@ privacy-enhancing.
   <span class="highlight">"credentialStatus": {
     "id": "https://example.edu/status/24",
     "type": "CredentialStatusList2017"
-  }</span>,
-  "proof": { <span class="comment">...</span> }
+  }</span>
 }
         </pre>
 
@@ -2281,7 +2281,9 @@ extensibility and program correctness are achieved.
 Let us assume we start with the <a>verifiable credential</a> shown below.
         </p>
 
-        <pre class="example nohighlight" title="A simple credential">
+        <pre class="example nohighlight vc"
+          title="A simple credential"
+          data-vc-verification-method="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2294,8 +2296,7 @@ Let us assume we start with the <a>verifiable credential</a> shown below.
   "credentialSubject": {
     "id": "did:example:abcdef1234567",
     "name": "Jane Doe"
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -2350,8 +2351,7 @@ example by including the context and adding the new <a>properties</a> and
     "id": "did:example:abcdef1234567",
     "name": "Jane Doe",
     <span class="highlight">"favoriteFood": "Papaya"</span>
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 
@@ -2501,7 +2501,9 @@ integrity protection mechanism. The <code>credentialSchema</code>
 [[JSON-SCHEMA-2018]] validation.
         </p>
 
-        <pre class="example nohighlight" title="Usage of the credentialSchema property to perform JSON schema validation">
+        <pre class="example nohighlight vc"
+          title="Usage of the credentialSchema property to perform JSON schema validation"
+          data-vc-verification-method="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2521,8 +2523,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
   <span class="highlight">"credentialSchema": {
     "id": "https://example.org/examples/degree.json",
     "type": "JsonSchemaValidator2018"
-  }</span>,
-  "proof": { <span class="comment">...</span> }
+  }</span>
 }
         </pre>
 
@@ -2631,7 +2632,8 @@ determined by the specific <code>refreshService</code> <a>type</a> definition.
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the refreshService property by an issuer">
+        <pre class="example nohighlight"
+          title="Usage of the refreshService property by an issuer">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2651,8 +2653,7 @@ determined by the specific <code>refreshService</code> <a>type</a> definition.
   <span class="highlight">"refreshService": {
     "id": "https://example.edu/refresh/3732"
     "type": "ManualRefreshService2018",
-  }</span>,
-  "proof": { <span class="comment">...</span> }
+  }</span>
 }
         </pre>
 
@@ -2710,7 +2711,9 @@ by the specific <code>termsOfUse</code> <a>type</a> definition.
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the termsOfUse property by an issuer">
+        <pre class="example nohighlight vc"
+          title="Usage of the termsOfUse property by an issuer"
+          data-vc-verification-method="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2737,8 +2740,8 @@ by the specific <code>termsOfUse</code> <a>type</a> definition.
       "target": "http://example.edu/credentials/3732",
       "action": ["Archival"]
     }]
-  }</span>,
-  "proof": { <span class="comment">...</span> }
+  }]
+  </span>
 }
         </pre>
 
@@ -2880,7 +2883,8 @@ non-credential data might be supported by the specification, see the
 Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]] document.
         </p>
 
-        <pre class="example nohighlight" title="Usage of the evidence property">
+        <pre class="example nohighlight"
+          title="Usage of the evidence property">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -4213,7 +4217,9 @@ possible by not specifying the <a>subject</a> identifier, expressed using the
 <a>verifiable credential</a> is a <a>bearer credential</a>:
       </p>
 
-      <pre class="example nohighlight" title="Usage of issuer properties">
+      <pre class="example nohighlight vc"
+        title="Usage of issuer properties"
+        data-vc-verification-method="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -4229,8 +4235,7 @@ possible by not specifying the <a>subject</a> identifier, expressed using the
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
       </pre>
 
@@ -4670,7 +4675,8 @@ example, the following highlighted links are not content-integrity protected but
 probably should be:
       </p>
 
-      <pre class="example nohighlight" title="Non-content-integrity protected links">
+      <pre class="example nohighlight"
+        title="Non-content-integrity protected links">
 {
   "@context": [
     <span class="highlight">"https://www.w3.org/2018/credentials/v1"</span>,

--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script src="./common.js" class="remove"></script>
     <script class="remove"
-      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@0.0.1/dist/main.js"></script>
+      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@0.0.2/dist/main.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@0.0.2/dist/displayVcExample.js"></script>
     <script type="text/javascript" class="remove">
       var respecConfig = {
         group: "vc",

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script src="./common.js" class="remove"></script>
     <script class="remove"
-      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@0.0.2/dist/main.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@0.0.2/dist/displayVcExample.js"></script>
+      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@1.0.0/dist/main.js"></script>
+
     <script type="text/javascript" class="remove">
       var respecConfig = {
         group: "vc",
@@ -1199,7 +1199,7 @@ about the <code>id</code>.
         </dl>
 
         <pre class="example nohighlight vc" title="Usage of the id property"
-          data-vc-verification-method="https://example.edu/issuers/565049#key-1">
+          data-vc-vm="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1275,7 +1275,7 @@ in a document containing machine-readable information about the
         </dl>
 
         <pre class="example nohighlight vc" title="Usage of the type property"
-          data-vc-verification-method="https://example.edu/issuers/565049#key-1">
+          data-vc-vm="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1492,7 +1492,7 @@ a set of objects that contain one or more properties that are each related to a
 
         <pre class="example nohighlight vc"
           title="Usage of the credentialSubject property"
-          data-vc-verification-method="https://example.edu/issuers/565049#key-1">
+          data-vc-vm="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1569,7 +1569,7 @@ machine-readable information about the <a>issuer</a> that can be used to
         </dl>
 
         <pre class="example nohighlight vc" title="Usage of issuer property"
-          data-vc-verification-method="https://example.edu/issuers/14#key-1">
+          data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1596,7 +1596,7 @@ associating an object with the issuer property:
 
         <pre class="example nohighlight vc"
           title="Usage of issuer expanded property"
-          data-vc-verification-method="did:example:76e12ec712ebc6f1c221ebfeb1f#key-1">
+          data-vc-vm="did:example:76e12ec712ebc6f1c221ebfeb1f#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1651,7 +1651,7 @@ at which the information associated with the <code>credentialSubject</code>
 
         <pre class="example nohighlight vc"
           title="Usage of issuanceDate property"
-          data-vc-verification-method="https://example.edu/issuers/14#key-1">
+          data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1789,7 +1789,7 @@ ceases to be valid.
 
         <pre class="example nohighlight vc"
           title="Usage of the expirationDate property"
-          data-vc-verification-method="https://example.edu/issuers/14#key-1">
+          data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1860,7 +1860,7 @@ privacy-enhancing.
 
         <pre class="example nohighlight vc"
           title="Usage of the status property"
-          data-vc-verification-method="https://example.edu/issuers/14#key-1">
+          data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2283,7 +2283,7 @@ Let us assume we start with the <a>verifiable credential</a> shown below.
 
         <pre class="example nohighlight vc"
           title="A simple credential"
-          data-vc-verification-method="https://example.edu/issuers/14#keys-1">
+          data-vc-vm="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2503,7 +2503,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
 
         <pre class="example nohighlight vc"
           title="Usage of the credentialSchema property to perform JSON schema validation"
-          data-vc-verification-method="https://example.edu/issuers/14#keys-1">
+          data-vc-vm="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -2713,7 +2713,7 @@ by the specific <code>termsOfUse</code> <a>type</a> definition.
 
         <pre class="example nohighlight vc"
           title="Usage of the termsOfUse property by an issuer"
-          data-vc-verification-method="https://example.edu/issuers/14#keys-1">
+          data-vc-vm="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -4219,7 +4219,7 @@ possible by not specifying the <a>subject</a> identifier, expressed using the
 
       <pre class="example nohighlight vc"
         title="Usage of issuer properties"
-        data-vc-verification-method="https://example.edu/issuers/14#keys-1">
+        data-vc-vm="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
       src="https://unpkg.com/browse/jquery/dist/jquery.min.js"></script>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script src="./common.js" class="remove"></script>
+    <script class="remove"
+      src="https://cdn.jsdelivr.net/gh/digitalbazaar/respec-vc@0.0.1/dist/main.js"></script>
     <script type="text/javascript" class="remove">
       var respecConfig = {
         group: "vc",
@@ -46,7 +48,11 @@
         // Uncomment these to use the respec extension that generates a list of
         //   normative statements:
         preProcess: [/*prepare_reqlist*/],
-        postProcess: [/*add_reqlist_button*/, restrictRefs],
+        postProcess: [
+          restrictRefs,
+          window.respecVc.createVcExamples
+          /*add_reqlist_button*/
+        ],
 
         github: "https://github.com/w3c/vc-data-model/",
         includePermalinks: false,
@@ -1191,7 +1197,8 @@ about the <code>id</code>.
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the id property">
+        <pre class="example nohighlight vc" title="Usage of the id property"
+          data-vc-verification-method="https://example.edu/issuers/565049/keys/1">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -1207,8 +1214,7 @@ about the <code>id</code>.
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"
     }
-  },
-  "proof": { <span class="comment">...</span> }
+  }
 }
         </pre>
 


### PR DESCRIPTION
This PR adds the [respec-vc](https://github.com/digitalbazaar/respec-vc) extension to the specification and activates it for example #4. You can view the result here:

https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/834.html#example-usage-of-the-id-property

or see the image below:

![image](https://user-images.githubusercontent.com/108611/142772916-03bafc46-c176-4673-b8b3-da19999dccd8.png)

Click the tabs to view the Credential, Verifiable Credential (with proof), and Verifiable Credential (as JWT).

Once this is merged, I can go through and update any other examples that would benefit from this feature. Once that's done, we can close issue #833 and PR #817.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/834.html" title="Last updated on Nov 21, 2021, 5:38 PM UTC (42392a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/834/df99d22...42392a6.html" title="Last updated on Nov 21, 2021, 5:38 PM UTC (42392a6)">Diff</a>