### PR TITLE
Moving a comma for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3576,7 +3576,7 @@ specification. For example, the <code>kid</code> can refer to a key in a
 
             <p>
 For backward compatibility with JWT processors, the following registered JWT
-claim names MUST be used instead of, or in addition to, their respective standard 
+claim names MUST be used, instead of or in addition to, their respective standard 
 <a>verifiable credential</a> counterparts:
             </p>
 


### PR DESCRIPTION
Was a change request on #828 that was "resolved" but not applied.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/840.html" title="Last updated on Nov 22, 2021, 2:37 PM UTC (5fd17ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/840/e77940a...5fd17ee.html" title="Last updated on Nov 22, 2021, 2:37 PM UTC (5fd17ee)">Diff</a>