### PR TITLE
Fix jQuery URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
       For the three scripts below, if your spec resides on dev.w3 you can check them
       out in the same tree and use relative links so that they'll work offline,
      -->
-    <script class="remove"
-      src="https://unpkg.com/jquery/dist/jquery.min.js"></script>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script src="./common.js" class="remove"></script>
     <script class="remove"

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       out in the same tree and use relative links so that they'll work offline,
      -->
     <script class="remove"
-      src="https://unpkg.com/browse/jquery/dist/jquery.min.js"></script>
+      src="https://unpkg.com/jquery/dist/jquery.min.js"></script>
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
     <script src="./common.js" class="remove"></script>
     <script class="remove"


### PR DESCRIPTION
Use the code URL, not the browse UI URL.

Linking to the browse UI is clearly wrong, and was just causing failures when HTML was loaded.  But I have to wonder if jQuery is even used since it wasn't being loaded properly (at least not at this point).

I also think unpkg best practice is to link to a specific version to avoid redirects and ensure use of the same code.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-data-model/pull/850.html" title="Last updated on Dec 9, 2021, 1:12 AM UTC (15ff3d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/850/4b9bdd4...davidlehn:15ff3d0.html" title="Last updated on Dec 9, 2021, 1:12 AM UTC (15ff3d0)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/davidlehn/vc-data-model/pull/850.html" title="Last updated on Dec 16, 2021, 5:46 PM UTC (97991bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/850/4b9bdd4...davidlehn:97991bd.html" title="Last updated on Dec 16, 2021, 5:46 PM UTC (97991bd)">Diff</a>