### PR TITLE
Rename "Linked Data Proofs" to "Data Integrity".

### DIFF
--- a/common.js
+++ b/common.js
@@ -33,9 +33,9 @@ var vcwg = {
       status: "WD",
       publisher: "Internationalization Working Group"
     },
-    "LD-PROOFS": {
-      title: "Linked Data Proofs",
-      href: "https://w3c-ccg.github.io/ld-proofs/",
+    "DATA-INTEGRITY": {
+      title: "Data Integrity",
+      href: "https://w3c-ccg.github.io/data-integrity-spec/",
       authors: [
         "Manu Sporny",
         "Dave Longley"

--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ At the time of publication, Working Group members had implemented
 JSON Web Tokens [[RFC7519]] secured using JSON Web Signatures [[RFC7515]]
           </li>
           <li>
-Data Integrity [[?DATA-INTEGRITY]]
+Data Integrity Proofs [[?DATA-INTEGRITY]]
           </li>
           <li>
 Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
@@ -1704,7 +1704,7 @@ and embedded proofs. An <dfn>external proof</dfn> is one that wraps an
 expression of this data model, such as a JSON Web Token, which is elaborated on
 in Section <a href="#json-web-token"></a>. An <dfn>embedded proof</dfn> is a
 mechanism where the proof is included in the data, such as a Linked Data
-Signature, which is elaborated upon in Section <a href="#linked-data-proofs"></a>.
+Signature, which is elaborated upon in Section <a href="#data-integrity-proofs"></a>.
         </p>
 
         <p>
@@ -2258,8 +2258,8 @@ use of [[?LINKED-DATA]].
           </li>
           <li>
 Support multiple types of cryptographic proof formats through the use of
-Data Integrity [[?DATA-INTEGRITY]] and a variety of signature suites listed
-in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
+Data Integrity Proofs [[?DATA-INTEGRITY]] and a variety of signature suites
+listed in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
           </li>
           <li>
 Provide all of the extensibility mechanisms outlined above in a data format that
@@ -3461,7 +3461,7 @@ being actively utilized to issue <a>verifiable credentials</a> are:
 
         <ul>
           <li>Section <a href="#json-web-token"></a>, and</li>
-          <li>Section <a href="#linked-data-proofs"></a>.</li>
+          <li>Section <a href="#data-integrity-proofs"></a>.</li>
         </ul>
 
         <section>
@@ -3870,7 +3870,7 @@ BjYgP62KvhIvW8BbkGUelYMetA
         </section>
 
         <section>
-          <h4>Linked Data Proofs</h4>
+          <h4>Data Integrity Proofs</h4>
 
           <p>
 This specification utilizes Linked Data to publish information on the Web
@@ -3889,7 +3889,7 @@ which are designed to protect the data model as described by this specification.
 
           <p>
 Unlike the use of JSON Web Token, no extra pre- or post-processing is necessary.
-The Linked Data Proofs format was designed to simply and easily protect
+The Data Integrity Proofs format was designed to simply and easily protect
 <a>verifiable credentials</a> and <a>verifiable presentations</a>. Protecting
 a <a>verifiable credential</a> or <a>verifiable presentation</a> is as simple
 as passing a valid example in this specification to a Linked Data Signatures

--- a/index.html
+++ b/index.html
@@ -579,7 +579,7 @@ At the time of publication, Working Group members had implemented
 JSON Web Tokens [[RFC7519]] secured using JSON Web Signatures [[RFC7515]]
           </li>
           <li>
-Linked Data Proofs [[?LD-PROOFS]]
+Data Integrity [[?DATA-INTEGRITY]]
           </li>
           <li>
 Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
@@ -1022,8 +1022,8 @@ the <a>verifier</a> and <a>verified</a>.
 Implementers that are interested in understanding more about the
 <code>proof</code> mechanism used above can learn more in Section <a
 href="#proofs-signatures"></a> and by reading the following specifications:
-Linked Data Proofs [[?LD-PROOFS]], Linked Data Cryptographic Suites
-Registry[[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded Payload Option
+Data Integrity [[?DATA-INTEGRITY]], Linked Data Cryptographic Suites
+Registry [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded Payload Option
 [[RFC7797]]. A list of proof mechanisms is available in the Verifiable
 Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
         </p>
@@ -1765,7 +1765,7 @@ As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
 single proof mechanism for use with <a>verifiable credentials</a>. For more
 information about the <code>proof</code> mechanism, see the following
-specifications: Linked Data Proofs [[?LD-PROOFS]], Linked Data Cryptographic
+specifications: Data Integrity [[?DATA-INTEGRITY]], Linked Data Cryptographic
 Suites Registries [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded
 Payload Option [[RFC7797]]. A list of proof mechanisms is available in the
 Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
@@ -1971,7 +1971,7 @@ The example below shows a <a>verifiable presentation</a> that embeds
 The contents of the <code>verifiableCredential</code> <a>property</a> shown
 above are <a>verifiable credentials</a>, as described by this specification. The
 contents of the <code>proof</code> <a>property</a> are proofs, as described by
-the Linked Data Proofs [[?LD-PROOFS]] specification. An example of a
+the Data Integrity [[?DATA-INTEGRITY]] specification. An example of a
 <a>verifiable presentation</a> using the JWT proof mechanism is given in section
 <a href="#json-web-token"></a>.
         </p>
@@ -2258,7 +2258,7 @@ use of [[?LINKED-DATA]].
           </li>
           <li>
 Support multiple types of cryptographic proof formats through the use of
-Linked Data Proofs [[?LD-PROOFS]] and a variety of signature suites listed
+Data Integrity [[?DATA-INTEGRITY]] and a variety of signature suites listed
 in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
           </li>
           <li>
@@ -3879,8 +3879,8 @@ their associated properties. When information is presented in this manner,
 other related information can be easily discovered and new information can be
 easily merged into the existing graph of knowledge. Linked Data is
 extensible in a decentralized way, greatly reducing barriers to large scale
-integration. The data model in this specification works well with the
-<a href="https://w3c-ccg.github.io/ld-proofs/">Linked Data Proofs</a> and
+integration. The data model in this specification works well with
+<a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a> and
 the associated <a
   href="https://w3c-ccg.github.io/ld-cryptosuite-registry/">Linked Data
   Cryptographic Suites</a>


### PR DESCRIPTION
This updates the name and link for the [Data Integrity draft specification](https://w3c-ccg.github.io/data-integrity-spec/) that was previously called "Linked Data Proofs", and is mentioned in the [proposed Verifiable Credentials Working Group Charter](https://w3c.github.io/vc-wg-charter/). This may not yet be the final name of that specification.

Fixes https://github.com/w3c/vc-data-model/issues/858.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/peacekeeper/vc-data-model/pull/859.html" title="Last updated on Jan 19, 2022, 8:39 PM UTC (65e46ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/859/74cd6e5...peacekeeper:65e46ac.html" title="Last updated on Jan 19, 2022, 8:39 PM UTC (65e46ac)">Diff</a>