### PR TITLE
address clarification that the URI can be used to retrieve data

### DIFF
--- a/index.html
+++ b/index.html
@@ -2634,7 +2634,7 @@ such that the recipient can refresh the <a>verifiable credential</a>. Each
 <code>refreshService</code> value MUST specify its <code>type</code> (for
 example, <code>ManualRefreshService2018</code>) and its <code>id</code>, which
 is the <a>URI</a> of the service. There is an expectation that machine readable
-information needs to be retrievable from the URI as well. The precise content of
+information needs to be retrievable from the URI. The precise content of
 each refresh service is determined by the specific <code>refreshService</code> 
 <a>type</a> definition.
           </dd>

--- a/index.html
+++ b/index.html
@@ -1847,7 +1847,8 @@ include the following:
 <code>type</code> <a>property</a>, which expresses the <a>credential</a> status
 type (also referred to as the <a>credential</a> status method). It is expected
 that the value will provide enough information to determine the current status
-of the <a>credential</a>. For example, the object could contain a link to an
+of the <a>credential</a> and that machine readable information needs to be
+retrievable from the URI. For example, the object could contain a link to an
 external document noting whether or not the <a>credential</a> is suspended or
 revoked.
               </li>
@@ -2627,13 +2628,15 @@ thereby bypassing the <a>holder</a>.
         <dl>
           <dt><var>refreshService</var></dt>
           <dd>
-The value of the <code>refreshService</code> <a>property</a> MUST be one or
-more refresh services that provides enough information to the recipient's
-software such that the recipient can refresh the <a>verifiable credential</a>.
-Each <code>refreshService</code> value MUST specify its <code>type</code> (for
+The value of the <code>refreshService</code> <a>property</a> MUST be one or more
+refresh services that provides enough information to the recipient's software
+such that the recipient can refresh the <a>verifiable credential</a>. Each
+<code>refreshService</code> value MUST specify its <code>type</code> (for
 example, <code>ManualRefreshService2018</code>) and its <code>id</code>, which
-is the <a>URI</a> of the service. The precise content of each refresh service is
-determined by the specific <code>refreshService</code> <a>type</a> definition.
+is the <a>URI</a> of the service. There is an expectation that machine readable
+information needs to be retrievable from the URI as well. The precise content of
+each refresh service is determined by the specific <code>refreshService</code> 
+<a>type</a> definition.
           </dd>
         </dl>
 


### PR DESCRIPTION
From [feedback on VC Data Model v1.1](https://lists.w3.org/Archives/Public/public-new-work/2022Jan/0002.html)

``` 
* Correction 2, changing "URL" to "URI", moves from a value that can be
fetched to a value that can't necessarily be fetched. The meaning of these
`id` values is undefined both before and after the change, but it moves
from the possibility of defining a general meaning for the fetched
resource, to a need to define the meaning of particular URIs in a table.
That seems like the wrong direction. The WG could cite
https://url.spec.whatwg.org/ if their goal is simply to provide a normative
definition of the "URL" term.
```

The WG also experienced some frustration in attempting to package the proposed corrections in such a way as to make them more accessible for reviewers. We would have definitely benefited from some additional tooling.
The following contain records of the issue and the WG's conversation which led to the corrections related to the above concerns:
- The issue that drove this correction is #748 
- The PR that proposed the changes is #819


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/866.html" title="Last updated on Jan 28, 2022, 9:35 AM UTC (56c0663)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/866/c48544c...56c0663.html" title="Last updated on Jan 28, 2022, 9:35 AM UTC (56c0663)">Diff</a>