### PR TITLE
Updating References in the note on transitive trust

### DIFF
--- a/index.html
+++ b/index.html
@@ -2230,9 +2230,9 @@ models. In the Verifiable Credentials Data Model, a <a>verifier</a> either
 directly trusts or does not trust an <a>issuer</a>. While it is possible to
 build transitive trust models using the Verifiable Credentials Data Model,
 implementers are urged to
-<a href="https://datatracker.ietf.org/doc/draft-housley-web-pki-problems/">learn
+<a href="https://datatracker.ietf.org/doc/draft-iab-web-pki-problems/">learn
 about the security weaknesses</a> introduced by
-<a href="https://www.cs.cornell.edu/people/egs/papers/dnssurvey.pdf">broadly
+<a href="https://www.usenix.org/conference/imc-05/perils-transitive-trust-domain-name-system">broadly
 delegating trust</a> in the manner adopted by Certificate Authority systems.
         </p>
       </section>


### PR DESCRIPTION
Both of the documents referenced in the note on transitive trust are old. Updated to the latest version


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/shigeya/vc-data-model/pull/868.html" title="Last updated on Feb 1, 2022, 6:12 AM UTC (a493a32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/868/c48544c...shigeya:a493a32.html" title="Last updated on Feb 1, 2022, 6:12 AM UTC (a493a32)">Diff</a>