### PR TITLE
Fixes example signature name typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1738,7 +1738,7 @@ as the value of the <code>proof</code> <a>property</a> will vary accordingly.
 For example, if digital signatures are used for the proof mechanism, the
 <code>proof</code> <a>property</a> is expected to have name-value pairs that
 include a signature, a reference to the signing entity, and a representation of
-the signing date. The example below uses RSA digital signatures.
+the signing date. The example below uses Ed25519 digital signatures.
         </p>
 
         <pre class="example nohighlight"


### PR DESCRIPTION
The example contains Ed25519 signature instead of RSA as mentioned
in the line.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kushaldas/vc-data-model/pull/876.html" title="Last updated on Aug 14, 2022, 7:46 PM UTC (c9b2ea5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/876/17329f4...kushaldas:c9b2ea5.html" title="Last updated on Aug 14, 2022, 7:46 PM UTC (c9b2ea5)">Diff</a>