### PR TITLE
Fix the `credentialStatus.type` description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1855,12 +1855,7 @@ include the following:
               </li>
               <li>
 <code>type</code> <a>property</a>, which expresses the <a>credential</a> status
-type (also referred to as the <a>credential</a> status method). It is expected
-that the value will provide enough information to determine the current status
-of the <a>credential</a> and that machine readable information needs to be
-retrievable from the URI. For example, the object could contain a link to an
-external document noting whether or not the <a>credential</a> is suspended or
-revoked.
+type (also referred to as the <a>credential</a> status method).
               </li>
             </ul>
           </dd>
@@ -1871,6 +1866,11 @@ The precise contents of the <a>credential</a> status information is determined
 by the specific <code>credentialStatus</code> <a>type</a> definition, and varies
 depending on factors such as whether it is simple to implement or if it is
 privacy-enhancing.
+It is expected that the value will provide enough information to determine the
+current status of the <a>credential</a> and that machine readable information
+needs to be retrievable from the URI. For example, the object could contain a
+link to an external document noting whether or not the <a>credential</a> is
+suspended or revoked.
         </p>
 
         <pre class="example nohighlight vc"


### PR DESCRIPTION
fixes #891

I moved part of the text that was under the `type` property to the paragraph below that refers to the contents of the whole `credentialStatus` object.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mirceanis/vc-data-model/pull/892.html" title="Last updated on Aug 14, 2022, 7:46 PM UTC (17d414a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/892/17329f4...mirceanis:17d414a.html" title="Last updated on Aug 14, 2022, 7:46 PM UTC (17d414a)">Diff</a>