### PR TITLE
Migrate Data Integrity section to dedicated specification.

### DIFF
--- a/common.js
+++ b/common.js
@@ -33,15 +33,16 @@ var vcwg = {
       status: "WD",
       publisher: "Internationalization Working Group"
     },
-    "DATA-INTEGRITY": {
-      title: "Data Integrity",
-      href: "https://w3c-ccg.github.io/data-integrity-spec/",
+    "VC-DATA-INTEGRITY": {
+      title: "Verifiable Credential Data Integrity",
+      href: "https://w3c.github.io/vc-data-integrity/",
       authors: [
         "Manu Sporny",
-        "Dave Longley"
+        "Dave Longley",
+        "Mike Prorock"
       ],
-      status: "CG-DRAFT",
-      publisher: "Credentials Community Group"
+      status: "ED",
+      publisher: "Verifiable Credentials Working Group"
     },
     "LDP-REGISTRY": {
       title: "Linked Data Cryptographic Suite Registry",

--- a/index.html
+++ b/index.html
@@ -588,7 +588,7 @@ At the time of publication, Working Group members had implemented
 JSON Web Tokens [[RFC7519]] secured using JSON Web Signatures [[RFC7515]]
           </li>
           <li>
-Data Integrity Proofs [[?DATA-INTEGRITY]]
+Data Integrity Proofs [[?VC-DATA-INTEGRITY]]
           </li>
           <li>
 Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
@@ -1031,7 +1031,7 @@ the <a>verifier</a> and <a>verified</a>.
 Implementers that are interested in understanding more about the
 <code>proof</code> mechanism used above can learn more in Section <a
 href="#proofs-signatures"></a> and by reading the following specifications:
-Data Integrity [[?DATA-INTEGRITY]], Linked Data Cryptographic Suites
+Data Integrity [[?VC-DATA-INTEGRITY]], Linked Data Cryptographic Suites
 Registry [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded Payload Option
 [[RFC7797]]. A list of proof mechanisms is available in the Verifiable
 Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
@@ -1713,8 +1713,8 @@ and embedded proofs. An <dfn class="lint-ignore">external proof</dfn> is one
 that wraps an expression of this data model, such as a JSON Web Token, which is
 elaborated on in the Securing Verifiable Credentials using JSON Web Tokens
 [[?VC-JWT]] specification</a>. An <dfn>embedded proof</dfn> is a mechanism where
-the proof is included in the data, such as a Linked Data Signature, which is
-elaborated upon in Section <a href="#data-integrity-proofs"></a>.
+the proof is included in the data, such as a Data Integrity Proof, which is
+elaborated upon in Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]].
         </p>
 
         <p>
@@ -1775,7 +1775,7 @@ As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
 single proof mechanism for use with <a>verifiable credentials</a>. For more
 information about the <code>proof</code> mechanism, see the following
-specifications: Data Integrity [[?DATA-INTEGRITY]], Linked Data Cryptographic
+specifications: Data Integrity [[?VC-DATA-INTEGRITY]], Linked Data Cryptographic
 Suites Registries [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded
 Payload Option [[RFC7797]]. A list of proof mechanisms is available in the
 Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
@@ -1982,7 +1982,7 @@ The example below shows a <a>verifiable presentation</a> that embeds
 The contents of the <code>verifiableCredential</code> <a>property</a> shown
 above are <a>verifiable credentials</a>, as described by this specification. The
 contents of the <code>proof</code> <a>property</a> are proofs, as described by
-the Data Integrity [[?DATA-INTEGRITY]] specification. An example of a
+the Data Integrity [[?VC-DATA-INTEGRITY]] specification. An example of a
 <a>verifiable presentation</a> using the JWT proof mechanism is
 provided in the Securing Verifiable Credentials using JSON Web Tokens
 [[?VC-JWT]] specification.
@@ -2273,7 +2273,7 @@ use of [[?LINKED-DATA]].
           </li>
           <li>
 Support multiple types of cryptographic proof formats through the use of
-Data Integrity Proofs [[?DATA-INTEGRITY]] and a variety of signature suites
+Data Integrity Proofs [[?VC-DATA-INTEGRITY]] and a variety of signature suites
 listed in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
           </li>
           <li>
@@ -3478,46 +3478,13 @@ being actively utilized to issue <a>verifiable credentials</a> are:
 
         <ul>
           <li>
-<a href="https://w3c.github.io/vc-jwt/">Using JWTs to Secure Verifiable
-Credentials</a>, and
+Verifiable Credentials using JSON Web Tokens [[?VC-JWT]], and
           </li>
-          <li>Section <a href="#data-integrity-proofs"></a>.</li>
+          <li>
+Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]].
+          </li>
         </ul>
 
-        <section>
-          <h4>Data Integrity Proofs</h4>
-
-          <p>
-This specification utilizes Linked Data to publish information on the Web
-using standards, such as URLs and JSON-LD, to identify <a>subjects</a> and
-their associated properties. When information is presented in this manner,
-other related information can be easily discovered and new information can be
-easily merged into the existing graph of knowledge. Linked Data is
-extensible in a decentralized way, greatly reducing barriers to large scale
-integration. The data model in this specification works well with
-<a href="https://w3c-ccg.github.io/data-integrity-spec/">Data Integrity</a> and
-the associated <a
-  href="https://w3c-ccg.github.io/ld-cryptosuite-registry/">Linked Data
-  Cryptographic Suites</a>
-which are designed to protect the data model as described by this specification.
-          </p>
-
-          <p>
-Unlike the use of JSON Web Token, no extra pre- or post-processing is necessary.
-The Data Integrity Proofs format was designed to simply and easily protect
-<a>verifiable credentials</a> and <a>verifiable presentations</a>. Protecting
-a <a>verifiable credential</a> or <a>verifiable presentation</a> is as simple
-as passing a valid example in this specification to a Linked Data Signatures
-implementation and generating a digital signature.
-          </p>
-
-          <p class="note">
-For more information about the different qualities of the various syntax
-formats (for example, JSON+JWT, JSON-LD+JWT, or JSON-LD+LD-Proofs), see the
-Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]] document.
-          </p>
-
-        </section>
       </section>
     </section>
 


### PR DESCRIPTION
This PR migrates the data integrity section into a dedicated specification.

DO NOT MERGE this until the Data Integrity specification is migrated into the VCWG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/900.html" title="Last updated on Aug 14, 2022, 8:23 PM UTC (17c8957)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/900/893fa58...17c8957.html" title="Last updated on Aug 14, 2022, 8:23 PM UTC (17c8957)">Diff</a>