### PR TITLE
Specify the draft Verifiable Credentials v2.0 context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -78,7 +78,8 @@
         },
         "proof": {
           "@id": "https://w3id.org/security#proof",
-          "@type": "@id", "@container": "@graph"
+          "@type": "@id", 
+          "@container": "@graph"
         },
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -51,7 +51,8 @@
         },
         "proof": {
           "@id": "https://w3id.org/security#proof",
-          "@type": "@id", "@container": "@graph"
+          "@type": "@id", 
+          "@container": "@graph"
         },
         "refreshService": {
           "@id": "https://www.w3.org/2018/credentials#refreshService",
@@ -89,7 +90,8 @@
         },
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
-          "@type": "@id", "@container": "@graph"
+          "@type": "@id", 
+          "@container": "@graph"
         }
       }
     }

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -51,7 +51,7 @@
         },
         "proof": {
           "@id": "https://w3id.org/security#proof",
-          "@type": "@id", 
+          "@type": "@id",
           "@container": "@graph"
         },
         "refreshService": {
@@ -61,14 +61,6 @@
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
           "@type": "@id"
-        },
-        "validFrom": {
-          "@id": "https://www.w3.org/2018/credentials#validFrom",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "validUntil": {
-          "@id": "https://www.w3.org/2018/credentials#validUntil",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
         }
       }
     },
@@ -90,7 +82,7 @@
         },
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
-          "@type": "@id", 
+          "@type": "@id",
           "@container": "@graph"
         }
       }

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -1,0 +1,92 @@
+{
+  "@context": {
+    "@protected": true,
+
+    "id": "@id",
+    "type": "@type",
+
+    "VerifiableCredential": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+      "@context": {
+        "@protected": true,
+
+        "credentialSchema": {
+          "@id": "https://www.w3.org/2018/credentials#credentialSchema",
+          "@type": "@id"
+        },
+        "credentialStatus": {
+          "@id": "https://www.w3.org/2018/credentials#credentialStatus",
+          "@type": "@id"
+        },
+        "credentialSubject": {
+          "@id": "https://www.w3.org/2018/credentials#credentialSubject",
+          "@type": "@id"
+        },
+        "description": {
+          "@id": "https://schema.org/description",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "evidence": {
+          "@id": "https://www.w3.org/2018/credentials#evidence",
+          "@type": "@id"
+        },
+        "holder": {
+          "@id": "https://www.w3.org/2018/credentials#holder",
+          "@type": "@id"
+        },
+        "issued": {
+          "@id": "https://www.w3.org/2018/credentials#issued",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "issuer": {
+          "@id": "https://www.w3.org/2018/credentials#issuer",
+          "@type": "@id"
+        },
+        "name": {
+          "@id": "https://schema.org/description",
+          "@type": "http://www.w3.org/2001/XMLSchema#string"
+        },
+        "proof": {
+          "@id": "https://w3id.org/security#proof",
+          "@type": "@id", "@container": "@graph"
+        },
+        "refreshService": {
+          "@id": "https://www.w3.org/2018/credentials#refreshService",
+          "@type": "@id"
+        },
+        "termsOfUse": {
+          "@id": "https://www.w3.org/2018/credentials#termsOfUse",
+          "@type": "@id"
+        },
+        "validFrom": {
+          "@id": "https://www.w3.org/2018/credentials#validFrom",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "validUntil": {
+          "@id": "https://www.w3.org/2018/credentials#validUntil",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+
+    "VerifiablePresentation": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+      "@context": {
+        "@protected": true,
+
+        "holder": {
+          "@id": "https://www.w3.org/2018/credentials#holder",
+          "@type": "@id"
+        },
+        "proof": {
+          "@id": "https://w3id.org/security#proof",
+          "@type": "@id", "@container": "@graph"
+        },
+        "verifiableCredential": {
+          "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
+          "@type": "@id", "@container": "@graph"
+        }
+      }
+    }
+  }
+}

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -10,6 +10,9 @@
       "@context": {
         "@protected": true,
 
+        "id": "@id",
+        "type": "@type",
+
         "credentialSchema": {
           "@id": "https://www.w3.org/2018/credentials#credentialSchema",
           "@type": "@id"
@@ -74,6 +77,8 @@
       "@context": {
         "@protected": true,
 
+        "id": "@id",
+        "type": "@type",
         "holder": {
           "@id": "https://www.w3.org/2018/credentials#holder",
           "@type": "@id"


### PR DESCRIPTION
This PR addresses PR #752 and issue #904 by specifying the Verifiable Credential v2 JSON-LD Context. The new context:

1. Removes all cryptography suites (until it becomes clear what the plan for future suites and the core context are) as requested by @OR13.
2. Removes the use of CURIEs and replaces them with full URLs as requested by @dlongley .
3. Adds the `name` and `description` VC properties as requested in PR #752 by @tplooker and @kdenhartog.
4. Temporarily removes issuanceDate/expirationDate/validFrom/validUntil due to lack of consensus on which ones to use.

This is just an initial PR for a draft v2 context. It's expected that it will change as the WG progresses its discussions.