### PR TITLE
Remove proof from v2 context

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -49,11 +49,6 @@
           "@id": "https://schema.org/description",
           "@type": "http://www.w3.org/2001/XMLSchema#string"
         },
-        "proof": {
-          "@id": "https://w3id.org/security#proof",
-          "@type": "@id",
-          "@container": "@graph"
-        },
         "refreshService": {
           "@id": "https://www.w3.org/2018/credentials#refreshService",
           "@type": "@id"
@@ -75,11 +70,6 @@
         "holder": {
           "@id": "https://www.w3.org/2018/credentials#holder",
           "@type": "@id"
-        },
-        "proof": {
-          "@id": "https://w3id.org/security#proof",
-          "@type": "@id", 
-          "@container": "@graph"
         },
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",


### PR DESCRIPTION
Related: https://github.com/w3c/vc-data-model/issues/881

`proof` is not a property of "Credentials" it is a property of "Verifiable Credentials" that are secured by Data Integrity.

The context defining the data integrity suite that is used to "secure a verifiable credential" should define proof, since it also needs to define the `proof.type` and other associated attributes.

