### PR TITLE
Add DataIntegrityProof to credentials/v2 JSON-LD Context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -78,13 +78,76 @@
         },
         "proof": {
           "@id": "https://w3id.org/security#proof",
-          "@type": "@id", 
+          "@type": "@id",
           "@container": "@graph"
         },
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
           "@type": "@id",
           "@container": "@graph"
+        }
+      }
+    },
+
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "cryptosuite": "https://w3id.org/security#cryptosuite",
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
         }
       }
     }


### PR DESCRIPTION
This PR addresses issue #901 by adding DataIntegrityProof to the credentials/v2 JSON-LD Context. Here's the proposal for streamlining Data Integrity cryptosuites that was discussed at W3C TPAC:

https://docs.google.com/presentation/d/16J9TcFc6fX18Cun_Rhj3xqNlnhkCs6MnPkGBlRL3YKg/edit

This PR establishes the entirety of what we'd need to include in the credentials/v2 context to support the proposal above. This addition should cover around 80%-ish of the data integrity proof use cases we have and ensure that we don't have to keep adding date-stamped cryptosuites to the base VC context. It also makes life easier for developers using Data Integrity and VCs (as they don't have to specify separate JSON-LD Cryptosuite contexts).

Here's an open source library that implements a cryptosuite based on the new DataIntegrityProof type (with a README explaining how to use it):

https://github.com/digitalbazaar/eddsa-2022-cryptosuite

Here's a draft interoperability test suite demonstrating its implementability (for `eddsa-2022`):

https://w3c-ccg.github.io/di-eddsa-2022-test-suite/#conformance

The Data Integrity specification has defined this over the course of the last several weeks with reviews from multiple WG members, changes requested and made, and consensus achieved on the core concepts:

https://w3c.github.io/vc-data-integrity/#how-it-works

... and is defined normatively here:

https://w3c.github.io/vc-data-integrity/#proofs
https://w3c.github.io/vc-data-integrity/#dataintegrityproof

This PR is an alternate proposal to PR #924.