### PR TITLE
Corrects out of sync link titles in section 4.3 to json-ld spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1715,7 +1715,7 @@ This specification identifies two classes of proof mechanisms: external proofs
 and embedded proofs. An <dfn class="lint-ignore">external proof</dfn> is one
 that wraps an expression of this data model, such as a JSON Web Token, which is
 elaborated on in the Securing Verifiable Credentials using JSON Web Tokens
-[[?VC-JWT]] specification</a>. An <dfn>embedded proof</dfn> is a mechanism where
+[[?VC-JWT]] specification. An <dfn>embedded proof</dfn> is a mechanism where
 the proof is included in the data, such as a Data Integrity Proof, which is
 elaborated upon in Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]].
         </p>

--- a/index.html
+++ b/index.html
@@ -1417,9 +1417,9 @@ A valid evidence <a>type</a>. For example,<br>
         <p class="note">
 The <a>type</a> system for the Verifiable Credentials Data Model is the same as
 for [[JSON-LD]] and is detailed in
-<a href="https://www.w3.org/TR/json-ld/#specifying-the-type">Section 5.4:
+<a href="https://www.w3.org/TR/json-ld/#specifying-the-type">Section 3.5:
 Specifying the Type</a> and
-<a href="https://www.w3.org/TR/json-ld/#json-ld-grammar">Section 8: JSON-LD
+<a href="https://www.w3.org/TR/json-ld/#json-ld-grammar">Section 9: JSON-LD
 Grammar</a>. When using a JSON-LD context (see Section
 <a href="#extensibility"></a>), this specification aliases the
 <code>@type</code> keyword to <code>type</code> to make the JSON-LD documents


### PR DESCRIPTION
Minor corrections on links. In section 4.3 the note mentions:
_"The type system for the Verifiable Credentials Data Model is the same as for [JSON-LD] and is detailed in Section 5.4: Specifying the Type and Section 8: JSON-LD Grammar."_

It  noted that section numbers in the links are out of sync with the JSON-LD spec. They should respectively point to :
- Section 3.5: Specifying the Type 
- Section 9: JSON-LD Grammar.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/richardbergquist/vc-data-model/pull/955.html" title="Last updated on Oct 24, 2022, 8:59 PM UTC (1ba9bb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/955/5f62aed...richardbergquist:1ba9bb4.html" title="Last updated on Oct 24, 2022, 8:59 PM UTC (1ba9bb4)">Diff</a>