### PR TITLE
fix: fixes #762

### DIFF
--- a/index.html
+++ b/index.html
@@ -1502,10 +1502,9 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
           <dt>credentialSubject</dt>
           <dd>
 The value of the <code>credentialSubject</code> <a>property</a> is defined as
-a set of objects that contain one or more properties that are each related to a
+a set of objects that MUST contain one or more properties that are each related to a
 <a>subject</a> of the <a>verifiable credential</a>. Each object MAY contain an
-<code>id</code>, as described in Section <a href="#identifiers"></a>. Furthermore,
-each object MUST contain at least one or more <a>claims</a> about the subject.
+<code>id</code>, as described in Section <a href="#identifiers"></a>.
           </dd>
         </dl>
         

--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,7 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
           <dt>credentialSubject</dt>
           <dd>
 The value of the <code>credentialSubject</code> <a>property</a> is defined as
-a set of objects that MUST contain one or more properties that are each related to a
+a set of objects that contain one or more properties that are each related to a
 <a>subject</a> of the <a>verifiable credential</a>. Each object MAY contain an
 <code>id</code>, as described in Section <a href="#identifiers"></a>.
           </dd>
@@ -3456,6 +3456,11 @@ that as long as the same <code>@context</code> declaration is made at the top of
 a <a>verifiable credential</a> or <a>verifiable presentation</a>,
 interoperability is guaranteed for all terms understood by users of the data
 model whether or not they use a [[!JSON-LD]] processor.
+            </li>
+            <li>
+A <code>credentialSubject</code> MUST NOT be represented as a single string
+value. This includes cases where the <code>credentialSubject</code> contains
+only an <code>id</code> property.
             </li>
           </ul>
         </section>

--- a/index.html
+++ b/index.html
@@ -1504,10 +1504,11 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
 The value of the <code>credentialSubject</code> <a>property</a> is defined as
 a set of objects that contain one or more properties that are each related to a
 <a>subject</a> of the <a>verifiable credential</a>. Each object MAY contain an
-<code>id</code>, as described in Section <a href="#identifiers"></a>.
+<code>id</code>, as described in Section <a href="#identifiers"></a>. Furthermore,
+each object MUST contain at least one or more <a>claims</a> about the subject.
           </dd>
         </dl>
-
+        
         <pre class="example nohighlight vc"
           title="Usage of the credentialSubject property"
           data-vc-vm="https://example.edu/issuers/565049#key-1">


### PR DESCRIPTION
Forbids `credentialSubject` represented as JSON-LD string values. I found it more appropriate to add this language to the JSON-LD section since it is JSON-LD related.