### PR TITLE
Rename issuanceDate/expirationDate to validFrom/validUntil.

### DIFF
--- a/diagrams/credential-graph.svg
+++ b/diagrams/credential-graph.svg
@@ -39,7 +39,7 @@ and a public key belonging to the creator, Example University.
 		    <text x="385" y="290">Credential 123</text>
 
 		  <line x1="350" y1="282" x2="250" y2="282" />
-		  	<text x="265" y="265">issuanceDate</text>
+		  	<text x="265" y="265">validFrom</text>
 		    <rect x="60" y="265" width="190" height="40" />
 		      <text x="80" y="290">2010-01-01T19:37.24Z</text>
 

--- a/diagrams/presentation-graph.svg
+++ b/diagrams/presentation-graph.svg
@@ -67,7 +67,7 @@ A signature with a nonce, date, algorithm used, and a public key for the proof's
 		    <text x="385" y="290">Credential 123</text>
 
 		  <line x1="350" y1="282" x2="250" y2="282" />
-		  	<text x="265" y="265">issuanceDate</text>
+		  	<text x="265" y="265">validFrom</text>
 		    <rect x="60" y="265" width="190" height="40" />
 		      <text x="80" y="290">2010-01-01T19:37.24Z</text>
 

--- a/index.html
+++ b/index.html
@@ -249,8 +249,8 @@ the classes of vehicle entitled to drive, or date of birth)
 Evidence related to how the <a>credential</a> was derived
           </li>
           <li>
-Information related to constraints on the credential (for example, expiration
-date, or terms of use).
+Information related to constraints on the credential (for example,
+validity period, or terms of use).
           </li>
         </ul>
 
@@ -705,11 +705,11 @@ expected to be added to the graph.
 
         <p>
 A <a>credential</a> is a set of one or more <a>claims</a> made by the same
-<a>entity</a>. <a>Credentials</a> might also include an identifier and
-metadata to describe properties of the <a>credential</a>, such as the
-<a>issuer</a>, the expiry date and time, a representative image, a public key
-to use for <a>verification</a> purposes, the revocation mechanism, and so on.
-The metadata might be signed by the <a>issuer</a>. A
+<a>entity</a>. <a>Credentials</a> might also include an identifier and metadata
+to describe properties of the <a>credential</a>, such as the
+<a>issuer</a>, the validity date and time period, a representative image, a
+public key to use for <a>verification</a> purposes, the revocation mechanism,
+and so on. The metadata might be signed by the <a>issuer</a>. A
 <a>verifiable credential</a> is a set of tamper-evident <a>claims</a> and
 metadata that cryptographically prove who issued it.
         </p>
@@ -2561,10 +2561,10 @@ then be used by a <a>verifier</a> to determine if the proof provided with the
         <h3>Refreshing</h3>
 
         <p>
-It is useful for systems to enable the manual or automatic refresh of an
-expired <a>verifiable credential</a>. For more information about expired
-<a>verifiable credentials</a>, see Section <a href="#expiration"></a>. This
-specification defines a <code>refreshService</code> <a>property</a>, which
+It is useful for systems to enable the manual or automatic refresh of an expired
+<a>verifiable credential</a>. For more information about validity periods for
+<a>verifiable credentials</a>, see Section <a href="#validity-periods"></a>.
+This specification defines a <code>refreshService</code> <a>property</a>, which
 enables an <a>issuer</a> to include a link to a refresh service.
         </p>
         <p>
@@ -4107,7 +4107,7 @@ automatic.
         <p>
 For example, an <code>ageOver</code> <a>verifiable credential</a> is useful for
 gaining access to a bar. If an <a>issuer</a> issues such a
-<a>verifiable credential</a> with a very short expiration date and an automatic
+<a>verifiable credential</a> with a very short validity period and an automatic
 renewal mechanism, then the <a>issuer</a> could possibly correlate the behavior
 of the <a>holder</a> in a way that negatively impacts the <a>holder</a>.
         </p>
@@ -4381,14 +4381,14 @@ would comprise a false <a>claim</a>.
 
         <p>
 When <a>verifiable credentials</a> are issued for highly dynamic information,
-implementers should ensure the expiration times are set appropriately.
-Expiration periods longer than the timeframe where the
-<a>verifiable credential</a> is valid might create exploitable security
-vulnerabilities. Expiration periods shorter than the timeframe where the
-information expressed by the <a>verifiable credential</a> is valid creates a
-burden on <a>holders</a> and <a>verifiers</a>. It is therefore important to set
-validity periods for <a>verifiable credentials</a> that are appropriate to the
-use case and the expected lifetime for the information contained in the
+implementers should ensure the validity periods are set appropriately. Validity
+periods longer than the timeframe where the <a>verifiable credential</a> is
+meant for use might create exploitable security vulnerabilities. Validity
+periods shorter than the timeframe where the information expressed by the
+<a>verifiable credential</a> is expected to be used creates a burden on
+<a>holders</a> and <a>verifiers</a>. It is therefore important to set validity
+periods for <a>verifiable credentials</a> that are appropriate to the use case
+and the expected lifetime for the information contained in the
 <a>verifiable credential</a>.
         </p>
       </section>
@@ -4712,7 +4712,7 @@ signatures, implementations are expected to ensure:
           <li>
 Acceptably recent metadata regarding the public key associated with the
 signature is available. For example, the metadata might include
-<a>properties</a> related to expiration, key owner, or key purpose.
+<a>properties</a> related to validity periods, key owner, or key purpose.
           </li>
           <li>
 The key is not suspended, revoked, or expired.
@@ -4744,12 +4744,13 @@ purposes and to a <a>verifiable credential</a> as a method of assertion.
       </section>
 
       <section class="informative">
-        <h3>Expiration</h3>
+        <h3>Validity Periods</h3>
 
         <p>
-The <code>validUntil</code> is expected to be within an expected range
-for the <a>verifier</a>. For example, a <a>verifier</a> can check that the end of the
-validity period of a <a>verifiable credential</a> is not in the past.
+The <code>validFrom</code> and <code>validUntil</code> properties are expected
+to be within an expected range for the <a>verifier</a>. For example, a
+<a>verifier</a> can check that the end of the validity period of a <a>verifiable
+credential</a> is not in the past.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -756,7 +756,7 @@ which is usually a digital signature.
                Proof Graph on the bottom.  The Credental Graph has
                Credential 123 with 4 properties: 'type' of value
                AlumniCredential, 'issuer' of Example University,
-               'issuanceDate' of 2010-01-01T19:23:24Z, and
+               'validFrom' of 2010-01-01T19:23:24Z, and
                credentialSubject of Pat, who has an alumniOf property
                with value of Example University.  The Proof Graph has
                Signature 456 with 5 properties: 'type' of
@@ -924,7 +924,7 @@ discount from a university. In the example below, Pat receives an alumni
   <span class='comment'>// the entity that issued the credential</span>
   "issuer": "https://example.edu/issuers/565049",
   <span class='comment'>// when the credential was issued</span>
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   <span class='comment'>// claims about the subjects of the credential</span>
   "credentialSubject": {
     <span class='comment'>// identifier for the only subject of the credential</span>
@@ -989,7 +989,7 @@ the <a>verifier</a> and <a>verified</a>.
     "id": "http://example.edu/credentials/1872",
     "type": ["VerifiableCredential", "AlumniCredential"],
     "issuer": "https://example.edu/issuers/565049",
-    "issuanceDate": "2010-01-01T19:23:24Z",
+    "validFrom": "2010-01-01T19:23:24Z",
     "credentialSubject": {
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "alumniOf": {
@@ -1120,7 +1120,7 @@ processors that support JSON-LD can process the <code>@context</code>
   "id": "http://example.edu/credentials/58473",
   "type": ["VerifiableCredential", "AlumniCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T00:00:00Z",
+  "validFrom": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "alumniOf": {
@@ -1226,7 +1226,7 @@ about the <code>id</code>.
   <span class="highlight">"id": "http://example.edu/credentials/3732"</span>,
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T00:00:00Z",
+  "validFrom": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     <span class="highlight">"id": "did:example:ebfeb1f712ebc6f1c276e12ec21"</span>,
     "degree": {
@@ -1302,7 +1302,7 @@ in a document containing machine-readable information about the
   "id": "http://example.edu/credentials/3732",
   <span class="highlight">"type": ["VerifiableCredential", "UniversityDegreeCredential"]</span>,
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T00:00:00Z",
+  "validFrom": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1519,7 +1519,7 @@ a set of objects that MUST contain one or more claims that are each related to a
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T00:00:00Z",
+  "validFrom": "2010-01-01T00:00:00Z",
   <span class="highlight">"credentialSubject"</span>: {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1547,7 +1547,7 @@ who are spouses. Note the use of array notation to associate multiple
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "RelationshipCredential"],
   "issuer": "https://example.com/issuer/123",
-  "issuanceDate": "2010-01-01T00:00:00Z",
+  "validFrom": "2010-01-01T00:00:00Z",
   "credentialSubject": <span class="highlight">[{
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "name": "Jayden Doe",
@@ -1596,7 +1596,7 @@ machine-readable information about the <a>issuer</a> that can be used to
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   <span class="highlight">"issuer": "https://example.edu/issuers/14"</span>,
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1626,7 +1626,7 @@ associating an object with the issuer property:
     "id": "did:example:76e12ec712ebc6f1c221ebfeb1f",
     "name": "Example University"
   }</span>,
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1649,15 +1649,15 @@ example, <code>"did:example:abfe13f712120431c276e12ecab"</code>).
         <h3>Issuance Date</h3>
 
         <p>
-This specification defines the <code>issuanceDate</code> <a>property</a> for
+This specification defines the <code>validFrom</code> <a>property</a> for
 expressing the date and time when a <a>credential</a> becomes valid.
         </p>
 
         <dl>
-          <dt><var>issuanceDate</var></dt>
+          <dt><var>validFrom</var></dt>
           <dd>
-A <a>credential</a> MUST have an <code>issuanceDate</code> <a>property</a>. The
-value of the <code>issuanceDate</code> <a>property</a> MUST be a string value of
+A <a>credential</a> MUST have an <code>validFrom</code> <a>property</a>. The
+value of the <code>validFrom</code> <a>property</a> MUST be a string value of
 an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>] combined
 <code>date-time</code> string representing the date and time the
 <a>credential</a> becomes valid, which could be a date and time in the future.
@@ -1668,7 +1668,7 @@ at which the information associated with the <code>credentialSubject</code>
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Usage of issuanceDate property"
+          title="Usage of validFrom property"
           data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
@@ -1678,7 +1678,7 @@ at which the information associated with the <code>credentialSubject</code>
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  <span class="highlight">"issuanceDate": "2010-01-01T19:23:24Z"</span>,
+  <span class="highlight">"validFrom": "2010-01-01T19:23:24Z"</span>,
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1688,17 +1688,6 @@ at which the information associated with the <code>credentialSubject</code>
   }
 }
         </pre>
-
-        <p class="note">
-It is expected that the next version of this specification will add the
-<code>validFrom</code> <a>property</a> and will deprecate the
-<code>issuanceDate</code> <a>property</a> in favor of a new <code>issued</code>
-<a>property</a>. The range of values for both properties are expected to remain
-as [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>] combined
-<code>date-time</code> strings. Implementers are advised that the
-<code>validFrom</code> and <code>issued</code> <a>properties</a> are reserved
-and use for any other purpose is discouraged.
-        </p>
 
       </section>
 
@@ -1756,7 +1745,7 @@ the signing date. The example below uses Ed25519 digital signatures.
   "id": "http://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1792,14 +1781,14 @@ Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
         <h3>Expiration</h3>
 
         <p>
-This specification defines the <code>expirationDate</code> <a>property</a> for
+This specification defines the <code>validUntil</code> <a>property</a> for
 the expression of <a>credential</a> expiration information.
         </p>
 
         <dl>
-          <dt><var>expirationDate</var></dt>
+          <dt><var>validUntil</var></dt>
           <dd>
-If present, the value of the <code>expirationDate</code> <a>property</a> MUST be
+If present, the value of the <code>validUntil</code> <a>property</a> MUST be
 a string value of an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
 <code>date-time</code> representing the date and time the <a>credential</a>
 ceases to be valid.
@@ -1807,7 +1796,7 @@ ceases to be valid.
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Usage of the expirationDate property"
+          title="Usage of the validUntil property"
           data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
@@ -1817,8 +1806,8 @@ ceases to be valid.
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
-  <span class="highlight">"expirationDate": "2020-01-01T19:23:24Z"</span>,
+  "validFrom": "2010-01-01T19:23:24Z",
+  <span class="highlight">"validUntil": "2020-01-01T19:23:24Z"</span>,
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1828,14 +1817,6 @@ ceases to be valid.
   }
 }
         </pre>
-
-        <p class="note">
-It is expected that the next version of this specification will add the
-<code>validUntil</code> <a>property</a> in a way that deprecates, but
-preserves backwards compatibility with the <code>expirationDate</code>
-<a>property</a>. Implementers are advised that the <code>validUntil</code>
-<a>property</a> is reserved and its use for any other purpose is discouraged.
-        </p>
 
       </section>
 
@@ -1889,7 +1870,7 @@ suspended or revoked.
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -2317,7 +2298,7 @@ Let us assume we start with the <a>verifiable credential</a> shown below.
   "id": "http://example.com/credentials/4643",
   "type": ["VerifiableCredential"],
   "issuer": "https://example.com/issuers/14",
-  "issuanceDate": "2018-02-24T05:28:04Z",
+  "validFrom": "2018-02-24T05:28:04Z",
   "credentialSubject": {
     "id": "did:example:abcdef1234567",
     "name": "Jane Doe"
@@ -2370,7 +2351,7 @@ example by including the context and adding the new <a>properties</a> and
   "id": "http://example.com/credentials/4643",
   "type": ["VerifiableCredential", "CustomExt12"],
   "issuer": "https://example.com/issuers/14",
-  "issuanceDate": "2018-02-24T05:28:04Z",
+  "validFrom": "2018-02-24T05:28:04Z",
   <span class="highlight">"referenceNumber": 83294847,</span>
   "credentialSubject": {
     "id": "did:example:abcdef1234567",
@@ -2537,7 +2518,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -2581,7 +2562,7 @@ see Section <a href="#zero-knowledge-proofs"></a>.
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -2669,7 +2650,7 @@ each refresh service is determined by the specific <code>refreshService</code>
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -2749,7 +2730,7 @@ by the specific <code>termsOfUse</code> <a>type</a> definition.
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -2807,7 +2788,7 @@ in an archive.
     "id": "http://example.edu/credentials/3732",
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],
     "issuer": "https://example.edu/issuers/14",
-    "issuanceDate": "2010-01-01T19:23:24Z",
+    "validFrom": "2010-01-01T19:23:24Z",
     "credentialSubject": {
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "degree": {
@@ -2920,7 +2901,7 @@ Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]] document.
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -3248,7 +3229,7 @@ can issue the <a>credential</a> shown below and present it to the
     },
   }</span>,
   "issuer": "https://example.com/people#me",
-  "issuanceDate": "2017-12-05T14:27:42Z",
+  "validFrom": "2017-12-05T14:27:42Z",
   "proof": { <span class="comment">...</span> }
 }
         </pre>
@@ -3329,10 +3310,10 @@ If present, the following properties are represented as a single value:
 <code>issuer</code> <a>property</a>
         </li>
         <li>
-<code>issuanceDate</code> <a>property</a>
+<code>validFrom</code> <a>property</a>
         </li>
         <li>
-<code>expirationDate</code> <a>property</a>.
+<code>validUntil</code> <a>property</a>.
         </li>
       </ul>
 
@@ -3821,7 +3802,7 @@ possible by not specifying the <a>subject</a> identifier, expressed using the
   "id": "http://example.edu/credentials/temporary/28934792387492384",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2017-10-22T12:23:48Z",
+  "validFrom": "2017-10-22T12:23:48Z",
   "credentialSubject": {
     <span class="comment">// note that the 'id' property is not specified for bearer credentials</span>
     "degree": {
@@ -4722,9 +4703,9 @@ checking the proofs on the <a>verifiable credentials</a>.
         <h3>Issuance Date</h3>
 
         <p>
-The <code>issuanceDate</code> is expected to be within an expected range for the
-<a>verifier</a>. For example, a <a>verifier</a> can check that the issuance date
-of a <a>verifiable credential</a> is not in the future.
+The <code>validFrom</code> is expected to be within an expected range for the
+<a>verifier</a>. For example, a <a>verifier</a> can check that the start of
+a validity period for a <a>verifiable credential</a> is not in the future.
         </p>
       </section>
 
@@ -4797,7 +4778,7 @@ purposes and to a <a>verifiable credential</a> as a method of assertion.
         <h3>Expiration</h3>
 
         <p>
-The <code>expirationDate</code> is expected to be within an expected range
+The <code>validUntil</code> is expected to be within an expected range
 for the <a>verifier</a>. For example, a <a>verifier</a> can check that the
 expiration date of a <a>verifiable credential</a> is not in the past.
         </p>
@@ -4892,11 +4873,11 @@ is also provided in this section.
         "credentialStatus": {"@id": "cred:credentialStatus", "@type": "@id"},
         "credentialSubject": {"@id": "cred:credentialSubject", "@type": "@id"},
         "evidence": {"@id": "cred:evidence", "@type": "@id"},
-        "expirationDate": {"@id": "cred:expirationDate", "@type": "xsd:dateTime"},
+        "validUntil": {"@id": "cred:validUntil", "@type": "xsd:dateTime"},
         "holder": {"@id": "cred:holder", "@type": "@id"},
         "issued": {"@id": "cred:issued", "@type": "xsd:dateTime"},
         "issuer": {"@id": "cred:issuer", "@type": "@id"},
-        "issuanceDate": {"@id": "cred:issuanceDate", "@type": "xsd:dateTime"},
+        "validFrom": {"@id": "cred:validFrom", "@type": "xsd:dateTime"},
         "proof": {"@id": "sec:proof", "@type": "@id", "@container": "@graph"},
         "refreshService": {
           "@id": "cred:refreshService",

--- a/index.html
+++ b/index.html
@@ -1671,8 +1671,10 @@ at which the information associated with the <code>credentialSubject</code>
           <dd>
   If present, the value of the <code>validUntil</code> <a>property</a> MUST be
   a string value of an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
-  <code>date-time</code> representing the date and time the <a>credential</a>
-  ceases to be valid.
+  combined <code>date-time</code> string representing the date and time the
+  <a>credential</a> ceases to be valid, which could be a date and time in the past.
+  Note that this value represents the latest point in time at which the information
+  associated with the <code>credentialSubject</code> <a>property</a> is valid.
           </dd>
         </dl>
 
@@ -4672,7 +4674,7 @@ checking the proofs on the <a>verifiable credentials</a>.
         <p>
 The <code>validFrom</code> is expected to be within an expected range for the
 <a>verifier</a>. For example, a <a>verifier</a> can check that the start of
-a validity period for a <a>verifiable credential</a> is not in the future.
+the validity period for a <a>verifiable credential</a> is not in the future.
         </p>
       </section>
 
@@ -4746,8 +4748,8 @@ purposes and to a <a>verifiable credential</a> as a method of assertion.
 
         <p>
 The <code>validUntil</code> is expected to be within an expected range
-for the <a>verifier</a>. For example, a <a>verifier</a> can check that the
-expiration date of a <a>verifiable credential</a> is not in the past.
+for the <a>verifier</a>. For example, a <a>verifier</a> can check that the end of the
+validity period of a <a>verifiable credential</a> is not in the past.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1646,11 +1646,13 @@ example, <code>"did:example:abfe13f712120431c276e12ecab"</code>).
       </section>
 
       <section>
-        <h3>Issuance Date</h3>
+        <h3>Validity Period</h3>
 
         <p>
-This specification defines the <code>validFrom</code> <a>property</a> for
-expressing the date and time when a <a>credential</a> becomes valid.
+This specification defines the <code>validFrom</code> <a>property</a> to help an
+issuer to express the date and time when a <a>credential</a> becomes valid and
+the <code>validUntil</code> <a>property</a> for expressing the date and time
+when a <a>credential</a> ceases to be valid.
         </p>
 
         <dl>
@@ -1665,10 +1667,17 @@ Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>
 <a>property</a> becomes valid.
           </dd>
+          <dt><var>validUntil</var></dt>
+          <dd>
+  If present, the value of the <code>validUntil</code> <a>property</a> MUST be
+  a string value of an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
+  <code>date-time</code> representing the date and time the <a>credential</a>
+  ceases to be valid.
+          </dd>
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Usage of validFrom property"
+          title="Usage of validFrom and validUntil property"
           data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
@@ -1679,6 +1688,7 @@ at which the information associated with the <code>credentialSubject</code>
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
   <span class="highlight">"validFrom": "2010-01-01T19:23:24Z"</span>,
+  <span class="highlight">"validUntil": "2020-01-01T19:23:24Z"</span>,
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -1774,49 +1784,6 @@ Suites Registries [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded
 Payload Option [[RFC7797]]. A list of proof mechanisms is available in the
 Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
         </p>
-
-      </section>
-
-      <section>
-        <h3>Expiration</h3>
-
-        <p>
-This specification defines the <code>validUntil</code> <a>property</a> for
-the expression of <a>credential</a> expiration information.
-        </p>
-
-        <dl>
-          <dt><var>validUntil</var></dt>
-          <dd>
-If present, the value of the <code>validUntil</code> <a>property</a> MUST be
-a string value of an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
-<code>date-time</code> representing the date and time the <a>credential</a>
-ceases to be valid.
-          </dd>
-        </dl>
-
-        <pre class="example nohighlight vc"
-          title="Usage of the validUntil property"
-          data-vc-vm="https://example.edu/issuers/14#key-1">
-{
-  "@context": [
-    "https://www.w3.org/2018/credentials/v1",
-    "https://www.w3.org/2018/credentials/examples/v1"
-  ],
-  "id": "http://example.edu/credentials/3732",
-  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-  "issuer": "https://example.edu/issuers/14",
-  "validFrom": "2010-01-01T19:23:24Z",
-  <span class="highlight">"validUntil": "2020-01-01T19:23:24Z"</span>,
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "degree": {
-      "type": "BachelorDegree",
-      "name": "Bachelor of Science and Arts"
-    }
-  }
-}
-        </pre>
 
       </section>
 

--- a/schema/verifiable-credential/example-1.json
+++ b/schema/verifiable-credential/example-1.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/1872",
   "type": ["VerifiableCredential", "AlumniCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "alumniOf": {

--- a/schema/verifiable-credential/example-11.json
+++ b/schema/verifiable-credential/example-11.json
@@ -6,7 +6,7 @@
   "id": "http://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-12.json
+++ b/schema/verifiable-credential/example-12.json
@@ -6,8 +6,8 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
-  "expirationDate": "2020-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "validUntil": "2020-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-13.json
+++ b/schema/verifiable-credential/example-13.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-18.json
+++ b/schema/verifiable-credential/example-18.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-20.json
+++ b/schema/verifiable-credential/example-20.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-21.json
+++ b/schema/verifiable-credential/example-21.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-23.json
+++ b/schema/verifiable-credential/example-23.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/14",
-  "issuanceDate": "2010-01-01T19:23:24Z",
+  "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/example-4.json
+++ b/schema/verifiable-credential/example-4.json
@@ -6,7 +6,7 @@
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "issuer": "https://example.edu/issuers/565049",
-  "issuanceDate": "2010-01-01T00:00:00Z",
+  "validFrom": "2010-01-01T00:00:00Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/schema/verifiable-credential/verifiable-credential-schema.json
+++ b/schema/verifiable-credential/verifiable-credential-schema.json
@@ -174,7 +174,7 @@
         }
       ]
     },
-    "issuanceDate": {
+    "validFrom": {
       "type": "string"
     },
     "credentialSubject": {
@@ -191,7 +191,7 @@
         }
       ]
     },
-    "expirationDate": {
+    "validUntil": {
       "type": "string"
     },
     "credentialStatus": {
@@ -290,7 +290,7 @@
     "@context",
     "type",
     "issuer",
-    "issuanceDate",
+    "validFrom",
     "credentialSubject"
   ],
   "additionalProperties": true

--- a/schema/verifiable-presentation/example-2.json
+++ b/schema/verifiable-presentation/example-2.json
@@ -13,7 +13,7 @@
     "id": "http://example.edu/credentials/1872",
     "type": ["VerifiableCredential", "AlumniCredential"],
     "issuer": "https://example.edu/issuers/565049",
-    "issuanceDate": "2010-01-01T19:23:24Z",
+    "validFrom": "2010-01-01T19:23:24Z",
     "credentialSubject": {
       "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
       "alumniOf": {

--- a/schema/verifiable-presentation/example-25.json
+++ b/schema/verifiable-presentation/example-25.json
@@ -16,7 +16,7 @@
         "type": "did:example:schema:22KpkXgecryx9k7N6XN1QoN3gXwBkSU8SfyyYQG"
       },
       "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
-      "issuanceDate": "2017-12-05T14:27:42Z",
+      "validFrom": "2017-12-05T14:27:42Z",
       "credentialSubject": {
         "degreeType": "BachelorDegree",
         "degreeSchool": "College of Engineering"

--- a/schema/verifiable-presentation/example-45.json
+++ b/schema/verifiable-presentation/example-45.json
@@ -14,7 +14,7 @@
       "id": "http://pharma.example.com/credentials/3732",
       "type": ["VerifiableCredential", "PrescriptionCredential"],
       "issuer": "https://pharma.example.com/issuer/4",
-      "issuanceDate": "2010-01-01T19:23:24Z",
+      "validFrom": "2010-01-01T19:23:24Z",
       "credentialSubject": {
         "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
         "prescription": {
@@ -44,7 +44,7 @@
       "id": "https://example.com/VC/123456789",
       "type": ["VerifiableCredential", "PrescriptionCredential"],
       "issuer": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-      "issuanceDate": "2010-01-03T19:53:24Z",
+      "validFrom": "2010-01-03T19:53:24Z",
       "credentialSubject": {
         "id": "did:example:76e12ec21ebhyu1f712ebc6f1z2",
         "prescription": {

--- a/schema/verifiable-presentation/verifiable-presentation-schema-test.js
+++ b/schema/verifiable-presentation/verifiable-presentation-schema-test.js
@@ -18,7 +18,7 @@ describe('Verifiable Presentation', function () {
     });
 
     // Note: this example fails because the dependent VC is not valid;
-    // it is missing an issuanceDate. Both the VP and VC proofs are missing
+    // it is missing an validFrom. Both the VP and VC proofs are missing
     // created, proofPurpose, and verificationMethod fields. The example has
     // been modified to get the test to pass.
     it('should validate example 25 using JSON Schema 2020-12 ', function () {


### PR DESCRIPTION
This PR implements a decision made by the VCWG to rename issuanceDate/expirationDate to validFrom/validUntil:

https://github.com/w3c/vc-data-model/issues/913#issuecomment-1293435120

The PR also merges the `issuanceDate` and `expirationDate` sections into one due to unnecessary duplicated content, you can preview the new combined section (which only contains editorial changes) here:

https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/992.html#validity-period


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/992.html" title="Last updated on Dec 18, 2022, 9:46 PM UTC (7522a1d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/992/f293b35...7522a1d.html" title="Last updated on Dec 18, 2022, 9:46 PM UTC (7522a1d)">Diff</a>