### PR TITLE
Add normative dependency on VC Data Integrity.

### DIFF
--- a/common.js
+++ b/common.js
@@ -35,13 +35,13 @@ var vcwg = {
     },
     "VC-DATA-INTEGRITY": {
       title: "Verifiable Credential Data Integrity",
-      href: "https://w3c.github.io/vc-data-integrity/",
+      href: "https://www.w3.org/TR/vc-data-integrity/",
       authors: [
         "Manu Sporny",
         "Dave Longley",
         "Mike Prorock"
       ],
-      status: "ED",
+      status: "WD",
       publisher: "Verifiable Credentials Working Group"
     },
     "LDP-REGISTRY": {

--- a/index.html
+++ b/index.html
@@ -593,7 +593,7 @@ At the time of publication, Working Group members had implemented
 JSON Web Tokens [[RFC7519]] secured using JSON Web Signatures [[RFC7515]]
           </li>
           <li>
-Data Integrity Proofs [[?VC-DATA-INTEGRITY]]
+Data Integrity Proofs [[VC-DATA-INTEGRITY]]
           </li>
           <li>
 Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
@@ -1036,7 +1036,7 @@ the <a>verifier</a> and <a>verified</a>.
 Implementers that are interested in understanding more about the
 <code>proof</code> mechanism used above can learn more in Section <a
 href="#proofs-signatures"></a> and by reading the following specifications:
-Data Integrity [[?VC-DATA-INTEGRITY]], Linked Data Cryptographic Suites
+Data Integrity [[VC-DATA-INTEGRITY]], Linked Data Cryptographic Suites
 Registry [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded Payload Option
 [[RFC7797]]. A list of proof mechanisms is available in the Verifiable
 Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
@@ -1719,7 +1719,7 @@ that wraps an expression of this data model, such as a JSON Web Token, which is
 elaborated on in the Securing Verifiable Credentials using JSON Web Tokens
 [[?VC-JWT]] specification. An <dfn>embedded proof</dfn> is a mechanism where
 the proof is included in the data, such as a Data Integrity Proof, which is
-elaborated upon in Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]].
+elaborated upon in Verifiable Credential Data Integrity [[VC-DATA-INTEGRITY]].
         </p>
 
         <p>
@@ -1780,7 +1780,7 @@ As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
 single proof mechanism for use with <a>verifiable credentials</a>. For more
 information about the <code>proof</code> mechanism, see the following
-specifications: Data Integrity [[?VC-DATA-INTEGRITY]], Linked Data Cryptographic
+specifications: Data Integrity [[VC-DATA-INTEGRITY]], Linked Data Cryptographic
 Suites Registries [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded
 Payload Option [[RFC7797]]. A list of proof mechanisms is available in the
 Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
@@ -1987,7 +1987,7 @@ The example below shows a <a>verifiable presentation</a> that embeds
 The contents of the <code>verifiableCredential</code> <a>property</a> shown
 above are <a>verifiable credentials</a>, as described by this specification. The
 contents of the <code>proof</code> <a>property</a> are proofs, as described by
-the Data Integrity [[?VC-DATA-INTEGRITY]] specification. An example of a
+the Data Integrity [[VC-DATA-INTEGRITY]] specification. An example of a
 <a>verifiable presentation</a> using the JWT proof mechanism is
 provided in the Securing Verifiable Credentials using JSON Web Tokens
 [[?VC-JWT]] specification.
@@ -2278,7 +2278,7 @@ use of [[?LINKED-DATA]].
           </li>
           <li>
 Support multiple types of cryptographic proof formats through the use of
-Data Integrity Proofs [[?VC-DATA-INTEGRITY]] and a variety of signature suites
+Data Integrity Proofs [[VC-DATA-INTEGRITY]] and a variety of signature suites
 listed in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
           </li>
           <li>
@@ -3487,7 +3487,7 @@ being actively utilized to issue <a>verifiable credentials</a> are:
 Verifiable Credentials using JSON Web Tokens [[?VC-JWT]], and
           </li>
           <li>
-Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]].
+Verifiable Credential Data Integrity [[VC-DATA-INTEGRITY]].
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -5243,6 +5243,10 @@ v1.1 Recommendation</a>:
         <li>
 Increment version number to v2.0 and remove prior REC-track comments.
         </li>
+        <li>
+Add normative dependency on Verifiable Credential Data Integrity specification
+[[VC-DATA-INTEGRITY]].
+        </li>
       </ul>
 
       <p>


### PR DESCRIPTION
This PR addresses issue #912 by adding a normative dependency on the VC Data Integrity specification (as requested by @Sebastian-Elfors-IDNow) and adding a line to the revision history for the specification (as requested by @Sakurann). The normative references from the Proof section were added a while ago. 

This PR should address issue #912 in its entirety.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/993.html" title="Last updated on Dec 11, 2022, 7:47 PM UTC (8330424)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/993/6bae9b7...8330424.html" title="Last updated on Dec 11, 2022, 7:47 PM UTC (8330424)">Diff</a>