### PR TITLE
Add termsOfUse to presentations in v2 context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -85,6 +85,10 @@
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
           "@type": "@id",
           "@container": "@graph"
+        },
+        "termsOfUse": {
+          "@id": "https://www.w3.org/2018/credentials#termsOfUse",
+          "@type": "@id"
         }
       }
     },

--- a/index.html
+++ b/index.html
@@ -2751,7 +2751,7 @@ in an archive.
     }
   ],
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-  "type": ["VerifiablePresentation", "VerifiablePresentationTermsOfUseExtension"],
+  "type": ["VerifiablePresentation"],
   "verifiableCredential": [{
     "@context": [
       "https://www.w3.org/ns/credentials/v2",
@@ -2784,17 +2784,6 @@ in an archive.
   "proof": [ ... ]
 }
         </pre>
-
-        <p class="note">
-Warning: The <code>termsOfUse</code> property is improperly defined within the
-<code>VerifiablePresentation</code> scoped context. This is a bug with the
-version 1 context and will be fixed in the version 2 context. In the meantime,
-implementors who wish to use this feature will be required to extend the context
-of their <a>verifiable presentation</a> with an additional term that defines the
-<code>termsOfUse</code> property, which can then be used alongside the
-<a>verifiable presentation</a> type property, in order for the term to be
-semantically recognized in a JSON-LD processor.
-        </p>
 
         <p>
 In the example above, the <a>holder</a> (the <code>assigner</code>), who is


### PR DESCRIPTION
This PR is a partial fix to issue #810, which notes that the v1 context failed to include the ability to use `termsOfUse` in a presentation. This PR fixes that and makes it possible to use `termsOfUse` by just including the base v2 context. /cc @kdenhartog


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1004.html" title="Last updated on Jan 15, 2023, 8:18 PM UTC (505a671)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1004/0eaebed...505a671.html" title="Last updated on Jan 15, 2023, 8:18 PM UTC (505a671)">Diff</a>