### PR TITLE
Clarify appropriate usage of type information during validation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4629,7 +4629,8 @@ type is expected to contain specific <a>properties</a> that can be used to
 determine whether or not the <a>presentation</a> meets a set of processing rules
 that the <a>verifier</a> is executing. By requesting
 <a>verifiable credentials</a> of a particular <code>type</code>, the
-<a>verifier</a> is able to gather specific information from the <a>holder</a>
+<a>verifier</a> is able to gather specific information from the <a>holder</a>,
+which originated  with the <a>issuer</a> of each <a>verifiable credential</a>,
 that will enable it to determine the next stage of an interaction with a
 <a>holder</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -1266,9 +1266,11 @@ cryptographic keys, and other machine-readable information associated with a
         <p>
 Software systems that process the kinds of objects specified in this document
 use type information to determine whether or not a provided
-<a>verifiable credential</a> or <a>verifiable presentation</a> is appropriate.
-This specification defines a <code>type</code> <a>property</a> for the
-expression of type information.
+<a>verifiable credential</a> or <a>verifiable presentation</a> is appropriate
+for the intended use case. This specification defines a <code>type</code>
+<a>property</a> for the expression of type information. This type information
+can be used during <a>validation</a> processes as described in Appendix
+<a href="#validation"></a>.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -4618,6 +4618,24 @@ data fields in this specification by <a>verifiers</a>.
       </p>
 
       <section class="informative">
+        <h3>Credential Type</h3>
+
+        <p>
+When a <a>verifier</a> requests one or more <a>verifiable credentials</a>
+from a <a>holder</a>, they can specify the type of credential(s) that they would
+like to receive. The type of a credential is expressed via the
+<a href="#types">type</a> property. A <a>verifiable credential</a> of a specific
+type is expected to contain specific <a>properties</a> that can be used to
+determine whether or not the <a>presentation</a> meets a set of processing rules
+that the <a>verifier</a> is executing. By requesting
+<a>verifiable credentials</a> of a particular <code>type</code>, the
+<a>verifier</a> is able to gather specific information from the <a>holder</a>
+that will enable it to determine the next stage of an interaction with a
+<a>holder</a>.
+        </p>
+      </section>
+
+      <section class="informative">
         <h3>Credential Subject</h3>
 
         <p>


### PR DESCRIPTION
This PR clarifies the appropriate usage of type information during validation and addresses issue #848.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 522  :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 21, 2023, 5:10 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvc-data-model%2F2f69ea87f425e9a5a2ef90cc1796dd25eea673d8%2Findex.html%3FisPreview%3Dtrue)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-data-model%231005.)._
</details>
