### PR TITLE
Change the reference URL in the vocabulary template file

### DIFF
--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -25,8 +25,8 @@
           }
         },
         specStatus:  "base",
-        shortName:   "2018/credentials/v2",
-        thisVersion: "https://w3.org/2018/credentials/v2",
+        shortName:   "2018/credentials/",
+        thisVersion: "https://w3.org/2018/credentials/",
         doJsonLd:    true,
         editors: [{
           name:       "Ivan Herman",

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -26,7 +26,7 @@
         },
         specStatus:  "base",
         shortName:   "2018/credentials/",
-        thisVersion: "https://w3.org/2018/credentials/",
+        thisVersion: "https://www.w3.org/2018/credentials/",
         doJsonLd:    true,
         editors: [{
           name:       "Ivan Herman",


### PR DESCRIPTION
The reference to the vocabulary should be

```
https://w3.org/2018/credentials/
```

and not `..../credentials/v2/` as it stands today. That was the URL used for the development phase, and that is now behind us...