### PR TITLE
Add language clarifying multiple data schemas

### DIFF
--- a/index.html
+++ b/index.html
@@ -2468,12 +2468,14 @@ to determine if the provided data conforms to the provided schema object. Each
 or <code><a href="https://transmute-industries.github.io/vc-credential-schema-open-api-specification/">
 OpenApiSpecificationValidator2022</a></code>), and an <code>id</code> <a>property</a>
 which MUST be a <a>URL</a> identifying the schema file. </p>
+
 <p>The precise contents of each data schema object is determined by its 
 <code>type</code> definition. Different <code>type</code> implementations
 of data schema objects may choose to support different processing mechanisms 
 such as enabling the use of multiple data schemas for a single credential.
 Types may also enable specific processing rules (e.g. if there are multiple 
-schemas, all must be valid, some must be valid, and so on).</p>
+schemas, all must be valid, some must be valid, this schema applies to this
+portion of a credential, and so on).</p>
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2463,8 +2463,8 @@ The value of the <code>credentialSchema</code> <a>property</a> MUST be a single
 data schema object which provides <a>verifiers</a> with enough information 
 to determine if the provided data conforms to the provided schema object. Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (e.g.,
-<code><a href="https://w3c-ccg.github.io/vc-json-schemas/">CredentialSchema2022</a></code>)
-, and an <code>id</code> <a>property</a> which MUST be a <a>URL</a> identifying
+<a href="https://w3c-ccg.github.io/vc-json-schemas/">`CredentialSchema2022`</a>),
+and an `id` <a>property</a> which MUST be a <a>URL</a> identifying
 the schema file. </p>
 
 <p>The precise contents of each data schema object is determined by its 

--- a/index.html
+++ b/index.html
@@ -2458,14 +2458,22 @@ the <a>verifiable credentials</a> that it issues:
 
         <dl>
           <dt><var>credentialSchema</var></dt>
-          <dd>
-The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
-more data schemas that provide <a>verifiers</a> with enough information to
-determine if the provided data conforms to the provided schema. Each
-<code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code>JsonSchemaValidator2018</code>), and an <code>id</code> <a>property</a>
-that MUST be a <a>URL</a> identifying the schema file. The precise contents of
-each data schema is determined by the specific type definition.
+          <dd><p>
+The value of the <code>credentialSchema</code> <a>property</a> MUST be a single
+data schema object which provides <a>verifiers</a> with enough information 
+to determine if the provided data conforms to the provided schema object. Each
+<code>credentialSchema</code> MUST specify its <code>type</code> (e.g.,
+<code>JsonSchemaValidator2018</code>, 
+<code><a href="https://w3c-ccg.github.io/vc-json-schemas/">CredentialSchema2022</a></code>,
+or <code><a href="https://transmute-industries.github.io/vc-credential-schema-open-api-specification/">
+OpenApiSpecificationValidator2022</a></code>), and an <code>id</code> <a>property</a>
+which MUST be a <a>URL</a> identifying the schema file. </p>
+<p>The precise contents of each data schema object is determined by its 
+<code>type</code> definition. Different <code>type</code> implementations
+of data schema objects may choose to support different processing mechanisms 
+such as enabling the use of multiple data schemas for a single credential.
+Types may also enable specific processing rules (e.g. if there are multiple 
+schemas, all must be valid, some must be valid, and so on).</p>
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2461,7 +2461,7 @@ the <a>verifiable credentials</a> that it issues:
           <dd><p>
 The value of the <code>credentialSchema</code> <a>property</a> MUST be a single
 data schema object which provides <a>verifiers</a> with enough information 
-to determine if the provided data conforms to the provided schema object. Each
+to determine whether the provided data conforms to the provided schema object. Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (e.g.,
 <a href="https://w3c-ccg.github.io/vc-json-schemas/">`CredentialSchema2022`</a>),
 and an `id` <a>property</a> which MUST be a <a>URL</a> identifying

--- a/index.html
+++ b/index.html
@@ -2473,9 +2473,10 @@ which MUST be a <a>URL</a> identifying the schema file. </p>
 <code>type</code> definition. Different <code>type</code> implementations
 of data schema objects might choose to support different processing mechanisms 
 such as enabling the use of multiple data schemas for a single credential.
-Types may also enable specific processing rules (e.g. if there are multiple 
-schemas, all must be valid, some must be valid, this schema applies to this
-portion of a credential, and so on).</p>
+Types might also enable specific processing rules. For example, if there are multiple 
+schemas, the processing rules might state that all schemas are expected to be valid, 
+some are expected to be valid, or that a certain schema applies to a certain 
+portion of a credential.</p>
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2457,26 +2457,24 @@ the <a>verifiable credentials</a> that it issues:
         </p>
 
         <dl>
-          <dt><var>credentialSchema</var></dt>
+          <dt><var>`</var></dt>
           <dd><p>
 The value of the <code>credentialSchema</code> <a>property</a> MUST be a single
 data schema object which provides <a>verifiers</a> with enough information 
 to determine if the provided data conforms to the provided schema object. Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (e.g.,
-<code>JsonSchemaValidator2018</code>, 
-<code><a href="https://w3c-ccg.github.io/vc-json-schemas/">CredentialSchema2022</a></code>,
-or <code><a href="https://transmute-industries.github.io/vc-credential-schema-open-api-specification/">
-OpenApiSpecificationValidator2022</a></code>), and an <code>id</code> <a>property</a>
-which MUST be a <a>URL</a> identifying the schema file. </p>
+<code><a href="https://w3c-ccg.github.io/vc-json-schemas/">CredentialSchema2022</a></code>)
+, and an <code>id</code> <a>property</a> which MUST be a <a>URL</a> identifying
+the schema file. </p>
 
 <p>The precise contents of each data schema object is determined by its 
 <code>type</code> definition. Different <code>type</code> implementations
 of data schema objects might choose to support different processing mechanisms 
 such as enabling the use of multiple data schemas for a single credential.
-Types might also enable specific processing rules. For example, if there are multiple 
-schemas, the processing rules might state that all schemas are expected to be valid, 
-some are expected to be valid, or that a certain schema applies to a certain 
-portion of a credential.</p>
+Types might also enable specific processing rules. For example, if there are
+multiple schemas, the processing rules might state that all schemas are
+expected to be valid, some are expected to be valid, or that a certain schema
+applies to a certain portion of a credential.</p>
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2471,7 +2471,7 @@ which MUST be a <a>URL</a> identifying the schema file. </p>
 
 <p>The precise contents of each data schema object is determined by its 
 <code>type</code> definition. Different <code>type</code> implementations
-of data schema objects may choose to support different processing mechanisms 
+of data schema objects might choose to support different processing mechanisms 
 such as enabling the use of multiple data schemas for a single credential.
 Types may also enable specific processing rules (e.g. if there are multiple 
 schemas, all must be valid, some must be valid, this schema applies to this


### PR DESCRIPTION
Addresses #950


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 6, 2023, 6:15 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvc-data-model%2Fdb7d236885dab37a099c65dbace861a697f1850c%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/0GVPUy/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-02-06
ReSpec version: 32.7.0
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 28323ms.
    at ExecutionContext._ExecutionContext_evaluate (/u/spec-generator/node_modules/puppeteer-core/lib/cjs/puppeteer/common/ExecutionContext.js:229:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer-core/lib/cjs/puppeteer/common/ExecutionContext.js:107:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:252:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-data-model%231023.)._
</details>
