### PR TITLE
ignore gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .idea/vcs.xml
 .idea/workspace.xml
 .vscode
+.idea
+.gitignore
 
 **/node_modules
 **/.DS_Store


### PR DESCRIPTION
this PR adds `.gitignore` to itself so that local changes to the file don't result in it appearing as a modified file and added to PRs.

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>