### PR TITLE
change ZKP section

### DIFF
--- a/index.html
+++ b/index.html
@@ -2921,8 +2921,8 @@ knowledge of a value without disclosing the actual value. This data model
 supports being secured with the use of zero-knowledge proof mechanisms.
         </p>
         <p>
-Some capabilities that are compatible with <a>verifiable credentials</a> that
-made possible by zero-knowledge proof mechanisms:
+Some capabilities that are compatible with <a>verifiable credentials</a> which
+are made possible by zero-knowledge proof mechanisms:
         </p>
         <ul>
           <li>
@@ -2941,11 +2941,11 @@ allows a <a>holder</a> to share a different signature value with each
 presentation, which in turn reduces the amount of data shared.
           </li>
           <li>
-Privacy preserving identification of the <a>holder</a>/<a>subject</a>. This
+Privacy preserving identification of the <a>holder</a> and/or <a>subject</a>. This
 allows a <a>holder</a> to prove that a <a>credential</a> was issued to them, or
 a <a>subject</a> to prove that a <a>credential</a> was issued about them,
 without sharing an identifier. This also reduces the amount of data necessary to
-share. This capability can also be used to combine multiple
+be shared. This capability can also be used to combine multiple
 <a>verifiable credentials</a> from multiple <a>issuers</a> into a single
 <a>verifiable presentation</a> without revealing <a>verifiable credential</a> or
 <a>subject</a> identifiers to the <a>verifier</a>.

--- a/index.html
+++ b/index.html
@@ -2908,69 +2908,66 @@ information about the <code>proof</code> <a>property</a>, see Section
       <section>
         <h3>Zero-Knowledge Proofs</h3>
 
-<p class="issue" data-number="863">
-We anticipate this section will undergo major revision for v2 of the data model,
-and plan to remove the normative requirements and move it to the
-implementation guide if there are no active work items related to the topic of
-"Zero-Knowledge Proofs" when we transition v2 to CR.
-</p>
-
-        <p>
-A zero-knowledge proof is a cryptographic method where an entity can prove to
-another entity that they know a certain value without disclosing the actual
-value. A real-world example is proving that an accredited university has
-granted a degree to you without revealing your identity or any other personally
-identifiable information contained on the degree.
+        <p class="issue" data-number="863">
+We plan to remove the normative requirements in this section if there are no
+active work items for securing <a>verifiable credentials</a> using zero
+knowledge proof mechanisms when we transition v2 of the data model to CR.
+Additionally, the remaining non-normative language will likely be moved to the
+Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]].
         </p>
         <p>
-The key capabilities introduced by zero-knowledge proof mechanisms are the
-ability of a <a>holder</a> to:
+Zero-knowledge proofs are cryptographic methods which enable a user to prove
+knowledge of a value without disclosing the actual value. This data model
+supports being secured with the use of zero-knowledge proof mechanisms.
         </p>
-
+        <p>
+Some capabilities that are compatible with <a>verifiable credentials</a> that
+made possible by zero-knowledge proof mechanisms:
+        </p>
         <ul>
           <li>
-Combine multiple <a>verifiable credentials</a> from multiple <a>issuers</a> into
-a single <a>verifiable presentation</a> without revealing
-<a>verifiable credential</a> or <a>subject</a> identifiers to the
-<a>verifier</a>. This makes it more difficult for the <a>verifier</a> to collude
-with any of the issuers regarding the issued <a>verifiable credentials</a>.
-          </li>
-          <li>
-Selectively disclose the <a>claims</a> in a <a>verifiable credential</a> to a
-<a>verifier</a> without requiring the issuance of multiple atomic
-<a>verifiable credentials</a>. This allows a <a>holder</a> to provide a
+Selective disclosure of the properties in a <a>verifiable credential</a> by the
+<a>holder</a> to a <a>verifier</a>. This allows a <a>holder</a> to provide a
 <a>verifier</a> with precisely the information they need and nothing more.
+This also enables the production of a derived <a>verifiable credential</a> that
+is formatted according to the <a>verifier's</a> data schema without needing to
+involve the <a>issuer</a> during presentation. This provides a great deal of
+flexibility for <a>holders</a> to use their issued
+<a>verifiable credentials</a>.
           </li>
           <li>
-Produce a derived <a>verifiable credential</a> that is formatted according to
-the <a>verifier's</a> data schema instead of the <a>issuer's</a>, without
-needing to involve the <a>issuer</a> after <a>verifiable credential</a>
-issuance. This provides a great deal of flexibility for <a>holders</a> to use
-their issued <a>verifiable credentials</a>.
+Blinding of the signature value that is shared with a <a>verifier</a>. This
+allows a <a>holder</a> to share a different signature value with each
+presentation, which in turn reduces the amount of data shared.
+          </li>
+          <li>
+Privacy preserving identification of the <a>holder</a>/<a>subject</a>. This
+allows a <a>holder</a> to prove that a <a>credential</a> was issued to them, or
+a <a>subject</a> to prove that a <a>credential</a> was issued about them,
+without sharing an identifier. This also reduces the amount of data necessary to
+share. This capability can also be used to combine multiple
+<a>verifiable credentials</a> from multiple <a>issuers</a> into a single
+<a>verifiable presentation</a> without revealing <a>verifiable credential</a> or
+<a>subject</a> identifiers to the <a>verifier</a>.
           </li>
         </ul>
-
         <p>
-This specification describes a data model that supports selective disclosure
-with the use of zero-knowledge proof mechanisms. The examples below highlight
-how the data model can be used to issue, present, and verify zero-knowledge
-<a>verifiable credentials</a>.
+Not all capabilities are supported in all zero-knowledge proof mechanisms.
+Specific details about the capabilities and techniques provided by a particular
+zero knowledge proof mechanism, along with any normative requirements for using
+them with <a>verifiable credentials</a>, would be found in a specification for
+securing <a>verifiable credentials</a> with that zero-knowledge proof mechanism.
         </p>
-
         <p>
-For a <a>holder</a> to use a zero-knowledge <a>verifiable presentation</a>,
-they need an <a>issuer</a> to have issued a <a>verifiable credential</a> in a manner
-that enables the <a>holder</a> to derive a proof from the originally issued
-<a>verifiable credential</a>, so that the <a>holder</a> can present the
-information to a <a>verifier</a> in a privacy-enhancing manner.
-This implies that the <a>holder</a> can prove the validity of the
-<a>issuer's</a> signature without revealing the values that were signed, or when
-only revealing certain selected values. The standard practice is to do so by
-proving knowledge of the signature, without revealing the signature itself.
+We note that in most instances, for <a>holder</a> to make use of zero knowledge
+mechanisms with <a>verifiable credentials</a> requires an <a>issuer</a> to
+secure the <a>verifiable credential</a> in a manner that supports these
+capabilities.
+        </p>
+        <p>
 There are two requirements for <a>verifiable credentials</a> when they are to be
 used in zero-knowledge proof systems.
         </p>
-
         <ul>
           <li>
 The <a>verifiable credential</a> MUST contain a Proof, using the
@@ -2985,7 +2982,15 @@ so that it can be used by all parties to perform various cryptographic
 operations in zero-knowledge.
           </li>
         </ul>
-
+        <p>
+The examples below highlight how the data model might be used to issue and
+present <a>verifiable credentials</a> in zero-knowledge.
+        </p>
+        <p class="note">
+The provided examples will either be significantly re-written to demonstrate how
+to secure a <a>verifiable credential</a> using a normatively defined method that
+enable zero knowledge proofs, or they will be removed.
+        </p>
         <p>
 The following example shows one method of using <a>verifiable credentials</a> in
 zero-knowledge. It makes use of a Camenisch-Lysyanskaya Signature


### PR DESCRIPTION
This PR:

- Adds a version of the note initially drafter by Orie in #1026 
- modernizes and generalizes the language in the section in an attempt to make it more applicable to various zero knowledge proof mechanisms.
- adds a note that the examples will either be re-worked or removed.


I believe this PR prepares this section for for one of these possibilities:
1. The WG normatively specifies a method for securing VCs that supports ZKPs, in which case the examples and normative language in this section could be easily updated.
2. The WG does not normatively specify a method for securing VCs that supports ZKPs, in which case the examples and normative language in this section would be removed, and the remaining language could be moved to the implementation guide.

Signed-off-by: Brent Zundel <brent.zundel@gmail.com>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1030.html" title="Last updated on Mar 21, 2023, 6:46 PM UTC (5cbc6a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1030/aeaa1ce...brentzundel:5cbc6a4.html" title="Last updated on Mar 21, 2023, 6:46 PM UTC (5cbc6a4)">Diff</a>