### PR TITLE
Add guidance for `credential+ld+json` for `external`proof

### DIFF
--- a/index.html
+++ b/index.html
@@ -5133,7 +5133,7 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   </p>
 
   <p>
-    This media type MUST NOT be used with <dfn>embedded proof</dfn>.
+    This media type MUST NOT be used to describe a verifiable credential with an <dfn>embedded proof</dfn>.
   </p>
   <p>
     This media type MAY be used with <dfn>external proof</dfn>.

--- a/index.html
+++ b/index.html
@@ -5135,7 +5135,7 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   <p>
     This media type can be used with credentials secured using an <a>external proof</a>.
   </p>
-  <p>If a [[JSON-LD]] context is present in the body of the document, and indicated by the presence of `ld+json` in the media type, the credential MUST be a valid <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a>.</p>
+  <p>A [[JSON-LD]] context is expected to be present in the body of the document, and as indicated by the presence of `ld+json` in the media type, the credential is expected to be a valid <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a>.</p>
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -5133,9 +5133,6 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   </p>
 
   <p>
-    This media type MUST NOT be used to describe a verifiable credential with an <dfn>embedded proof</dfn>.
-  </p>
-  <p>
     This media type MAY be used with <dfn>external proof</dfn>.
   </p>
 </section>

--- a/index.html
+++ b/index.html
@@ -5139,7 +5139,6 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   <p>
     This media type MAY be used with <dfn>external proof</dfn>.
   </p>
-
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -5133,7 +5133,7 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   </p>
 
   <p>
-    This media type can be used with credentials secured using an <dfn>external proof</dfn>.
+    This media type can be used with credentials secured using an <a>external proof</a>.
   </p>
   <p>If a [[JSON-LD]] context is present in the body of the document, and indicated by the presence of `ld+json` in the media type, the credential MUST be a valid <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a>.</p>
 </section>

--- a/index.html
+++ b/index.html
@@ -5135,7 +5135,6 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   <p>
     This media type MUST NOT be used with <dfn>embedded proof</dfn>.
   </p>
-
   <p>
     This media type MAY be used with <dfn>external proof</dfn>.
   </p>

--- a/index.html
+++ b/index.html
@@ -5132,6 +5132,14 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
     the use of a specific media type.
   </p>
 
+  <p>
+    This media type MUST NOT be used with <dfn>embedded proof</dfn>.
+  </p>
+
+  <p>
+    This media type MAY be used with <dfn>external proof</dfn>.
+  </p>
+
 </section>
 
 

--- a/index.html
+++ b/index.html
@@ -5133,7 +5133,7 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   </p>
 
   <p>
-    This media type MAY be used with <dfn>external proof</dfn>.
+    This media type can be used with credentials secured using an <dfn>external proof</dfn>.
   </p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -5135,6 +5135,7 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   <p>
     This media type can be used with credentials secured using an <dfn>external proof</dfn>.
   </p>
+  <p>If a [[JSON-LD]] context is present in the body of the document, and indicated by the presence of `ld+json` in the media type, the credential MUST be a valid <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a>.</p>
 </section>
 
 


### PR DESCRIPTION
Remove proposed guidance that lacked consensus per @dlongley on: https://github.com/w3c/vc-data-model/pull/1014


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1033.html" title="Last updated on Mar 6, 2023, 10:30 PM UTC (b0d7938)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1033/034e5d0...b0d7938.html" title="Last updated on Mar 6, 2023, 10:30 PM UTC (b0d7938)">Diff</a>