### PR TITLE
Add rendering property to VC Data Model

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,18 @@ pre .comment {
   -ms-user-select: none;
   user-select: none;
 }
+ol.algorithm {
+  counter-reset: numsection;
+  list-style-type: none;
+}
+ol.algorithm li {
+  margin: 0.5em 0;
+}
+ol.algorithm li:before {
+  font-weight: bold;
+  counter-increment: numsection;
+  content: counters(numsection, ".") ") ";
+}
     </style>
   </head>
   <body>
@@ -2756,6 +2768,42 @@ In the example above, the <a>issuer</a> has provided an SVG rendering template
 for a bachelor's degree that will be filled in with the information in the
 <a>verifiable credential</a>.
         </p>
+
+        <section>
+          <h5>SvgRenderingTemplate2023 Algorithm</h5>
+
+          <p>
+The following algorithm is used to transform the SVG image template into the
+final SVG image that is displayed. The inputs to the algorithm are the
+<a>verifiable credential</a> (`verifiableCredential`) and the SVG image
+source code (`svgImage`). The output is a SVG image.
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Generate a map, `replacementMap`, by finding all strings in `svgImage` that
+start with `{{` (double open parenthesis) and end with `}}`
+(double close parenthesis). For each string, `templateKey`, that is found:
+              <ol class="algorithm">
+                <li>
+Generate another string, `templateValue`, by evaluating the value of
+`templateKey` (without the opening or closing parenthesis) using the JSON
+Pointer [[RFC6901]] algorithm with the `verifiableCredential` as input to the
+algorithm. If the evaluation is `null`, set `templateValue` to the empty string.
+                </li>
+                <li>
+Set a key in `replacementMap` by using `templateKey` and associate it with
+`templateValue`.
+                </li>
+              </ol>
+            </li>
+            <li>
+For every key in `replacementMap`, replace each corresponding
+string in `svgImage` that matches the key with the associated value in the
+`replacementMap`.
+            </li>
+          </ol>
+        </section>
         </section>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2790,12 +2790,12 @@ source code (`svgImage`). The output is a SVG image.
           <ol class="algorithm">
             <li>
 Generate a map, `replacementMap`, by finding all strings in `svgImage` that
-start with `{{` (double open parenthesis) and end with `}}`
-(double close parenthesis). For each string, `templateKey`, that is found:
+start with `{{` (double open braces) and end with `}}`
+(double close braces). For each string, `templateKey`, that is found:
               <ol class="algorithm">
                 <li>
 Generate another string, `templateValue`, by evaluating the value of
-`templateKey` (without the opening or closing parenthesis) using the JSON
+`templateKey` (without the opening or closing braces) using the JSON
 Pointer [[RFC6901]] algorithm with the `verifiableCredential` as input to the
 algorithm. If the evaluation is `null`, set `templateValue` to the empty string.
                 </li>

--- a/index.html
+++ b/index.html
@@ -2660,6 +2660,14 @@ the <a>verifier</a> to <code>https://example.edu/refresh/3732</code>.
       <section>
         <h3>Rendering</h3>
 
+        <p class="issue" title="FEATURE AT RISK: Rendering">
+The rendering feature might not be included in the final version 2.0
+specification and is thus considered a feature at risk. It is unknown at this
+time if there will be enough implementations for the feature. The Working
+Group is seeking implementer feedback on whether or not they see this
+feature as worth keeping in the final version 2.0 specification.
+        </p>
+
         <p>
 Rendering hints can be used when the <a>issuer</a> has a specific way that
 they want to express a <a>verifiable credential</a> to an observer through

--- a/index.html
+++ b/index.html
@@ -2659,6 +2659,104 @@ aspects of the badge for individuals that have accessibility needs related
 to their eyesight.
         </p>
 
+        <dl>
+          <dt><var>render</var></dt>
+          <dd>
+The value of the <code>render</code> <a>property</a> MUST specify one or
+more rendering hints that can be used by software to express the
+<a>verifiable credential</a> using a visual, auditory, or haptic mechanism.
+Each <code>render</code> value MUST specify its <a>type</a>, for example,
+<code>SvgRenderingTemplate2023</code>. The precise contents of each
+rendering hint is determined by the specific <code>render</code> <a>type</a>
+definition.
+          </dd>
+        </dl>
+
+        <section>
+          <h4>SvgRenderingTemplate2023</h4>
+
+          <p>
+When an <a>issuer</a> desires to specify SVG rendering instructions for a
+<a>verifiable credential</a>, they MAY add a `render` property that uses the
+data model described below.
+          </p>
+
+          <table class="simple">
+            <thead>
+              <tr>
+                <th style="white-space: nowrap">Property</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>id</td>
+                <td>
+A URL that dereferences to an SVG image [[SVG]] with an associated
+`image/svg+xml` media type.
+                </td>
+              </tr>
+              <tr>
+                <td>type</td>
+                <td>
+The <code>type</code> property MUST be <code>SvgRenderingTemplate2023</code>.
+                </td>
+              </tr>
+              <tr>
+                <td>digestMultibase</td>
+                <td>
+An optional multibase-encoded multihash of the SVG image. The multibase value
+MUST be `z` and the multihash value MUST be SHA-2 with 256-bits of output
+(`0x12`).
+<p class="issue">
+The Working Group is seeking feedback related to the mechanism used to express
+the cryptographic hash of the SVG image. This property is a placeholder for that
+discussion and is not meant to imply a final decision related to the way this
+will be done if the feature is accepted in the future.
+</p>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p>
+The data model shown above is expressed in a <a>verifiable credential</a>
+in the example below.
+          </p>
+
+          <pre class="example nohighlight"
+          title="Usage of the render property by an issuer">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "https://example.edu/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  },
+  <span class="highlight">"render": [{
+    "id": "https://example.edu/credentials/BachelorDegree.svg",
+    "type": "SvgRenderingTemplate2023",
+    "digestMultibase": "zQmAPdhyxzznFCwYxAp2dRerWC85Wg6wFl9G270iEu5h6JqW"
+  }]
+  </span>
+}
+        </pre>
+
+        <p>
+In the example above, the <a>issuer</a> has provided an SVG rendering template
+for a bachelor's degree that will be filled in with the information in the
+<a>verifiable credential</a>.
+        </p>
+        </section>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -2646,6 +2646,22 @@ the <a>verifier</a> to <code>https://example.edu/refresh/3732</code>.
       </section>
 
       <section>
+        <h3>Rendering</h3>
+
+        <p>
+Rendering hints can be used when the <a>issuer</a> has a specific way that
+they want to express a <a>verifiable credential</a> to an observer through
+a visual, auditory, or haptic mechanism. For example, an <a>issuer</a> of an
+employee badge credential might want to include rich imagery of their corporate
+logo and specific placement of employee information in specific areas of the
+badge. They might also want to provide an audio read out of the important
+aspects of the badge for individuals that have accessibility needs related
+to their eyesight.
+        </p>
+
+      </section>
+
+      <section>
         <h3>Terms of Use</h3>
 
         <p>


### PR DESCRIPTION
This PR addresses issue #928 by adding a `render` property to the VC Data Model. The feature is marked "at risk" in the spec. It attempts to specify a simple, but concrete solution using:

1. Simple handlebars syntax, like so: `{{VARIABLE}}`.
2. JSON Pointer (simple 6 page spec with many implementations).
3. SVG as the image format.

I expect this feature to generate discussion, so we will need more than the 7 day window to discuss... I'll set it at 30 days and see if we can come to consensus by that point.

This PR is based off of work done at Rebooting the Web of Trust: 

* https://youtu.be/YhZAaFExOwM?t=6192
* https://github.com/WebOfTrustInfo/rwot11-the-hague/blob/master/advance-readings/rendering-verifiable-credentials.md
* https://github.com/WebOfTrustInfo/rwot11-the-hague/blob/master/draft-documents/rendering-vcs-snapshot-9-27-22.md


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1035.html" title="Last updated on Feb 17, 2023, 10:02 AM UTC (ee96f98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1035/fe54b80...ee96f98.html" title="Last updated on Feb 17, 2023, 10:02 AM UTC (ee96f98)">Diff</a>