### PR TITLE
Replace JsonSchemaValidator2018 (undefined) with CredentialSchema2022

### DIFF
--- a/common.js
+++ b/common.js
@@ -118,12 +118,12 @@ var vcwg = {
       href: 'https://en.wikipedia.org/wiki/InterPlanetary_File_System',
       publisher: 'Wikipedia'
     },
-    'JSON-SCHEMA-2018': {
-      title: 'JSON Schema: A Media Type for Describing JSON Documents',
-      href: 'https://datatracker.ietf.org/doc/draft-handrews-json-schema/',
-      authors: ['Austin Wright', 'Henry Andrews'],
-      status: 'Internet-Draft',
-      publisher: 'Internet Engineering Task Force (IETF)'
+    'CREDENTIAL-SCHEMA-2022': {
+      title: 'Verifiable Credentials JSON Schema 2022',
+      href: 'https://w3c-ccg.github.io/vc-json-schemas/',
+      authors: ['Gabe Cohen', 'Orie Steele'],
+      status: 'CG-DRAFT',
+      publisher: 'Credentials Community Group'
     },
     'JSON-LD': {
       title: 'JSON-LD 1.1: A JSON-based Serialization for Linked Data',

--- a/index.html
+++ b/index.html
@@ -2463,7 +2463,7 @@ The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
 more data schemas that provide <a>verifiers</a> with enough information to
 determine if the provided data conforms to the provided schema. Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code><a href="https://w3c-ccg.github.io/vc-json-schemas/">CredentialSchema2022</a></code>), and an <code>id</code> <a>property</a>
+<code>CredentialSchema2022</code>), and an <code>id</code> <a>property</a>
 that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
           </dd>

--- a/index.html
+++ b/index.html
@@ -2463,7 +2463,7 @@ The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
 more data schemas that provide <a>verifiers</a> with enough information to
 determine if the provided data conforms to the provided schema. Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code>JsonSchemaValidator2018</code>), and an <code>id</code> <a>property</a>
+<code><a href="https://w3c-ccg.github.io/vc-json-schemas/">CredentialSchema2022</a></code>), and an <code>id</code> <a>property</a>
 that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
           </dd>
@@ -2477,7 +2477,7 @@ vocabulary using <code>credentialSchema</code> that is locked to some content
 integrity protection mechanism. The <code>credentialSchema</code>
 <a>property</a> also makes it possible to perform syntactic checking on the
 <a>credential</a> and to use <a>verification</a> mechanisms such as JSON Schema
-[[JSON-SCHEMA-2018]] validation.
+[[CREDENTIAL-SCHEMA-2022]] validation.
         </p>
 
         <pre class="example nohighlight"
@@ -2500,20 +2500,20 @@ integrity protection mechanism. The <code>credentialSchema</code>
   },
   <span class="highlight">"credentialSchema": {
     "id": "https://example.org/examples/degree.json",
-    "type": "JsonSchemaValidator2018"
+    "type": "CredentialSchema2022"
   }</span>
 }
         </pre>
 
         <p>
 In the example above, the <a>issuer</a> is specifying a
-<code>credentialSchema</code>, which points to a [[?JSON-SCHEMA-2018]] file that
+<code>credentialSchema</code>, which points to a [[?CREDENTIAL-SCHEMA-2022]] file that
 can be used by a <a>verifier</a> to determine if the
 <a>verifiable credential</a> is well formed.
         </p>
 
         <p class="note" >
-For information about linkages to JSON Schema [[JSON-SCHEMA-2018]] or other
+For information about linkages to JSON Schema [[CREDENTIAL-SCHEMA-2022]] or other
 optional <a>verification</a> mechanisms, see the Verifiable Credentials
 Implementation Guidelines [[VC-IMP-GUIDE]] document.
         </p>
@@ -4987,7 +4987,7 @@ convenience, the base context is also provided below.
         <p>
 The <a>verifiable credential</a> and <a>verifiable presentation</a> data models
 leverage a variety of underlying technologies including [[JSON-LD]] and
-[[JSON-SCHEMA-2018]]. This section will provide a comparison of the
+[[CREDENTIAL-SCHEMA-2022]]. This section will provide a comparison of the
 <code>@context</code>, <code>type</code>, and <code>credentialSchema</code>
 properties, and cover some of the more specific use cases where it is possible
 to use these features of the data model.

--- a/index.html
+++ b/index.html
@@ -2477,7 +2477,7 @@ vocabulary using <code>credentialSchema</code> that is locked to some content
 integrity protection mechanism. The <code>credentialSchema</code>
 <a>property</a> also makes it possible to perform syntactic checking on the
 <a>credential</a> and to use <a>verification</a> mechanisms such as JSON Schema
-[[CREDENTIAL-SCHEMA-2022]] validation.
+[[?CREDENTIAL-SCHEMA-2022]] validation.
         </p>
 
         <pre class="example nohighlight"
@@ -2513,7 +2513,7 @@ can be used by a <a>verifier</a> to determine if the
         </p>
 
         <p class="note" >
-For information about linkages to JSON Schema [[CREDENTIAL-SCHEMA-2022]] or other
+For information about linkages to JSON Schema [[?CREDENTIAL-SCHEMA-2022]] or other
 optional <a>verification</a> mechanisms, see the Verifiable Credentials
 Implementation Guidelines [[VC-IMP-GUIDE]] document.
         </p>
@@ -4987,7 +4987,7 @@ convenience, the base context is also provided below.
         <p>
 The <a>verifiable credential</a> and <a>verifiable presentation</a> data models
 leverage a variety of underlying technologies including [[JSON-LD]] and
-[[CREDENTIAL-SCHEMA-2022]]. This section will provide a comparison of the
+[[?CREDENTIAL-SCHEMA-2022]]. This section will provide a comparison of the
 <code>@context</code>, <code>type</code>, and <code>credentialSchema</code>
 properties, and cover some of the more specific use cases where it is possible
 to use these features of the data model.


### PR DESCRIPTION
This is a replacement of an unknown draft to a current CCG draft. Separately, I am interested in in bringing CredentialSchema2022 into this working group.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1042.html" title="Last updated on Mar 1, 2023, 11:58 PM UTC (8961924)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1042/fe54b80...8961924.html" title="Last updated on Mar 1, 2023, 11:58 PM UTC (8961924)">Diff</a>