### PR TITLE
Setting up a user dependent namespace document

### DIFF
--- a/vocab/credentials/v2/issuer-dependent.html
+++ b/vocab/credentials/v2/issuer-dependent.html
@@ -66,13 +66,13 @@
     <section>
         <h2>Issuer Dependent Terms</h2>
         <p>
-            The <a href="https://www.w3.org/TR/vc-data-model-2.0/#base-context">base context</a> of a Verifiable Credential, as defined in [vc-data-model], provides a mapping from the standard terms used in credentials to the vocabulary items defined by the Verifiable Credentials Working Group through different vocabularies, for example the <a href="https://www.w3.org/2018/credentials/">Verifiable Credentials Vocabulary</a>. Applications using additional, user-dependent vocabularies of their own are encouraged to create their own formal vocabularies, and corresponding JSON-LD context definitions, to ensure the interoperability of the credentials they produce and/or consume.
+            The <a href="https://www.w3.org/TR/vc-data-model-2.0/#base-context">base context</a> of a Verifiable Credential, as defined in [vc-data-model], provides a mapping from the standard terms used in credentials to the vocabulary items defined by the Verifiable Credentials Working Group through different vocabularies, such as the <a href="https://www.w3.org/2018/credentials/">Verifiable Credentials Vocabulary</a>. Applications using additional, user-dependent vocabularies of their own are encouraged to create their own formal vocabularies, and corresponding JSON-LD context definitions, to ensure the interoperability of the credentials they produce and/or consume.
         </p>
         <p>
-            There may be cases, however, when the creation of such formal vocabularies and context definitions is too much of a burden; this is the case for closed applications, experiments, or examples. The way the <a href="https://www.w3.org/TR/vc-data-model-2.0/#base-context">base context</a> has been constructed is such that issuers may use new, hitherto undefined terms without further ado, and these terms will be mapped on URL-s of the form <code>https://www.w3.org/ns/credentials/issuer-dependent#TERM</code>.
+            There may be cases, however, when the creation of such formal vocabularies and context definitions is too much of a burden, such as for closed applications, experiments, or examples. The <a href="https://www.w3.org/TR/vc-data-model-2.0/#base-context">base context</a> has been constructed in such a way that issuers may use new, hitherto undefined terms without further ado, and these terms will be mapped onto URLs of the form <code>https://www.w3.org/ns/credentials/issuer-dependent#TERM</code>.
         </p>
         <p>
-            This document provides a proper landing place for those URL-s, without any additional definitions for the terms themselves. 
+            This document provides a proper landing place for those URLs, without any additional definitions for the terms themselves. 
         </p>
     </section>
 

--- a/vocab/credentials/v2/issuer-dependent.html
+++ b/vocab/credentials/v2/issuer-dependent.html
@@ -1,0 +1,80 @@
+<html lang="en">
+  <head>
+    <meta charset='utf-8'/>
+    <title>Verifiable Credentials Issuer-Dependent Terms</title>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+    <script>
+      function remove_status_remark() {
+          const sotd = document.getElementById("sotd");
+          const p = sotd.getElementsByTagName('p')[0];
+          sotd.removeChild(p);
+      }
+    </script>
+    <script class="remove">
+      var respecConfig = {
+        localBiblio: {
+          "vc-data-model": {
+            title: "Verifiable Credentials Data Model v2.0",
+            href: "https://www.w3.org/TR/vc-data-model-2.0/",
+            authors: [
+              "Manu Sporny", "Grant Noble", "Dave Longley",
+              "Daniel C. Burnett", "Brent Zundel", "Kyle Den Hartog",
+              "Orie Steel", "Michael B. Jones", "Gabe Cohen"
+            ],
+            publisher: "W3C"
+          }
+        },
+        specStatus:  "base",
+        shortName:   "ns/credentials/issuer-dependent",
+        thisVersion: "https://www.w3.org/ns/credentials/issuer-dependent",
+        doJsonLd:    true,
+        editors: [{
+          name:       "Ivan Herman",
+          url:        "https://www.w3.org/People/Ivan/",
+          company:    "W3C",
+          w3cid:      7382,
+          orcid:      "0000-0003-0782-2704",
+          companyURL: "https://www.w3.org",
+          note:       "v2.0"
+        }],
+        postProcess : [remove_status_remark],
+        inlineCSS: true,
+        doRDFa: false,
+        noIDLIn: true,
+        noLegacyStyle: false
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+        <p>
+            This is the namespace document for the issuer dependent properties used in a 
+            Verifiable Credential [[vc-data-model]]
+        </p>
+    </section>
+    <section id="sotd">
+        <p>
+            This namespace has been defined by the <a href="https://www.w3.org/2017/vc/WG/">W3C Verifiable Credentials Working Group</a>.
+            Comments regarding this document are welcome. Please file issues
+            directly on <a href="https://github.com/w3c/vc-data-model/issues/">GitHub</a>, or send them to
+            <a href="mailto:public-vc-comments@w3.org">public-vc-comments@w3.org</a>
+            (<a href="mailto:public-vc-comments-request@w3.org?subject=subscribe">subscribe</a>,
+            <a href="https://lists.w3.org/Archives/Public/public-vc-comments/">archives</a>).    
+        </p>
+    </section>
+    <section id="conformance"></section>
+    <section>
+        <h2>Issuer Dependent Terms</h2>
+        <p>
+            The <a href="https://www.w3.org/TR/vc-data-model-2.0/#base-context">base context</a> of a Verifiable Credential, as defined in [vc-data-model], provides a mapping from the standard terms used in credentials to the vocabulary items defined by the Verifiable Credentials Working Group through different vocabularies, for example the <a href="https://www.w3.org/2018/credentials/">Verifiable Credentials Vocabulary</a>. Applications using additional, user-dependent vocabularies of their own are encouraged to create their own formal vocabularies, and corresponding JSON-LD context definitions, to ensure the interoperability of the credentials they produce and/or consume.
+        </p>
+        <p>
+            There may be cases, however, when the creation of such formal vocabularies and context definitions is too much of a burden; this is the case for closed applications, experiments, or examples. The way the <a href="https://www.w3.org/TR/vc-data-model-2.0/#base-context">base context</a> has been constructed is such that issuers may use new, hitherto undefined terms without further ado, and these terms will be mapped on URL-s of the form <code>https://www.w3.org/ns/credentials/issuer-dependent#TERM</code>.
+        </p>
+        <p>
+            This document provides a proper landing place for those URL-s, without any additional definitions for the terms themselves. 
+        </p>
+    </section>
+
+</body>
+</html>

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -54,6 +54,7 @@
           {uri: "vocabulary.ttl", label: "Turtle"},
           {uri: "vocabulary.jsonld", label: "JSON-LD"}
         ],
+        postProcess : [remove_status_remark],
         inlineCSS: true,
         doRDFa: false,
         noIDLIn: true,


### PR DESCRIPTION
The latest version of the `@context` file includes a reference, via a `@vocab`, to the `https://www.w3.org/ns/credentials/issuer-dependent` URL. At present, this URL leads to a 404, which is a big no-no. This PR creates a short "namespace document" alongside the VCDM vocabulary at `https://github.com/w3c/vc-data-model/tree/main/vocab/credentials/v2/issuer-dependent.html` (the file can be [previewed here](https://raw.githack.com/w3c/vc-data-model/issuer-dependent-namespace-document/vocab/credentials/v2/issuer-dependent.html)) which provides a simple landing place.

Although not part, physically, of the PR, I also have on my local disc a `.htaccess` file that is ready to be pushed onto `https://www.w3.org/ns/credentials/` and which looks as follows:

```
RewriteEngine On
RewriteBase /ns/credentials/
AddType application/ld+json .jsonld
AddType text/turtle .ttl


RewriteRule ^v2$ https://w3c.github.io/vc-data-model/contexts/credentials/v2 [E=json,P]
RewriteRule ^issuer-dependent$ https://w3c.github.io/vc-data-model/vocab/credentials/v2/issuer-dependent.html [P]
```

which takes care of mapping the `@vocab` URL to the file set up by this PR and, incidentally, also makes the mapping of the latest context file from `/ns/`, as requested in #935 (and as requested by @OR13). Note that the `.htaccess` filed does ***not*** map the core vocabulary file from `https://www.w3.org/ns/credentials/`, because that is still a pending issue #758. If the decision in #758 is to make that change, then the aforementioned `.htaccess` file can be extended accordingly.

