### PR TITLE
Restrict JSON-LD expression to compact document form.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3363,6 +3363,13 @@ side. The associated vocabulary document for the Verifiable Credentials Data
 Model is available at <code>https://www.w3.org/2018/credentials</code>.
         </p>
 
+        <p>
+This specification restricts the usage of JSON-LD representations. JSON-LD <a
+href="https://www.w3.org/TR/json-ld/#compacted-document-form">compact document
+form</a> MUST be utilized for all expressions of the data model described by
+this specification.
+        </p>
+
         <section>
           <h3>Syntactic Sugar</h3>
 

--- a/index.html
+++ b/index.html
@@ -3364,7 +3364,8 @@ Model is available at <code>https://www.w3.org/2018/credentials</code>.
         </p>
 
         <p>
-This specification restricts the usage of JSON-LD representations of Verifiable Credentials and Verifiable Presentations. JSON-LD <a
+This specification restricts the usage of JSON-LD representations of 
+<a>credentials</a> and <a> presentations</a>. JSON-LD <a
 href="https://www.w3.org/TR/json-ld/#compacted-document-form">compact document
 form</a> MUST be utilized for all representations of the data model described by
 this specification.

--- a/index.html
+++ b/index.html
@@ -3364,9 +3364,9 @@ Model is available at <code>https://www.w3.org/2018/credentials</code>.
         </p>
 
         <p>
-This specification restricts the usage of JSON-LD representations. JSON-LD <a
+This specification restricts the usage of JSON-LD representations of Verifiable Credentials and Verifiable Presentations. JSON-LD <a
 href="https://www.w3.org/TR/json-ld/#compacted-document-form">compact document
-form</a> MUST be utilized for all expressions of the data model described by
+form</a> MUST be utilized for all representations of the data model described by
 this specification.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -3364,11 +3364,11 @@ Model is available at <code>https://www.w3.org/2018/credentials</code>.
         </p>
 
         <p>
-This specification restricts the usage of JSON-LD representations of 
-<a>credentials</a> and <a> presentations</a>. JSON-LD <a
+This specification restricts the usage of JSON-LD representations of
+the data model. JSON-LD <a
 href="https://www.w3.org/TR/json-ld/#compacted-document-form">compact document
-form</a> MUST be utilized for all representations of the data model described by
-this specification.
+form</a> MUST be utilized for all representations of the data model in the
+base media type, `application/vc+ld+json`.
         </p>
 
         <section>


### PR DESCRIPTION
Addresses PR #779 by limiting JSON-LD expressions to compact document form.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1050.html" title="Last updated on Mar 15, 2023, 4:26 PM UTC (e63c069)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1050/8639d7c...e63c069.html" title="Last updated on Mar 15, 2023, 4:26 PM UTC (e63c069)">Diff</a>