### PR TITLE
VC.name term definition

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -47,7 +47,7 @@
           "@type": "@id"
         },
         "name": {
-          "@id": "https://schema.org/description",
+          "@id": "https://schema.org/name",
           "@type": "http://www.w3.org/2001/XMLSchema#string"
         },
         "proof": {


### PR DESCRIPTION
"name" pointing at https://schema.org/description doesn't seem right.