### PR TITLE
Add confidence method to VCDM

### DIFF
--- a/index.html
+++ b/index.html
@@ -2919,13 +2919,29 @@ information about the <code>proof</code> <a>property</a>, see Section
         <h3>Confidence Method</h3>
 
         <p>
-A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
-credential</a> to declare that a <a>subject</a> controls, or a <a>holder</a>
-has been designated to use, one or more particular confirmation methods. This
-binds a specific <a>claim</a> about a <a>subject</a> to one or more
-confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
-around how a <a>verifier</a> can validate that the <a>holder</a> is bound to
-the <a>claims</a> presented in a <a>verifiable credential</a>.
+An <a>issuer</a> can include a Confidence Method in a <a>verifiable
+credential</a> to inform verifiers of mechanisms they could use to increase
+their confidence in the truth of a variety of things, including the 
+following:</p>
+<ul>
+  <li>
+a particular identifier in the <a>verifiable credential</a> refers to the
+same <a>entity</a> the issuer intended it to refer to
+  </li>
+  <li>
+an <a>entity</a>, such as the presenter of a <a>verifiable credential</a>, 
+is the same <a>entity</a> that the <a>issuer</a> made claims about
+  </li>
+  <li>
+an <a>entity</a> controls, or has been designated to use, one or more 
+mechanisms for demonstrating proof-of-possession or proof-of-use of 
+cryptographic key material
+  </li>
+  <li>
+an <a>entity</a> identified in the <a>verifiable credential</a> can be 
+checked against a biometric
+  </li>
+</ul>
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -2906,6 +2906,153 @@ information about the <code>proof</code> <a>property</a>, see Section
       </section>
 
       <section>
+        <h3>Confirmation Method</h3>
+
+        <p>
+Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
+credential</a> to declare that the <a>subject</a> controls one or more
+particular confirmation methods and to bind the <a>claims</a> about the
+<a>subject</a> to one or more of these confirmation methods. In this way, an
+<a>issuer</a> explicitly enables a <a>verifier</a> to validate that the
+<a>holder</a> presenting the <a>verifiable credential</a> has proven control of
+one or more of these confirmation methods when the <a>claims</a> bound to the
+confirmation method are presented.
+        </p>
+
+        <p class="note">
+A <a>verifier</a> can decide to accept <a>claims</a> in a <a>verifiable
+credential</a> without validating the confirmation method or to use a different
+mechanism to validate the <a>holder</a> is bound to the presented <a>claims</a>
+if required without impacting liability if not specified by other means such
+as a <code>termsOfUse</code> policy.
+        </p>
+
+        <p>
+This specification defines the <code>confirmationMethod</code> <a>property</a>
+for expressing confirmation method information in a
+<code>credentialSubject</code> in a <a>verifiable credential</a>.
+        </p>
+
+        <p class="note">
+For example, an <a>issuer</a> can include a confirmation method based on public
+key cryptography in the <a>verifiable credential</a>. A <a>holder</a> can
+generate and include a <a>proof</a> with a cryptographic signature in the
+<a>verifiable presentation</a> where the verification key of the cryptographic
+signature is bound to a confirmation method in the embedded <a>verifiable
+credential</a>. A <a>verifier</a> can validate that the <a>holder</a> controls
+the confirmation method by verifying the <a>proof</a> of the <a>verifiable
+presentation</a> using the information in the confirmation method. The
+confirmation method can include the verification key or the type of the
+confirmation method can define that the verification key is inferred by other
+<a>properties</a> in the <a>verifiable credential</a> such as the
+<code>credentialSubject.id</code>.
+        </p>
+
+        <dl>
+          <dt><dfn>confirmationMethod</dfn></dt>
+          <dd>
+If present, the value of the <code>confirmationMethod</code> <a>property</a> is
+one or more confirmation methods each providing enough information for a
+<a>verifier</a> to validate a <a>holder</a> generating a <a>verifiable
+presentation</a> has proven control of a confirmation method bound to <a>claims
+</a> in a <a>verifiable credential</a> in the <a>verifiable presentation</a>.
+Each confirmation method MUST specify its <code>type</code> (for example,
+<code>DIDAuthWithSubjectIdConfirmation2023</code>) and MAY specify an <code>id
+</code>. The precise <a>properties</a> and semantics of each confirmation
+method is determined by the specific <code>confirmationMethod</code> type
+definition.
+          </dd>
+        </dl>
+
+        <p>
+The type <code>DIDAuthWithSubjectIdConfirmation2023</code> defines that a
+<a>verifier</a> MAY validate the confirmation method by verifying the proof of
+the <a>verifiable presentation</a> with the verification material of one of the
+authentication verification relationships of the
+<code>credentialSubject.id</code> in case the particular
+<code>credentialSubject.id</code> is a Decentralized Identifier (DID).
+        </p>
+
+       <pre class="example nohighlight"
+          title="Usage of the confirmationMethod property of type DIDAuthWithSubjectIdConfirmation2023">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "https://example.edu/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    <span class="highlight">"confirmationMethod": [{
+      "type": ["DIDAuthWithSubjectIdConfirmation2023"]
+    }]</span>,
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  },
+  "proof": { <span class="comment">...</span> }
+}
+        </pre>
+
+        <p>
+The type <code>VerificationKeyConfirmation2023</code> defines that a
+<a>verifier</a> MAY validate the confirmation method by verifying the proof of
+the <a>verifiable presentation</a> with the verification material contained in
+<code>publicKeyJwk</code> or <code>publicKeyMultibase</code>.
+        </p>
+
+       <pre class="example nohighlight"
+          title="Usage of the confirmationMethod property of type DIDAuthWithSubjectIdConfirmation2023">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://example.edu/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "https://example.edu/issuers/14",
+  "validFrom": "2010-01-01T19:23:24Z",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    <span class="highlight">"confirmationMethod": [{
+      "type": ["VerificationKeyConfirmation2023"],
+      "publicKeyJwk": {
+        "crv": "Ed25519",
+        "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
+        "kty": "OKP",
+        "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
+      }
+    },{
+      "type": ["VerificationKeyConfirmation2023"],
+      "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
+    }]</span>,
+    "degree": {
+      "type": "BachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  },
+  "proof": { <span class="comment">...</span> }
+}
+        </pre>
+
+        <p class="note">
+A confirmation method can express various metadata such as the <a>issuer's</a>
+level of confidence that the <a>holder</a> is the entity referenced by a
+<a>subject</a> of the <a>verifiable credential</a>, specific form factors or
+mechanisms of authenticators, references to other <a>verifiable credentials</a>
+or versioned trust frameworks. For example, an <a>issuer</a> can make a
+<a>claim</a> about a confirmation method that is based on a cryptographic key
+pair but to produce a signature using that key the <a>holder</a> has to unlock
+a device using multi-factor authentication.
+        </p>
+
+      </section>
+
+      <section>
         <h3>Zero-Knowledge Proofs</h3>
 
 <p class="issue" data-number="863">

--- a/index.html
+++ b/index.html
@@ -2953,8 +2953,8 @@ signature is bound to a confirmation method in the embedded <a>verifiable
 credential</a>.
           </p>
           <p>
-A <a>verifier</a> can validate that the <a>holder</a> controls
-or has been designated the ability to use the confirmation method
+A <a>verifier</a> can validate that the <a>holder</a> controls,
+or has been designated the ability to use, a confirmation method
 by verifying the <a>proof</a> of the <a>verifiable
 presentation</a> using the information in the confirmation method. The
 confirmation method can include the verification key, or the type of the

--- a/index.html
+++ b/index.html
@@ -2920,7 +2920,7 @@ information about the <code>proof</code> <a>property</a>, see Section
 
         <p>
 A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
-credential</a> to declare that the <a>subject</a> controls, or a <a>holder</a>
+credential</a> to declare that a <a>subject</a> controls, or a <a>holder</a>
 has been designated to use, one or more particular confirmation methods. This
 binds a specific <a>claim</a> about a <a>subject</a> to one or more
 confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance

--- a/index.html
+++ b/index.html
@@ -3063,7 +3063,7 @@ the <a>verifiable presentation</a> with the verification material contained in
 A confirmation method can express various metadata such as the <a>issuer's</a>
 level of confidence that the <a>holder</a> is the entity referenced by a
 <a>subject</a> of the <a>verifiable credential</a>, specific form factors or
-mechanisms of authenticators, references to other <a>verifiable credentials</a>
+mechanisms of authenticators, and/or references to other <a>verifiable credentials</a>
 or versioned trust frameworks. For example, an <a>issuer</a> can make a
 <a>claim</a> about a confirmation method that is based on a cryptographic key
 pair but to produce a signature using that key the <a>holder</a> has to unlock

--- a/index.html
+++ b/index.html
@@ -3024,7 +3024,7 @@ type-specific property of the confidence method.
   "issuer": "https://example.edu/issuers/14",
   "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
-    <span class="highlight">"confirmationMethod": [{
+    <span class="highlight">"confidenceMethod": [{
       "type": "VerificationKeyConfirmation",
       "publicKeyJwk": {
         "crv": "Ed25519",

--- a/index.html
+++ b/index.html
@@ -3065,7 +3065,7 @@ the <a>verifiable presentation</a> with the verification material contained in
         </pre>
 
         <p class="note">
-A confirmation method can express various metadata such as the <a>issuer's</a>
+A confirmation method can express various metadata such as the <a>issuer</a>'s
 level of confidence that the <a>holder</a> is the entity referenced by a
 <a>subject</a> of the <a>verifiable credential</a>, specific form factors or
 mechanisms of authenticators, and/or references to other <a>verifiable credentials</a>

--- a/index.html
+++ b/index.html
@@ -2373,7 +2373,7 @@ Implementers are advised to pay close attention to the extension points in this
 specification, such as in Sections <a href="#proofs-signatures"></a>,
 <a href="#status"></a>, <a href="#data-schemas"></a>,
 <a href="#refreshing"></a>, <a href="#terms-of-use"></a>,
-<a href="#evidence"></a> and <a href="#confirmation-method"></a>. While this
+<a href="#evidence"></a>, and <a href="#confirmation-method"></a>. While this
 specification does not define concrete implementations for those extension
 points, the Verifiable Credentials Extension Registry [[?VC-EXTENSION-REGISTRY]]
 provides an unofficial, curated list of extensions that developers can use from

--- a/index.html
+++ b/index.html
@@ -2999,8 +2999,8 @@ in the <a>claims</a> of the <a>verifiable credential</a>s they issue.
 Each confidence method MUST specify its <code>type</code> (for example,
 <code>DIDAuthWithSubjectIdConfirmation</code>) and MAY specify an
 <code>id</code>. The precise <a>properties</a> and semantics of each
-confirmation method are determined by the specific
-<code>confirmationMethod</code> type definition.
+confidence method are determined by the specific
+<code>confidenceMethod</code> type definition.
             </p>
           </dd>
         </dl>

--- a/index.html
+++ b/index.html
@@ -2957,10 +2957,10 @@ one or more confirmation methods each providing enough information for a
 presentation</a> has proven control of a confirmation method bound to <a>claims
 </a> in a <a>verifiable credential</a> in the <a>verifiable presentation</a>.
 Each confirmation method MUST specify its <code>type</code> (for example,
-<code>DIDAuthWithSubjectIdConfirmation2023</code>) and MAY specify an <code>id
-</code>. The precise <a>properties</a> and semantics of each confirmation
-method is determined by the specific <code>confirmationMethod</code> type
-definition.
+<code>DIDAuthWithSubjectIdConfirmation2023</code>) and MAY specify an
+<code>id</code>. The precise <a>properties</a> and semantics of each
+confirmation method is determined by the specific
+<code>confirmationMethod</code> type definition.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2923,10 +2923,10 @@ A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
 credential</a> to declare that the <a>subject</a> controls one or more
 particular confirmation methods and to bind the <a>claims</a> about the
 <a>subject</a> to one or more of these confirmation methods. In this way, an
-<a>issuer</a> explicitly enables a <a>verifier</a> to validate that the
-<a>holder</a> presenting the <a>verifiable credential</a> has proven control of
-one or more of these confirmation methods when the <a>claims</a> bound to the
-confirmation method are presented.
+<a>issuer</a> explicitly gives guidance and enables a <a>verifier</a> to
+validate that the <a>holder</a> presenting the <a>verifiable credential</a>has
+proven control of one or more of these confirmation methods when the
+<a>claims</a> bound to the confirmation method are presented.
         </p>
 
         <p class="note">
@@ -2972,8 +2972,11 @@ confirmation method can define that the verification key is to be inferred from 
 If present, the value of the <code>confirmationMethod</code> <a>property</a> is
 one or more confirmation methods, each providing enough information for a
 <a>verifier</a> to validate that the <a>holder</a> generating a <a>verifiable
-presentation</a> has proven control of a confirmation method bound to one or more <a>claims
-</a> in a <a>verifiable credential</a> in the <a>verifiable presentation</a>.
+presentation</a> has proven control of a confirmation method bound to one or more
+<a>claims</a> in a <a>verifiable credential</a> in the
+<a>verifiable presentation</a>. It is required that the <a>issuer</a> verifies
+for each <code>confirmationMethod</code> that the <a>holder</a> receiving the
+<code>verifiable credential</code> has proven control of it.
             </p>
             <p>
 Each confirmation method MUST specify its <code>type</code> (for example,

--- a/index.html
+++ b/index.html
@@ -2996,9 +2996,9 @@ authentication verification relationships of the
   "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    <span class="highlight">"confirmationMethod": [{
+    <span class="highlight">"confirmationMethod": {
       "type": "DIDAuthWithSubjectIdConfirmation2023"
-    }]</span>,
+    }</span>,
     "degree": {
       "type": "BachelorDegree",
       "name": "Bachelor of Science and Arts"

--- a/index.html
+++ b/index.html
@@ -2920,8 +2920,8 @@ information about the <code>proof</code> <a>property</a>, see Section
 
         <p>
 A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
-credential</a> to declare that the <a>subject</a> controls or a <a>holder</a>
-has been designated to use one or more particular confirmation methods and to
+credential</a> to declare that the <a>subject</a> controls, or a <a>holder</a>
+has been designated to use, one or more particular confirmation methods and to
 bind the <a>claims</a> about the <a>subject</a> to one or more of these
 confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
 and enables a <a>verifier</a> to validate that the <a>holder</a> presenting the

--- a/index.html
+++ b/index.html
@@ -2924,16 +2924,17 @@ credential</a> to declare that the <a>subject</a> controls, or a <a>holder</a>
 has been designated to use, one or more particular confirmation methods. This
 binds a specific <a>claim</a> about a <a>subject</a> to one or more
 confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
-around how a <a>verifier</a> can validate that the <a>holder</a> is bound to the <a>claims</a> presented in a <a>verifiable credential</a>.
+around how a <a>verifier</a> can validate that the <a>holder</a> is bound to
+the <a>claims</a> presented in a <a>verifiable credential</a>.
         </p>
 
         <p class="note">
 A <a>verifier</a> can decide to accept <a>claims</a> in a <a>verifiable
-credential</a> without validating the confirmation method, or to use a different
-mechanism to validate whether the <a>holder</a> is bound to the presented <a>claims</a>,
-if required. Such decision can prevent impact on the <a>verifier</a>'s
-liability or lack thereof if not specified by other means such
-as a <code>termsOfUse</code> policy.
+credential</a> without validating the confirmation method, or to use a
+different mechanism to validate whether the <a>holder</a> is bound to the
+presented <a>claims</a>, if required. Such decision can prevent impact on the
+<a>verifier</a>'s liability or lack thereof if not specified by other means
+such as a <code>termsOfUse</code> policy.
         </p>
 
         <p>
@@ -2957,8 +2958,8 @@ or has been designated the ability to use the confirmation method
 by verifying the <a>proof</a> of the <a>verifiable
 presentation</a> using the information in the confirmation method. The
 confirmation method can include the verification key, or the type of the
-confirmation method can define that the verification key is to be inferred from other
-<a>properties</a> in the <a>verifiable credential</a>, such as the
+confirmation method can define that the verification key is to be inferred from
+other <a>properties</a> in the <a>verifiable credential</a>, such as the
 <code>credentialSubject.id</code>.
           </p>
         </div>
@@ -2971,11 +2972,11 @@ confirmation method can define that the verification key is to be inferred from 
 If present, the value of the <code>confirmationMethod</code> <a>property</a> is
 one or more confirmation methods, each providing enough information for a
 <a>verifier</a> to validate that the <a>holder</a> generating a <a>verifiable
-presentation</a> has proven control of a confirmation method bound to one or more
-<a>claims</a> in a <a>verifiable credential</a> in the
+presentation</a> has proven control of a confirmation method bound to one or
+more <a>claims</a> in a <a>verifiable credential</a> in the
 <a>verifiable presentation</a>. It is required that the <a>issuer</a> verifies
-for each <code>confirmationMethod</code> that the <a>holder</a> receiving the
-<code>verifiable credential</code> has proven control of it.
+the <a>holder</a> can satisfy each <code>confirmationMethod</code> they include
+in the <a>claims</a> of the <a>verifiable credential</a>s they issue.
             </p>
             <p>
 Each confirmation method MUST specify its <code>type</code> (for example,

--- a/index.html
+++ b/index.html
@@ -2955,7 +2955,8 @@ credential</a>.
           </p>
           <p>
 A <a>verifier</a> can validate that the <a>holder</a> controls
-the confirmation method by verifying the <a>proof</a> of the <a>verifiable
+or has been designated the ability to use the confirmation method
+by verifying the <a>proof</a> of the <a>verifiable
 presentation</a> using the information in the confirmation method. The
 confirmation method can include the verification key, or the type of the
 confirmation method can define that the verification key is to be inferred from other

--- a/index.html
+++ b/index.html
@@ -1418,7 +1418,7 @@ A valid evidence <a>type</a>. For example,<br>
 
             <tr>
               <td>
-<a href="#confirmatinoMethod">confirmationMethod</a>&nbsp;object
+<a href="#confirmation-method">confirmationMethod</a>&nbsp;object
               </td>
               <td>
 A valid confirmation method <a>type</a>. For example,<br>
@@ -2371,8 +2371,9 @@ documents with implementations, or enabling aggressive caching of contexts.
         <p>
 Implementers are advised to pay close attention to the extension points in this
 specification, such as in Sections <a href="#proofs-signatures"></a>,
-<a href="#status"></a>, <a href="#data-schemas"></a>,<a href="#refreshing"></a>,
-<a href="#terms-of-use"></a>, and <a href="#evidence"></a>. While this
+<a href="#status"></a>, <a href="#data-schemas"></a>,
+<a href="#refreshing"></a>, <a href="#terms-of-use"></a>,
+<a href="#evidence"></a> and <a href="#confirmation-method"></a>. While this
 specification does not define concrete implementations for those extension
 points, the Verifiable Credentials Extension Registry [[?VC-EXTENSION-REGISTRY]]
 provides an unofficial, curated list of extensions that developers can use from

--- a/index.html
+++ b/index.html
@@ -2916,7 +2916,7 @@ information about the <code>proof</code> <a>property</a>, see Section
       </section>
 
       <section>
-        <h3>Confirmation Method</h3>
+        <h3>Confidence Method</h3>
 
         <p>
 A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable

--- a/index.html
+++ b/index.html
@@ -3027,7 +3027,7 @@ the <a>verifiable presentation</a> with the verification material contained in
         </p>
 
        <pre class="example nohighlight"
-          title="Usage of the confirmationMethod property of type DIDAuthWithSubjectIdConfirmation2023">
+          title="Usage of the confirmationMethod property of type VerificationKeyConfirmation2023">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",

--- a/index.html
+++ b/index.html
@@ -2921,7 +2921,7 @@ information about the <code>proof</code> <a>property</a>, see Section
         <p>
 An <a>issuer</a> can include a Confidence Method in a <a>verifiable
 credential</a> to inform verifiers of mechanisms they could use to increase
-their confidence in the truth of a variety of things, including the 
+their confidence in the truth of a variety of things, including the
 following:</p>
 <ul>
   <li>
@@ -2929,16 +2929,16 @@ a particular identifier in the <a>verifiable credential</a> refers to the
 same <a>entity</a> the issuer intended it to refer to
   </li>
   <li>
-an <a>entity</a>, such as the presenter of a <a>verifiable credential</a>, 
+an <a>entity</a>, such as the presenter of a <a>verifiable credential</a>,
 is the same <a>entity</a> that the <a>issuer</a> made claims about
   </li>
   <li>
-an <a>entity</a> controls, or has been designated to use, one or more 
-mechanisms for demonstrating proof-of-possession or proof-of-use of 
+an <a>entity</a> controls, or has been designated to use, one or more
+mechanisms for demonstrating proof-of-possession or proof-of-use of
 cryptographic key material
   </li>
   <li>
-an <a>entity</a> identified in the <a>verifiable credential</a> can be 
+an <a>entity</a> identified in the <a>verifiable credential</a> can be
 checked against a biometric
   </li>
 </ul>
@@ -2998,8 +2998,7 @@ the <a>issuer</a> verifies the <a>holder</a> can satisfy each
 <a>claims</a> of the <a>verifiable credential</a>s they issue.
             </p>
             <p>
-Each confidence method MUST specify its <code>type</code> (for example,
-<code>DIDAuthWithSubjectIdConfirmation</code>) and MAY specify an
+Each confidence method MUST specify its <code>type</code> and MAY specify an
 <code>id</code>. The precise <a>properties</a> and semantics of each
 confidence method are determined by the specific
 <code>confidenceMethod</code> type definition.
@@ -3008,44 +3007,9 @@ confidence method are determined by the specific
         </dl>
 
         <p>
-The type <code>DIDAuthWithSubjectIdConfirmation</code> defines that a
-<a>verifier</a> MAY validate the confidence method by verifying the proof of
-the <a>verifiable presentation</a> with the verification material of one of the
-authentication verification relationships of the
-<code>credentialSubject.id</code> if the particular
-<code>credentialSubject.id</code> is a Decentralized Identifier (DID).
-        </p>
-
-       <pre class="example nohighlight"
-          title="Usage of the confirmationMethod property of type DIDAuthWithSubjectIdConfirmation">
-{
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
-  ],
-  "id": "http://example.edu/credentials/3732",
-  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
-  "issuer": "https://example.edu/issuers/14",
-  "validFrom": "2010-01-01T19:23:24Z",
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    <span class="highlight">"confirmationMethod": {
-      "type": "DIDAuthWithSubjectIdConfirmation"
-    }</span>,
-    "degree": {
-      "type": "BachelorDegree",
-      "name": "Bachelor of Science and Arts"
-    }
-  },
-  "proof": { <span class="comment">...</span> }
-}
-        </pre>
-
-        <p>
-The type <code>VerificationKeyConfirmation</code> defines that a
-<a>verifier</a> MAY validate the confidence method by verifying the proof of
-the <a>verifiable presentation</a> with the verification material contained in
-<code>publicKeyJwk</code> or <code>publicKeyMultibase</code>.
+The following example demonstrates a confidence method based on proving
+possession of a cryptographic key. The corresponding public key is a
+type-specific property of the confidence method.
         </p>
 
        <pre class="example nohighlight"

--- a/index.html
+++ b/index.html
@@ -2989,11 +2989,13 @@ other <a>properties</a> in the <a>verifiable credential</a>, such as the
 If present, the value of the <code>confidenceMethod</code> <a>property</a> is
 one or more confidence methods. Each confidence method is bound to one or more
 claims in the <a>verifiable credential</a>, and provides enough information for a
-<a>verifier</a> to confirm whether the <a>holder</a> generating a <a>verifiable
-presentation</a> can satisfy that confirmation method. It is required that the
-<a>issuer</a> verifies
-the <a>holder</a> can satisfy each <code>confirmationMethod</code> they include
-in the <a>claims</a> of the <a>verifiable credential</a>s they issue.
+<a>verifier</a> to determine whether the <a>holder</a> can generate a
+<a>verifiable presentation</a> to increase the <a>verifier's</a> confidence
+that they are the same <a>entity</a> referenced by the confidence method.
+This is referred to as satisfying the confidence method. It is required that
+the <a>issuer</a> verifies the <a>holder</a> can satisfy each
+<code>confidenceMethod</code> the <a>issuer</a> includes in the
+<a>claims</a> of the <a>verifiable credential</a>s they issue.
             </p>
             <p>
 Each confidence method MUST specify its <code>type</code> (for example,

--- a/index.html
+++ b/index.html
@@ -2944,20 +2944,25 @@ for expressing confirmation method information in a
 <code>credentialSubject</code> in a <a>verifiable credential</a>.
         </p>
 
-        <p class="note">
+        <div class="note">
+          <p>
 For example, an <a>issuer</a> can include a confirmation method based on public
 key cryptography in the <a>verifiable credential</a>. A <a>holder</a> can
 generate and include a <a>proof</a> with a cryptographic signature in the
-<a>verifiable presentation</a> where the verification key of the cryptographic
+<a>verifiable presentation</a>, where the verification key of the cryptographic
 signature is bound to a confirmation method in the embedded <a>verifiable
-credential</a>. A <a>verifier</a> can validate that the <a>holder</a> controls
+credential</a>.
+          </p>
+          <p>
+A <a>verifier</a> can validate that the <a>holder</a> controls
 the confirmation method by verifying the <a>proof</a> of the <a>verifiable
 presentation</a> using the information in the confirmation method. The
-confirmation method can include the verification key or the type of the
-confirmation method can define that the verification key is inferred by other
-<a>properties</a> in the <a>verifiable credential</a> such as the
+confirmation method can include the verification key, or the type of the
+confirmation method can define that the verification key is to be inferred from other
+<a>properties</a> in the <a>verifiable credential</a>, such as the
 <code>credentialSubject.id</code>.
-        </p>
+          </p>
+        </div>
 
         <dl>
           <dt><dfn>confirmationMethod</dfn></dt>

--- a/index.html
+++ b/index.html
@@ -2967,16 +2967,21 @@ confirmation method can define that the verification key is to be inferred from 
         <dl>
           <dt><dfn>confirmationMethod</dfn></dt>
           <dd>
+          <dd>
+            <p>
 If present, the value of the <code>confirmationMethod</code> <a>property</a> is
-one or more confirmation methods each providing enough information for a
-<a>verifier</a> to validate a <a>holder</a> generating a <a>verifiable
-presentation</a> has proven control of a confirmation method bound to <a>claims
+one or more confirmation methods, each providing enough information for a
+<a>verifier</a> to validate that the <a>holder</a> generating a <a>verifiable
+presentation</a> has proven control of a confirmation method bound to one or more <a>claims
 </a> in a <a>verifiable credential</a> in the <a>verifiable presentation</a>.
+            </p>
+            <p>
 Each confirmation method MUST specify its <code>type</code> (for example,
 <code>DIDAuthWithSubjectIdConfirmation2023</code>) and MAY specify an
 <code>id</code>. The precise <a>properties</a> and semantics of each
-confirmation method is determined by the specific
+confirmation method are determined by the specific
 <code>confirmationMethod</code> type definition.
+            </p>
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -3007,7 +3007,7 @@ confidence method are determined by the specific
 
         <p>
 The type <code>DIDAuthWithSubjectIdConfirmation</code> defines that a
-<a>verifier</a> MAY validate the confirmation method by verifying the proof of
+<a>verifier</a> MAY validate the confidence method by verifying the proof of
 the <a>verifiable presentation</a> with the verification material of one of the
 authentication verification relationships of the
 <code>credentialSubject.id</code> if the particular

--- a/index.html
+++ b/index.html
@@ -2934,7 +2934,7 @@ are presented.
 A <a>verifier</a> can decide to accept <a>claims</a> in a <a>verifiable
 credential</a> without validating the confirmation method, or to use a different
 mechanism to validate whether the <a>holder</a> is bound to the presented <a>claims</a>,
-if required. Such decision may prevent impact on the <a>verifier</a>'s
+if required. Such decision can prevent impact on the <a>verifier</a>'s
 liability or lack thereof if not specified by other means such
 as a <code>termsOfUse</code> policy.
         </p>

--- a/index.html
+++ b/index.html
@@ -1421,7 +1421,7 @@ A valid evidence <a>type</a>. For example,<br>
 <a href="#confidence-method">confidenceMethod</a>&nbsp;object
               </td>
               <td>
-A valid confirmation method <a>type</a>. For example,<br>
+A valid confidence method <a>type</a>. For example,<br>
 <code>"type": "VerificationKeyConfirmation"</code>
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -2919,7 +2919,7 @@ information about the <code>proof</code> <a>property</a>, see Section
         <h3>Confirmation Method</h3>
 
         <p>
-Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
+A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
 credential</a> to declare that the <a>subject</a> controls one or more
 particular confirmation methods and to bind the <a>claims</a> about the
 <a>subject</a> to one or more of these confirmation methods. In this way, an

--- a/index.html
+++ b/index.html
@@ -2931,9 +2931,10 @@ confirmation method are presented.
 
         <p class="note">
 A <a>verifier</a> can decide to accept <a>claims</a> in a <a>verifiable
-credential</a> without validating the confirmation method or to use a different
-mechanism to validate the <a>holder</a> is bound to the presented <a>claims</a>
-if required without impacting liability if not specified by other means such
+credential</a> without validating the confirmation method, or to use a different
+mechanism to validate whether the <a>holder</a> is bound to the presented <a>claims</a>,
+if required. Such decision may prevent impact on the <a>verifier</a>'s
+liability or lack thereof if not specified by other means such
 as a <code>termsOfUse</code> policy.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -2925,7 +2925,7 @@ has been designated to use one or more particular confirmation methods and to
 bind the <a>claims</a> about the <a>subject</a> to one or more of these
 confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
 and enables a <a>verifier</a> to validate that the <a>holder</a> presenting the
-<a>verifiable credential</a>has proven control of one or more of these
+<a>verifiable credential</a> has proven control of one or more of these
 confirmation methods when the <a>claims</a> bound to the confirmation method
 are presented.
         </p>

--- a/index.html
+++ b/index.html
@@ -2990,7 +2990,7 @@ The type <code>DIDAuthWithSubjectIdConfirmation2023</code> defines that a
 <a>verifier</a> MAY validate the confirmation method by verifying the proof of
 the <a>verifiable presentation</a> with the verification material of one of the
 authentication verification relationships of the
-<code>credentialSubject.id</code> in case the particular
+<code>credentialSubject.id</code> if the particular
 <code>credentialSubject.id</code> is a Decentralized Identifier (DID).
         </p>
 

--- a/index.html
+++ b/index.html
@@ -2962,12 +2962,12 @@ for expressing confidence method information in a
 
         <div class="note">
           <p>
-For example, an <a>issuer</a> can include a confirmation method based on public
+For example, an <a>issuer</a> can include a confidence method based on public
 key cryptography in the <a>verifiable credential</a>. A <a>holder</a> can
-generate and include a <a>proof</a> with a cryptographic signature in the
-<a>verifiable presentation</a>, where the verification key of the cryptographic
-signature is bound to a confirmation method in the embedded <a>verifiable
-credential</a>.
+demonstrate they are able to generate and include a <a>proof</a> with a
+cryptographic signature in the <a>verifiable presentation</a> that will verify
+against the verification key expressed in the confidence method in the
+embedded <a>verifiable credential</a>.
           </p>
           <p>
 A <a>verifier</a> can validate that the <a>holder</a> controls,

--- a/index.html
+++ b/index.html
@@ -3041,7 +3041,7 @@ authentication verification relationships of the
 
         <p>
 The type <code>VerificationKeyConfirmation</code> defines that a
-<a>verifier</a> MAY validate the confirmation method by verifying the proof of
+<a>verifier</a> MAY validate the confidence method by verifying the proof of
 the <a>verifiable presentation</a> with the verification material contained in
 <code>publicKeyJwk</code> or <code>publicKeyMultibase</code>.
         </p>

--- a/index.html
+++ b/index.html
@@ -2982,7 +2982,7 @@ other <a>properties</a> in the <a>verifiable credential</a>, such as the
         </div>
 
         <dl>
-          <dt><dfn>confirmationMethod</dfn></dt>
+          <dt><dfn>confidenceMethod</dfn></dt>
           <dd>
           <dd>
             <p>

--- a/index.html
+++ b/index.html
@@ -2920,13 +2920,14 @@ information about the <code>proof</code> <a>property</a>, see Section
 
         <p>
 A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
-credential</a> to declare that the <a>subject</a> controls one or more
-particular confirmation methods and to bind the <a>claims</a> about the
-<a>subject</a> to one or more of these confirmation methods. In this way, an
-<a>issuer</a> explicitly gives guidance and enables a <a>verifier</a> to
-validate that the <a>holder</a> presenting the <a>verifiable credential</a>has
-proven control of one or more of these confirmation methods when the
-<a>claims</a> bound to the confirmation method are presented.
+credential</a> to declare that the <a>subject</a> controls or a <a>holder</a>
+has been designated to use one or more particular confirmation methods and to
+bind the <a>claims</a> about the <a>subject</a> to one or more of these
+confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
+and enables a <a>verifier</a> to validate that the <a>holder</a> presenting the
+<a>verifiable credential</a>has proven control of one or more of these
+confirmation methods when the <a>claims</a> bound to the confirmation method
+are presented.
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -3063,12 +3063,12 @@ the <a>verifiable presentation</a> with the verification material contained in
         </pre>
 
         <p class="note">
-A confirmation method can express various metadata such as the <a>issuer</a>'s
+A confidence method can express various metadata such as the <a>issuer</a>'s
 level of confidence that the <a>holder</a> is the entity referenced by a
 <a>subject</a> of the <a>verifiable credential</a>, specific form factors or
 mechanisms of authenticators, and/or references to other <a>verifiable credentials</a>
 or versioned trust frameworks. For example, an <a>issuer</a> can make a
-<a>claim</a> about a confirmation method that is based on a cryptographic key
+<a>claim</a> about a confidence method that is based on a cryptographic key
 pair, but to produce a signature using that key, the <a>holder</a> has to unlock
 a device using multi-factor authentication.
         </p>

--- a/index.html
+++ b/index.html
@@ -2955,8 +2955,8 @@ specified by other means such as a <code>termsOfUse</code> policy.
         </p>
 
         <p>
-This specification defines the <code>confirmationMethod</code> <a>property</a>
-for expressing confirmation method information in a
+This specification defines the <code>confidenceMethod</code> <a>property</a>
+for expressing confidence method information in a
 <code>credentialSubject</code> in a <a>verifiable credential</a>.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1416,6 +1416,15 @@ A valid evidence <a>type</a>. For example,<br>
               </td>
             </tr>
 
+            <tr>
+              <td>
+<a href="#confirmatinoMethod">confirmationMethod</a>&nbsp;object
+              </td>
+              <td>
+A valid confirmation method <a>type</a>. For example,<br>
+<code>"type": "VerificationKeyConfirmation2023"</code>
+              </td>
+            </tr>
           </tbody>
         </table>
 

--- a/index.html
+++ b/index.html
@@ -3066,7 +3066,7 @@ level of confidence that the <a>holder</a> is the entity referenced by a
 mechanisms of authenticators, and/or references to other <a>verifiable credentials</a>
 or versioned trust frameworks. For example, an <a>issuer</a> can make a
 <a>claim</a> about a confirmation method that is based on a cryptographic key
-pair but to produce a signature using that key the <a>holder</a> has to unlock
+pair, but to produce a signature using that key, the <a>holder</a> has to unlock
 a device using multi-factor authentication.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -2971,11 +2971,11 @@ embedded <a>verifiable credential</a>.
           </p>
           <p>
 A <a>verifier</a> can validate that the <a>holder</a> controls,
-or has been designated the ability to use, a confirmation method
+or has been designated the ability to use, a confidence method
 by verifying the <a>proof</a> of the <a>verifiable
-presentation</a> using the information in the confirmation method. The
-confirmation method can include the verification key, or the type of the
-confirmation method can define that the verification key is to be inferred from
+presentation</a> using the information in the confidence method. The
+confidence method can include the verification key, or the type of the
+confidence method can define that the verification key is to be inferred from
 other <a>properties</a> in the <a>verifiable credential</a>, such as the
 <code>credentialSubject.id</code>.
           </p>

--- a/index.html
+++ b/index.html
@@ -2997,7 +2997,7 @@ authentication verification relationships of the
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     <span class="highlight">"confirmationMethod": [{
-      "type": ["DIDAuthWithSubjectIdConfirmation2023"]
+      "type": "DIDAuthWithSubjectIdConfirmation2023"
     }]</span>,
     "degree": {
       "type": "BachelorDegree",
@@ -3029,7 +3029,7 @@ the <a>verifiable presentation</a> with the verification material contained in
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     <span class="highlight">"confirmationMethod": [{
-      "type": ["VerificationKeyConfirmation2023"],
+      "type": "VerificationKeyConfirmation2023",
       "publicKeyJwk": {
         "crv": "Ed25519",
         "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
@@ -3037,7 +3037,7 @@ the <a>verifiable presentation</a> with the verification material contained in
         "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
       }
     },{
-      "type": ["VerificationKeyConfirmation2023"],
+      "type": "VerificationKeyConfirmation2023",
       "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
     }]</span>,
     "degree": {

--- a/index.html
+++ b/index.html
@@ -2921,8 +2921,8 @@ information about the <code>proof</code> <a>property</a>, see Section
         <p>
 A Confirmation Method can be included by an <a>issuer</a> in a <a>verifiable
 credential</a> to declare that the <a>subject</a> controls, or a <a>holder</a>
-has been designated to use, one or more particular confirmation methods and to
-bind the <a>claims</a> about the <a>subject</a> to one or more of these
+has been designated to use, one or more particular confirmation methods. This
+binds a specific <a>claim</a> about a <a>subject</a> to one or more
 confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
 around how a <a>verifier</a> can validate that the <a>holder</a> is bound to the <a>claims</a> presented in a <a>verifiable credential</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -2950,7 +2950,7 @@ credential</a> without requiring use of the confidence method, or use a
 different mechanism to increase their confidence about whether, for
 example, the <a>holder</a> is the same <a>entity</a> the issuer made
 <a>claims</a> about in the <a>verifiable credential</a>. Such a decision
-can prevent impact on the <a>verifier</a>'s liability or lack thereof if not
+can impact the <a>verifier</a>'s liability or lack thereof if not
 specified by other means such as a <code>termsOfUse</code> policy.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1422,7 +1422,7 @@ A valid evidence <a>type</a>. For example,<br>
               </td>
               <td>
 A valid confirmation method <a>type</a>. For example,<br>
-<code>"type": "VerificationKeyConfirmation2023"</code>
+<code>"type": "VerificationKeyConfirmation"</code>
               </td>
             </tr>
           </tbody>
@@ -2977,7 +2977,7 @@ presentation</a> has proven control of a confirmation method bound to one or mor
             </p>
             <p>
 Each confirmation method MUST specify its <code>type</code> (for example,
-<code>DIDAuthWithSubjectIdConfirmation2023</code>) and MAY specify an
+<code>DIDAuthWithSubjectIdConfirmation</code>) and MAY specify an
 <code>id</code>. The precise <a>properties</a> and semantics of each
 confirmation method are determined by the specific
 <code>confirmationMethod</code> type definition.
@@ -2986,7 +2986,7 @@ confirmation method are determined by the specific
         </dl>
 
         <p>
-The type <code>DIDAuthWithSubjectIdConfirmation2023</code> defines that a
+The type <code>DIDAuthWithSubjectIdConfirmation</code> defines that a
 <a>verifier</a> MAY validate the confirmation method by verifying the proof of
 the <a>verifiable presentation</a> with the verification material of one of the
 authentication verification relationships of the
@@ -2995,7 +2995,7 @@ authentication verification relationships of the
         </p>
 
        <pre class="example nohighlight"
-          title="Usage of the confirmationMethod property of type DIDAuthWithSubjectIdConfirmation2023">
+          title="Usage of the confirmationMethod property of type DIDAuthWithSubjectIdConfirmation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -3008,7 +3008,7 @@ authentication verification relationships of the
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     <span class="highlight">"confirmationMethod": {
-      "type": "DIDAuthWithSubjectIdConfirmation2023"
+      "type": "DIDAuthWithSubjectIdConfirmation"
     }</span>,
     "degree": {
       "type": "BachelorDegree",
@@ -3020,14 +3020,14 @@ authentication verification relationships of the
         </pre>
 
         <p>
-The type <code>VerificationKeyConfirmation2023</code> defines that a
+The type <code>VerificationKeyConfirmation</code> defines that a
 <a>verifier</a> MAY validate the confirmation method by verifying the proof of
 the <a>verifiable presentation</a> with the verification material contained in
 <code>publicKeyJwk</code> or <code>publicKeyMultibase</code>.
         </p>
 
        <pre class="example nohighlight"
-          title="Usage of the confirmationMethod property of type VerificationKeyConfirmation2023">
+          title="Usage of the confirmationMethod property of type VerificationKeyConfirmation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -3039,7 +3039,7 @@ the <a>verifiable presentation</a> with the verification material contained in
   "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
     <span class="highlight">"confirmationMethod": [{
-      "type": "VerificationKeyConfirmation2023",
+      "type": "VerificationKeyConfirmation",
       "publicKeyJwk": {
         "crv": "Ed25519",
         "x": "VCpo2LMLhn6iWku8MKvSLg2ZAoC-nlOyPVQaO3FxVeQ",
@@ -3047,7 +3047,7 @@ the <a>verifiable presentation</a> with the verification material contained in
         "kid": "_Qq0UL2Fq651Q0Fjd6TvnYE-faHiOpRlPVQcY_-tA4A"
       }
     },{
-      "type": "VerificationKeyConfirmation2023",
+      "type": "VerificationKeyConfirmation",
       "publicKeyMultibase": "zH3C2AVvLMv6gmMNam3uVAjZpfkcJCwDwnZn6z3wXmqPV"
     }]</span>,
     "degree": {

--- a/index.html
+++ b/index.html
@@ -2946,11 +2946,12 @@ checked against a biometric
 
         <p class="note">
 A <a>verifier</a> can decide to accept <a>claims</a> in a <a>verifiable
-credential</a> without validating the confirmation method, or to use a
-different mechanism to validate whether the <a>holder</a> is bound to the
-presented <a>claims</a>, if required. Such decision can prevent impact on the
-<a>verifier</a>'s liability or lack thereof if not specified by other means
-such as a <code>termsOfUse</code> policy.
+credential</a> without requiring use of the confidence method, or use a
+different mechanism to increase their confidence about whether, for
+example, the <a>holder</a> is the same <a>entity</a> the issuer made
+<a>claims</a> about in the <a>verifiable credential</a>. Such a decision
+can prevent impact on the <a>verifier</a>'s liability or lack thereof if not
+specified by other means such as a <code>termsOfUse</code> policy.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -2924,10 +2924,7 @@ credential</a> to declare that the <a>subject</a> controls, or a <a>holder</a>
 has been designated to use, one or more particular confirmation methods and to
 bind the <a>claims</a> about the <a>subject</a> to one or more of these
 confirmation methods. In this way, an <a>issuer</a> explicitly gives guidance
-and enables a <a>verifier</a> to validate that the <a>holder</a> presenting the
-<a>verifiable credential</a> has proven control of one or more of these
-confirmation methods when the <a>claims</a> bound to the confirmation method
-are presented.
+around how a <a>verifier</a> can validate that the <a>holder</a> is bound to the <a>claims</a> presented in a <a>verifiable credential</a>.
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -3027,7 +3027,6 @@ the <a>verifiable presentation</a> with the verification material contained in
   "issuer": "https://example.edu/issuers/14",
   "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     <span class="highlight">"confirmationMethod": [{
       "type": "VerificationKeyConfirmation2023",
       "publicKeyJwk": {

--- a/index.html
+++ b/index.html
@@ -2986,8 +2986,8 @@ other <a>properties</a> in the <a>verifiable credential</a>, such as the
           <dd>
           <dd>
             <p>
-If present, the value of the <code>confirmationMethod</code> <a>property</a> is
-one or more confirmation methods. Each confirmation method is bound to one or more
+If present, the value of the <code>confidenceMethod</code> <a>property</a> is
+one or more confidence methods. Each confidence method is bound to one or more
 claims in the <a>verifiable credential</a>, and provides enough information for a
 <a>verifier</a> to confirm whether the <a>holder</a> generating a <a>verifiable
 presentation</a> can satisfy that confirmation method. It is required that the

--- a/index.html
+++ b/index.html
@@ -2996,7 +2996,7 @@ the <a>holder</a> can satisfy each <code>confirmationMethod</code> they include
 in the <a>claims</a> of the <a>verifiable credential</a>s they issue.
             </p>
             <p>
-Each confirmation method MUST specify its <code>type</code> (for example,
+Each confidence method MUST specify its <code>type</code> (for example,
 <code>DIDAuthWithSubjectIdConfirmation</code>) and MAY specify an
 <code>id</code>. The precise <a>properties</a> and semantics of each
 confirmation method are determined by the specific

--- a/index.html
+++ b/index.html
@@ -2970,11 +2970,11 @@ other <a>properties</a> in the <a>verifiable credential</a>, such as the
           <dd>
             <p>
 If present, the value of the <code>confirmationMethod</code> <a>property</a> is
-one or more confirmation methods, each providing enough information for a
-<a>verifier</a> to validate that the <a>holder</a> generating a <a>verifiable
-presentation</a> has proven control of a confirmation method bound to one or
-more <a>claims</a> in a <a>verifiable credential</a> in the
-<a>verifiable presentation</a>. It is required that the <a>issuer</a> verifies
+one or more confirmation methods. Each confirmation method is bound to one or more
+claims in the <a>verifiable credential</a>, and provides enough information for a
+<a>verifier</a> to confirm whether the <a>holder</a> generating a <a>verifiable
+presentation</a> can satisfy that confirmation method. It is required that the
+<a>issuer</a> verifies
 the <a>holder</a> can satisfy each <code>confirmationMethod</code> they include
 in the <a>claims</a> of the <a>verifiable credential</a>s they issue.
             </p>

--- a/index.html
+++ b/index.html
@@ -1418,7 +1418,7 @@ A valid evidence <a>type</a>. For example,<br>
 
             <tr>
               <td>
-<a href="#confirmation-method">confirmationMethod</a>&nbsp;object
+<a href="#confidence-method">confidenceMethod</a>&nbsp;object
               </td>
               <td>
 A valid confirmation method <a>type</a>. For example,<br>


### PR DESCRIPTION
Potentially fixes #789, #882 

This PR includes normative changes that define a new property `confirmationMethod` (aka holder binding):
- [x] Add confirmation method to Advanced Concepts Section
- [x] Add confirmation method to Types Section
- [x] Add confirmation method to Extension Points Section

Out-of-scope:
- Privacy and security considerations which requires a separate PR
- Validation section which requires a separate PR


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1054.html" title="Last updated on May 9, 2023, 6:33 PM UTC (05b4034)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1054/fe54b80...05b4034.html" title="Last updated on May 9, 2023, 6:33 PM UTC (05b4034)">Diff</a>