### PR TITLE
Add section describing use of media types 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3426,14 +3426,10 @@ model whether or not they use a [[!JSON-LD]] processor.
           Any media types associated with the core data model are listed in the section on
           <a href="#iana-considerations">IANA Considerations</a> for registration with IANA.
         </p>
-        <p>
-          When defining a media type for use with verifiable credentials — for instance, in a 
-          specification that defines a specific syntax — use of the term `verifiable` implies
-          the presence of a <a href="#proofs-signatures">proof</a> with the credential.  
-          This also applies when the term is abbreviated, as in other specifications, 
-          such as in the [[VC-JWT]] specification's use of `vc+ld+json`.
-          Use of media types identified as `verifiable` in this way MUST correspond to
-          the use of one or more proofs with the credential.
+        <p class="issue" data-number="1060">
+          Presence of the term "verifiable" (or a shortened version) in the media type may 
+          or may not imply a proof.  Original proposed language is tracked in the issue 
+          corresponding to this note.
         </p>
         <p>
           Use of the term `credential` in a media type related to a syntax of verifiable 

--- a/index.html
+++ b/index.html
@@ -3432,7 +3432,7 @@ model whether or not they use a [[!JSON-LD]] processor.
           the presence of a <a href="#proofs-signatures">proof</a> with the credential.  
           This also applies when the term is abbreviated, as in other specifications, 
           such as in the [[VC-JWT]] specification's use of `vc+ld+json`.
-          Use of media type identified as `verifiable` in this way MUST correspond with
+          Use of media types identified as `verifiable` in this way MUST correspond to
           the use of one or more proofs with the credential.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -3414,7 +3414,7 @@ model whether or not they use a [[!JSON-LD]] processor.
 
         <p>
           Media types as defined in [[RFC6838]] serve a useful purpose with verifiable 
-          credentials, especially in regards to identifcation of a particular syntax 
+          credentials, especially regarding identification of a particular syntax 
           that is in use with a verifiable credential.
         </p>
         <p>
@@ -3427,16 +3427,17 @@ model whether or not they use a [[!JSON-LD]] processor.
           <a href="#iana-considerations">IANA Considerations</a> for registration with IANA.
         </p>
         <p>
-          When defining a media type for use with verifiable credentials, for instance in a 
-          specification that defines a specific syntax, use of the term `verifiable` implies
+          When defining a media type for use with verifiable credentials — for instance, in a 
+          specification that defines a specific syntax — use of the term `verifiable` implies
           the presence of a <a href="#proofs-signatures">proof</a> with the credential.  
-          This is also the case if the term is abbreviated in accordance with other specs, such as in `vc+ld+json`. 
+          This also applies when the term is abbreviated, as in other specifications, 
+          such as in the [[VC-JWT]] specification's use of `vc+ld+json`.
           Use of media type identified as `verifiable` in this way MUST correspond with
           the use of one or more proofs with the credential.
         </p>
         <p>
           Use of the term `credential` in a media type related to a syntax of verifiable 
-          credentials without the corresponding use of `verifiable` as noted above does not 
+          credentials <i>without</i> the corresponding use of `verifiable` as described above <i>does not</i> 
           imply the presence of a proof with the <a href="#dfn-credential">credential</a>.
         </p>
         <p>
@@ -3444,7 +3445,7 @@ model whether or not they use a [[!JSON-LD]] processor.
           model: `application/credential+ld+json` and `application/verifiable+credential+ld+json`.
           Other specifications such as [[VC-JWT]] define additional media types as may be 
           required to allow for proper interpretation of the syntax of verifiable credentials 
-          encoded in the respective syntax described by the specification.
+          encoded in the syntax described by the respective specification.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -3431,8 +3431,8 @@ model whether or not they use a [[!JSON-LD]] processor.
           specification that defines a specific syntax, use of the term `verifiable` implies
           the presence of a <a href="#proofs-signatures">proof</a> with the credential.  
           This is also the case if the term is abbreviated in accordance with other specs, such as in `vc+ld+json`. 
-          Use of media type identified as `verifiable` in this way MUST correspond with use 
-          of one or more proofs with the credential.
+          Use of media type identified as `verifiable` in this way MUST correspond with
+          the use of one or more proofs with the credential.
         </p>
         <p>
           Use of the term `credential` in a media type related to a syntax of verifiable 

--- a/index.html
+++ b/index.html
@@ -3443,7 +3443,7 @@ model whether or not they use a [[!JSON-LD]] processor.
           At the time of this writing, there are two media types associated with the core data 
           model: `application/credential+ld+json` and `application/verifiable+credential+ld+json`.
           Other specifications such as [[VC-JWT]] define additional media types as may be 
-          required to allow for proper interpertation of the syntax of verifiable credentials 
+          required to allow for proper interpretation of the syntax of verifiable credentials 
           encoded in the respective syntax described by the specification.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -3430,7 +3430,7 @@ model whether or not they use a [[!JSON-LD]] processor.
           When defining a media type for use with verifiable credentials, for instance in a 
           specification that defines a specific syntax, use of the term `verifiable` implies
           the presence of a <a href="#proofs-signatures">proof</a> with the credential.  
-          This is also the case if the term is abbreviated, such as in `vc+ld+json`. 
+          This is also the case if the term is abbreviated in accordance with other specs, such as in `vc+ld+json`. 
           Use of media type identified as `verifiable` in this way MUST correspond with use 
           of one or more proofs with the credential.
         </p>

--- a/index.html
+++ b/index.html
@@ -3419,7 +3419,7 @@ model whether or not they use a [[!JSON-LD]] processor.
         </p>
         <p>
           Syntaxes SHOULD be identified by a media type, and certain conventions as 
-          outlined in this section should be followed when defining or using media types 
+          outlined in this section SHOULD be followed when defining or using media types 
           with verifiable credentials.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -3409,6 +3409,44 @@ model whether or not they use a [[!JSON-LD]] processor.
         </section>
 
       </section>
+      <section>
+        <h3>Media Types</h3>
+
+        <p>
+          Media types as defined in [[RFC6838]] serve a useful purpose with verifiable 
+          credentials, especially in regards to identifcation of a particular syntax 
+          that is in use with a verifiable credential.
+        </p>
+        <p>
+          Syntaxes SHOULD be identified by a media type, and certain conventions as 
+          outlined in this section should be followed when defining or using media types 
+          with verifiable credentials.
+        </p>
+        <p>
+          Any media types associated with the core data model are listed in the section on
+          <a href="#iana-considerations">IANA Considerations</a> for registration with IANA.
+        </p>
+        <p>
+          When defining a media type for use with verifiable credentials, for instance in a 
+          specification that defines a specific syntax, use of the term `verifiable` implies
+          the presence of a <a href="#proofs-signatures">proof</a> with the credential.  
+          This is also the case if the term is abbreviated, such as in `vc+ld+json`. 
+          Use of media type identified as `verifiable` in this way MUST correspond with use 
+          of one or more proofs with the credential.
+        </p>
+        <p>
+          Use of the term `credential` in a media type related to a syntax of verifiable 
+          credentials without the corresponding use of `verifiable` as noted above does not 
+          imply the presence of a proof with the <a href="#dfn-credential">credential</a>.
+        </p>
+        <p>
+          At the time of this writing, there are two media types associated with the core data 
+          model: `application/credential+ld+json` and `application/verifiable+credential+ld+json`.
+          Other specifications such as [[VC-JWT]] define additional media types as may be 
+          required to allow for proper interpertation of the syntax of verifiable credentials 
+          encoded in the respective syntax described by the specification.
+        </p>
+      </section>
 
       <section>
         <h3>Proof Formats</h3>


### PR DESCRIPTION
This is intended to be a work in progress PR to help achieve consensus on the right location for describing requirements and best practices around use of media types with VCs.  I believe that this PR should form a basis to close without merging #1014 as the normative language in that PR is probably in the wrong section and does not have consensus.  This PR also may provide guidance around how to proceed with #1034


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mesur-io/vc-data-model/pull/1055.html" title="Last updated on Mar 7, 2023, 2:18 PM UTC (fee2e8c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1055/ab0345e...mesur-io:fee2e8c.html" title="Last updated on Mar 7, 2023, 2:18 PM UTC (fee2e8c)">Diff</a>