### PR TITLE
Editorial break out of definitions for clarity

### DIFF
--- a/terms.html
+++ b/terms.html
@@ -9,11 +9,7 @@ An assertion made about a <a>subject</a>.
   </dd>
   <dt><dfn data-lt="credential|credentials">credential</dfn></dt>
   <dd>
-A set of one or more <a>claims</a> made by an <a>issuer</a>. A
-<dfn data-lt="verifiable credentials">verifiable credential</dfn> is a
-tamper-evident credential that has authorship that can be cryptographically
-verified. Verifiable credentials can be used to build
-<a>verifiable presentations</a>, which can also be cryptographically verified.
+A set of one or more <a>claims</a> made by an <a>issuer</a>. 
 The <a>claims</a> in a credential can be about different <a>subjects</a>.
   </dd>
   <dt><dfn>data minimization</dfn></dt>
@@ -102,17 +98,11 @@ more <a>subjects</a>, creating a <a>verifiable credential</a> from these
 <a>claims</a>, and transmitting the <a>verifiable credential</a> to a
 <a>holder</a>.
   </dd>
-  <dt><dfn data-lt="presentations">presentation</dfn></dt>
+  <dt><dfn data-lt="presentation|presentations">presentation</dfn></dt>
   <dd>
 Data derived from one or more <a>verifiable credentials</a>, issued by one or
-more <a>issuers</a>, that is shared with a specific <a>verifier</a>. A
-<dfn data-lt="verifiable presentations">verifiable presentation</dfn>
-is a tamper-evident presentation encoded in such a way that authorship of the
-data can be trusted after a process of cryptographic verification. Certain
-types of verifiable presentations might contain data that is synthesized from,
-but do not contain, the original <a>verifiable credentials</a> (for example,
-zero-knowledge proofs).
-  </dd>
+more <a>issuers</a>, that is shared with a specific <a>verifier</a>.
+  </dd>  
   <dt><dfn data-lt="credential repository|credential repositories|repositories">repository</dfn></dt>
   <dd>
 A program, such as a storage vault or personal <a>verifiable credential</a>
@@ -142,6 +132,12 @@ dependent stakeholders. This specification is constrained to <a>verifying</a>
 their usage. Validating <a>verifiable credentials</a> or
 <a>verifiable presentations</a> is outside the scope of this specification.
   </dd>
+  <dt><dfn data-lt="verifiable credential|verifiable credentials|vc|vcs">verifiable credential</dfn></dt>
+  <dd>
+A verifiable credential is a tamper-evident credential that has authorship that 
+can be cryptographically verified. Verifiable credentials can be used to build
+<a>verifiable presentations</a>, which can also be cryptographically verified.
+  </dd>
   <dt><dfn data-lt="verifiable data registries">verifiable data registry</dfn></dt>
   <dd>
 A role a system might perform by mediating the creation and <a>verification</a>
@@ -151,6 +147,14 @@ and so on, which might be required to use <a>verifiable credentials</a>. Some
 configurations might require correlatable identifiers for <a>subjects</a>. Some
 registries, such as ones for UUIDs and public keys, might just act as namespaces
 for identifiers.
+  </dd>
+  <dt><dfn data-lt="verifiable presentation|verifiable presentations|vp|vps">verifiable presentation</dfn></dt>
+  <dd>
+A verifiable presentation is a tamper-evident presentation encoded in such a way 
+that authorship of the data can be trusted after a process of cryptographic 
+verification. Certain types of verifiable presentations might contain data that 
+is synthesized from, but do not contain, the original <a>verifiable credentials</a> 
+(for example, zero-knowledge proofs).
   </dd>
   <dt><dfn data-lt="verify|verified|verifying|verifiable|verifiability">verification</dfn></dt>
   <dd>


### PR DESCRIPTION
the definition of verifiable credential and verifiable presentation were both embedded in other definitions.  this PR simply moves those definitions to top level terminology 