### PR TITLE
Adding the "Credential" class

### DIFF
--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -33,6 +33,11 @@ class:
     label: Refresh service
     comment: A Refresh Service is a mechanism that can be utilized by software agents to retrieve an updated copy of a Verifiable Credential.
 
+  - id: Credential
+    label: Credential
+    comment: |
+      A Credential is a set of one or more claims made by an issuer.
+
   - id: CredentialSchema
     label: Credential schema
     comment: A Credential Schema provides verifiers with enough information to determine if the provided data conforms to the provided schema.
@@ -45,48 +50,48 @@ class:
     label: Credential evidence
     comment: A Credential Evidence scheme provides enough information to a verifier to determine whether the evidence gathered meets their requirements for issuing a credential. The precise content of each evidence scheme is determined by the specific evidence type definition.
 
+  - id: CredentialGraph
+    label: (Verifiable) credential graph
+    comment: Instances of this class are RDF Graphs, where each of these graphs must include exactly one <a href="#Credential">Credential</a> (usually a <a href="#VerifiableCredential">Verifiable Credential</a>).
+
   - id: VerifiableCredential
     label: Verifiable credential
     comment: |
-      A Credential is a set of one or more claims made by an issuer. A Verifiable Credential is a tamper-evident credential that has authorship that can be cryptographically verified. Verifiable Credentials can be used to build Verifiable Presentations, which can also be cryptographically verified.
-
-  - id: VerifiableCredentialGraph
-    label: Verifiable credential graph
-    comment: Instances of this class are RDF Graphs, where each of these graphs must include exactly one Verifiable Credential
+      A Verifiable Credential is a <a href="#Credential">Credential</a> that is tamper-evident and has authorship that can be cryptographically verified. Verifiable Credentials can be used to build Verifiable Presentations, which can also be cryptographically verified.
 
   - id: VerifiablePresentation
     label: Verifiable presentation
     comment: |
-      A Presentation is data derived from one or more Credentials, issued by one or more `issuers`, that is shared with a specific `verifier`. A Verifiable Presentation is a tamper-evident Presentation encoded in such a way that authorship of the data can be trusted after a process of cryptographic verification. Certain types of verifiable presentations might contain data that is synthesized from, but do not contain, the original verifiable credentials (for example, zero-knowledge proofs).
+      A Presentation is data derived from one or more <a href="#Credential">Credentials</a> (usually, but not necessarily, <a href="#VerifiableCredential">Verifiable Credentials</a>), issued by one or more `issuers`, that is shared with a specific `verifier`. A Verifiable Presentation is a tamper-evident Presentation encoded in such a way that authorship of the data can be trusted after a process of cryptographic verification. Certain types of verifiable presentations might contain data that is synthesized from, but do not contain, the original verifiable credentials (for example, zero-knowledge proofs).
 
 property:
   - id: credentialSchema
     label: Credential schema
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: cred:CredentialSchema
     comment: The value of the `credentialSchema` property MUST be one or more <a href="#CredentialSchema">Credential schema</a> instances.
 
   - id: credentialStatus
     label: Credential status
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: cred:CredentialStatus
     comment: The value of the `credentialStatus` property MUST be an instance of a <a href="#CredentialStatus">Credential status</a>.
 
   - id: credentialSubject
     label: Credential subject
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: IRI
     comment: An entity about which claims are made.
 
   - id: evidence
     label: Evidence
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: cred:CredentialEvidence
     comment: The value of the `evidence` property MUST be one or more <a href="#CredentialEvidence">Credential evidence</a> instances.
 
   - id: expirationDate
     label: Expiration date
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: xsd:dateTime
     deprecated: true
     comment: The value of the `expirationDate` property was used to express the date and time the credential ceases to be valid. It has been deprecated in favor of <a href="#validUntil">`validUntil`</a>
@@ -94,7 +99,7 @@ property:
   - id: holder
     label: Holder
     domain:
-      - cred:VerifiableCredential
+      - cred:Credential
       - cred:VerifiablePresentation
     range : IRI
     comment: |
@@ -110,21 +115,21 @@ property:
 
   - id: issued
     label: issue date
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: xsd:dateTime
     comment: |
       The value of the `issued` property MUST be a string value of an ISO8601 combined date and time string representing the date and time the credential was issued. Note that this date represents the earliest date when the information associated with the <a href="#credentialSubject>`credentialSubject`</a> property became valid.
 
   - id: issuer
     label: issuer
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: IRI
     comment: |
       The value of the `issuer` property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the issuer that can be used to verify the information expressed in the credential.
 
   - id: refreshService
     label: refresh service
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: cred:RefreshService
     comment: The value of the `refreshService` property MUST be one or more Refresh Service instances such that the holder can refresh the credential.
 
@@ -136,26 +141,26 @@ property:
 
   - id: termsOfUse
     label: terms of use
-    domain: cred:VerifiableCredential,cred:VerifiablePresentation
+    domain: cred:Credential,cred:VerifiablePresentation
     range: odrl:Policy
     comment: |
       If specified, the value of the optional `termsOfUse` property MUST specify one or more terms of use policies under which the issuer issued the credential or presentation. Each `termsOfUse` policy MUST specify its type (for example, `IssuerPolicy`) and MAY specify its instance `id`. The precise content of each term of use is determined by the specific `TermsOfUse` type definition. If the recipient (a holder or verifier) violates the specified terms of use, the responsibility is their own, and such violation may incur legal liability.
 
   - id: validFrom
     label: Valid from
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: xsd:dateTime
     comment: |
       The value of the `validFrom` property MUST be a string value of an ISO8601 combined date and time string representing the date and time the credential was issued. Note that this date represents the earliest date when the information associated with the <a href="#credentialSubject>`credentialSubject`</a> property became valid.
 
   - id: validUntil
     label: Valid until
-    domain: cred:VerifiableCredential
+    domain: cred:Credential
     range: xsd:dateTime
     comment: The value of the `validUntil` property MUST be a string value of an ISO8601 combined date and time string representing the date and time the credential ceases to be valid.
 
   - id: verifiableCredential
     label: verifiable credential
     domain: cred:VerifiablePresentation
-    range: cred:VerifiableCredentialGraph
-    comment: The value of the `verifiableCredential` property MUST identify a <a href="#VerifiableCredentialGraph">Verifiable credential graph</a> (informally, it indirectly identifies a <a href="#VerifiableCredential">Verifiable credential</a> contained in a separate graph).
+    range: cred:CredentialGraph
+    comment: The value of the `verifiableCredential` property MUST identify a <a href="#CredentialGraph">(Verifiable) credential graph</a> (informally, it indirectly identifies a <a href="#Credential">Credential</a> contained in a separate graph).


### PR DESCRIPTION
To make the discussion in #1044 more focussed this PR represents what is proposed in that issue. Some notes are worth adding:

- There is an ambiguity on the term "VerifiablePresentation" insofar as the "Verifiable" adjective is in the name, but we did not discuss whether we want a separation of a `Presentation` vs. `VerifiablePresentation`. I propose in the PR not to go that far, although I changed the description text just a little bit to allow for, e.g., a Presentation that present only credentials.

- The PR does ***not*** propose any change on the `@context` file, which is a completely different animal altogether. This is on the vocabulary and the vocabulary only; it only does things (in my view) cleaner.

- The [`proof` property](https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html#proof) does _not_ appear in the PR, because it is not part of the vcdm vocabulary. Note also that the creators of the `proof` property do ***not*** define a domain for that property, which can of course be used on a `Credential` class instance, but can also be used on an instance of any other class in the universe. It is a different discussion to have whether we should restrict the domain of that property to credentials.

    Even if introduced a domain restriction for `proof` to be `VerifiableCredential` it is very important to understand what this means. It does ***not*** mean any type of constraints on an instance. An RDFS domain statement (as any other RDFS/OWL statement) is a _license to infer_. It means for a reasoner that "I see this instance of a Credential has a `proof` property on it, therefore I deduce this is (also) a Verifiable Credential". This is very different from a statement of the sort "I see this instance of a Credential has a `proof` property on it, but this is not marked to be a Verifiable Credential, therefore there is a violation". Expressing that second statement in an ontology, though possible, is very complicated and very few OWL reasoners can handle it (if any). 

Practicality: the PR only shows the changes in the YML file. To see the generated HTML and other files, see: 

- [HTML](https://labs.w3.org/spec-generator/?type=respec&url=https://raw.githack.com/w3c/yml2vocab/Setting-up-preview/previews/vcdm/vocabulary.html)
- [JSON-LD](https://raw.githubusercontent.com/w3c/yml2vocab/Setting-up-preview/previews/vcdm/vocabulary.jsonld)
- [TTL](https://raw.githubusercontent.com/w3c/yml2vocab/Setting-up-preview/previews/vcdm/vocabulary.ttl)

