### PR TITLE
Remove broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,8 +914,7 @@ discount from a university. In the example below, Pat receives an alumni
   <span class='comment'>// set the context, which establishes the special terms we will be using
   // such as 'issuer' and 'alumniOf'.</span>
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   <span class='comment'>// specify the identifier for the credential</span>
   "id": "http://example.edu/credentials/1872",
@@ -976,8 +975,7 @@ the <a>verifier</a> and <a>verified</a>.
         <pre class="example nohighlight" title="A simple example of a verifiable presentation">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "type": "VerifiablePresentation",
   <span class='comment'>// the verifiable credential issued in the previous example</span>
@@ -1114,8 +1112,7 @@ processors that support JSON-LD can process the <code>@context</code>
         <pre class="example nohighlight" title="Usage of the @context property">
 {
   <span class="highlight">"@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ]</span>,
   "id": "http://example.edu/credentials/58473",
   "type": ["VerifiableCredential", "AlumniCredential"],
@@ -1221,8 +1218,7 @@ about the <code>id</code>.
           data-vc-vm="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   <span class="highlight">"id": "http://example.edu/credentials/3732"</span>,
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1299,8 +1295,7 @@ in a document containing machine-readable information about the
           data-vc-vm="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   <span class="highlight">"type": ["VerifiableCredential", "UniversityDegreeCredential"]</span>,
@@ -1516,8 +1511,7 @@ a set of objects that MUST contain one or more claims that are each related to a
           data-vc-vm="https://example.edu/issuers/565049#key-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1544,8 +1538,7 @@ who are spouses. Note the use of array notation to associate multiple
           title="Specifying multiple subjects in a verifiable credential">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "RelationshipCredential"],
@@ -1593,8 +1586,7 @@ machine-readable information about the <a>issuer</a> that can be used to
           data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1620,8 +1612,7 @@ associating an object with the issuer property:
           data-vc-vm="did:example:76e12ec712ebc6f1c221ebfeb1f#key-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1686,8 +1677,7 @@ at which the information associated with the <code>credentialSubject</code>
           data-vc-vm="https://example.edu/issuers/14#key-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1754,8 +1744,7 @@ the signing date. The example below uses Ed25519 digital signatures.
           title="Usage of the proof property on a verifiable credential">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1836,8 +1825,7 @@ suspended or revoked.
           title="Usage of the status property">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1926,8 +1914,7 @@ The example below shows a <a>verifiable presentation</a> that embeds
         <pre class="example nohighlight" title="Basic structure of a presentation">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
@@ -2264,8 +2251,7 @@ Let us assume we start with the <a>verifiable credential</a> shown below.
           data-vc-vm="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.com/credentials/4643",
   "type": ["VerifiableCredential"],
@@ -2318,7 +2304,6 @@ example by including the context and adding the new <a>properties</a> and
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2",
     <span class="highlight">"https://example.com/contexts/mycontext.jsonld"</span>
   ],
   "id": "http://example.com/credentials/4643",
@@ -2484,8 +2469,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
           title="Usage of the credentialSchema property to perform JSON schema validation">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -2528,8 +2512,7 @@ see Section <a href="#zero-knowledge-proofs"></a>.
         <pre class="example nohighlight" title="Usage of the credentialSchema property to perform zero-knowledge validation">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -2616,8 +2599,7 @@ each refresh service is determined by the specific <code>refreshService</code>
           title="Usage of the refreshService property by an issuer">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -2695,8 +2677,7 @@ by the specific <code>termsOfUse</code> <a>type</a> definition.
           title="Usage of the termsOfUse property by an issuer">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -2734,7 +2715,6 @@ in an archive.
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2",
     {
         "@protected": true,
         "VerifiablePresentationTermsOfUseExtension": {
@@ -2855,8 +2835,7 @@ Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]] document.
           title="Usage of the evidence property">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -3000,8 +2979,7 @@ upon zero-knowledge proofs to selectively disclose attributes can be found in th
         <pre class="example nohighlight" title="A verifiable credential that supports CL Signatures">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   <span class="highlight">"credentialSchema": {
@@ -3067,8 +3045,7 @@ that the <a>holder</a> did not intend to share.
         <pre class="example nohighlight" title="A verifiable presentation that supports CL Signatures">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "type": "VerifiablePresentation",
   "verifiableCredential": [
@@ -3182,8 +3159,7 @@ can issue the <a>credential</a> shown below and present it to the
         <pre class="example nohighlight" title="A subject disputes a credential">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.com/credentials/123",
   "type": ["VerifiableCredential", "DisputeCredential"],
@@ -3809,8 +3785,7 @@ possible by not specifying the <a>subject</a> identifier, expressed using the
           data-vc-vm="https://example.edu/issuers/14#keys-1">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "id": "http://example.edu/credentials/temporary/28934792387492384",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],


### PR DESCRIPTION
Relies on issuer defined terms, which is the simplest way to define terms, and does not require the implementer to download several separate JSON-LD context files to make use of the examples in the spec.

- https://www.w3.org/ns/credentials/examples/v2 

^ this link is 404, and causes the examples in the spec to be invalid.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1066.html" title="Last updated on Mar 15, 2023, 5:18 PM UTC (cd4a854)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1066/e231ee3...cd4a854.html" title="Last updated on Mar 15, 2023, 5:18 PM UTC (cd4a854)">Diff</a>