### PR TITLE
Add 'render' hint property to v2 context

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -63,6 +63,11 @@
           "@id": "https://www.w3.org/2018/credentials#refreshService",
           "@type": "@id"
         },
+        "render": {
+          "@id": "https://www.w3.org/2018/credentials#render",
+          "@type": "@id",
+          "@container": "@graph"
+        }
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
           "@type": "@id"

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -65,8 +65,7 @@
         },
         "render": {
           "@id": "https://www.w3.org/2018/credentials#render",
-          "@type": "@id",
-          "@container": "@graph"
+          "@type": "@id"
         }
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",


### PR DESCRIPTION
This standalone PR adds the `render` hint property to the VC 2.0 `@context`. (Note: this separate from PR #1035).

The `render` hint allows for linking to, or embedding, issuer display preferences / hints in a flexible manner (see the [Rendering Verifiable Credentials](https://github.com/WebOfTrustInfo/rwot11-the-hague/blob/master/draft-documents/rendering-vcs-snapshot-9-27-22.md) paper from RWOT 11 for more info and examples).

The intention is to add examples of `render` usage to the VC Spec directory.