### PR TITLE
Rephrase confusing `externally linked content`

### DIFF
--- a/index.html
+++ b/index.html
@@ -4902,8 +4902,8 @@ critical to the security of the credential through the use of permanently cached
 files and/or cryptographic hashes. See the <a
 data-cite="vc-imp-guide/#content-integrity">Content Integrity</a>
 section of the Verifiable Credential Implementation Guide for further
-information. Ultimately, knowing the cryptographic digest of any externally
-linked content enables a <a>verifier</a> to confirm that the content is the same
+information. Ultimately, knowing the cryptographic digest of any linked external
+content enables a <a>verifier</a> to confirm that the content is the same
 as what the <a>issuer</a> or <a>holder</a> intended.
           </p>
           <p>


### PR DESCRIPTION
I think `externally linked content` is likely to be confusing to some (possibly many), as it can easily be read as "[local] content linked by/from external documents". I suggest `linked external content`.