### PR TITLE
Change the domain statement of "holder"

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -33,10 +33,6 @@
           "@id": "https://www.w3.org/2018/credentials#evidence",
           "@type": "@id"
         },
-        "holder": {
-          "@id": "https://www.w3.org/2018/credentials#holder",
-          "@type": "@id"
-        },
         "validFrom": {
           "@id": "https://www.w3.org/2018/credentials#validFrom",
           "@type": "http://www.w3.org/2001/XMLSchema#dateTime"

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -93,9 +93,7 @@ property:
 
   - id: holder
     label: Holder
-    domain:
-      - cred:VerifiableCredential
-      - cred:VerifiablePresentation
+    domain: cred:VerifiablePresentation
     range : IRI
     comment: |
       The value of the `holder` property MUST be a URI. It is RECOMMENDED that dereferencing the URI results in a document containing machine-readable information about the holder that can be used to verify the information expressed in the credential.


### PR DESCRIPTION
Remove the VerifiableCredential from the possible domains of holder. This is the "execution" of https://github.com/w3c/vc-data-model/pull/1076#issuecomment-1496223830.

Beware! This is a PR against the OR13-remove-holder-from-vc PR, not against the main branch!