### PR TITLE
Add table of reserved properties

### DIFF
--- a/common.js
+++ b/common.js
@@ -139,7 +139,7 @@ var vcwg = {
       status: 'ED',
       publisher: 'W3C Verifiable Credentials Working Group'
     },
-    'VC-SPECS-DIR': {
+    'VC-SPECS': {
       title: 'Verifiable Credentials Specifications Directory',
       href: 'https://w3c.github.io/vc-specs-dir/',
       authors: ['Manu Sporny'],

--- a/common.js
+++ b/common.js
@@ -138,6 +138,13 @@ var vcwg = {
       authors: ['Orie Steele', 'Michael Jones'],
       status: 'ED',
       publisher: 'W3C Verifiable Credentials Working Group'
+    },
+    'VC-SPECS-DIR': {
+      title: 'Verifiable Credentials Specifications Directory',
+      href: 'https://w3c.github.io/vc-specs-dir/',
+      authors: ['Manu Sporny'],
+      status: 'ED',
+      publisher: 'W3C Verifiable Credentials Working Group'
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -3270,6 +3270,13 @@ Implementers SHOULD NOT use these properties without a publicly disclosed
 specification describing their implementation.
         </p>
 
+        <p>
+In order to avoid collisions regarding how the following properties are used,
+implementations MUST specify a `type` property in the value associated with the
+reserved property. For more information related to adding `type` information,
+see Section <a href="#types"></a>.
+        </p>
+
         <p class="issue" title="Reserved properties under debate">
 The following extension point properties are under consideration for being
 marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,

--- a/index.html
+++ b/index.html
@@ -3255,9 +3255,9 @@ on top of this specification.
         <h3>Reserved Extension Points</h3>
 
         <p>
-This specification reserves a number of extension point <a>properties</a> that
-implementers signalled interest in, where their inclusion in this specification
-was considered to be premature, and where these extension points might be more
+This specification reserves a number of <a>properties</a> serving as possible extension points. While
+some implementers signaled interest in these, their inclusion in this specification
+was considered to be premature; these extension points might be more
 formally defined in future versions of this specification. While these extension
 points are reserved in the base context, their usage is undefined by this
 specification and implementers are cautioned that usage of these properties is

--- a/index.html
+++ b/index.html
@@ -3252,22 +3252,22 @@ on top of this specification.
       </section>
 
       <section class="informative">
-        <h3>Reserved Properties</h3>
+        <h3>Reserved Extension Points</h3>
 
         <p>
-This specification reserves a number of <a>properties</a> that implementers
-signalled interest in, where their inclusion in this specification was
-considered to be premature, and where these properties might be more formally
-defined in future versions of this specification. While these properties are
-reserved in the base context, their usage is undefined by this specification
-and implementers are cautioned that usage of these properties is considered
-experimental.
+This specification reserves a number of extension point <a>properties</a> that
+implementers signalled interest in, where their inclusion in this specification
+was considered to be premature, and where these extension points might be more
+formally defined in future versions of this specification. While these extension
+points are reserved in the base context, their usage is undefined by this
+specification and implementers are cautioned that usage of these properties is
+considered experimental.
         </p>
 
         <p class="issue" title="Reserved properties under debate">
-The following properties are under consideration for being marked as
-reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`, `evidence`,
-`render`, and `confirmationMethod`.
+The following extension point properties are under consideration for being
+marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,
+`evidence`, `render`, and `confirmationMethod`.
         </p>
 
         <table class="simple">
@@ -3291,8 +3291,15 @@ An example entry for a reserved property.
           </tbody>
         </table>
 
+        <p>
+A list of specifications that utilize the extension points defined in this
+specification, as well as the reserved extension points listed above, can
+be found in the Verifiable Credentials Specifications Directory
+[[VC-SPECS-DIR]].
+        </p>
+
+      </section>
     </section>
-  </section>
 
     <section>
       <h2>Syntaxes</h2>

--- a/index.html
+++ b/index.html
@@ -3251,19 +3251,21 @@ on top of this specification.
         </p>
       </section>
 
-      <section class="informative">
+      <section class="normative">
         <h3>Reserved Extension Points</h3>
 
         <p>
 This specification reserves a number of <a>properties</a> serving as possible extension points. While
 some implementers signaled interest in these, their inclusion in this specification
 was considered to be premature; these extension points might be more
-formally defined in future versions of this specification. While these extension
-points are reserved in the base context, their usage is undefined by this
+formally defined in future versions of this specification. It is important to note that they are not defined by this
 specification and implementers are cautioned that usage of these properties is
 considered experimental.
         </p>
-
+Implementers MAY use these properties, but SHOULD expect these terms and/or
+their meanings to change during the process to normatively specify them.
+Implementers SHOULD NOT use these terms without a publicly disclosed
+specification describing their implementation.
         <p class="issue" title="Reserved properties under debate">
 The following extension point properties are under consideration for being
 marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,
@@ -3292,10 +3294,11 @@ An example entry for a reserved property.
         </table>
 
         <p>
-A list of specifications that utilize the extension points defined in this
-specification, as well as the reserved extension points listed above, can
-be found in the Verifiable Credentials Specifications Directory
-[[VC-SPECS-DIR]].
+A non-normative list of specifications that stem from the extension points defined
+in this specification, as well as the reserved extension points, can be found in
+the Verifiable Credentials Specifications Directory [[VC-SPECS-DIR]]. Items in
+the directory that refer to reserved extension points SHOULD be treated as
+experimental.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -3252,6 +3252,27 @@ on top of this specification.
       </section>
     </section>
 
+    <section class="informative">
+      <h3>Reserved Properties</h3>
+
+      <p>
+This specification reserves a number of <a>properties</a> that implementers
+signalled interest in, where their inclusion in this specification was
+considered to be premature, and where these properties might be more formally
+defined in future versions of this specification. While these properties are
+reserved in the base context, their usage is undefined by this specification
+and implementers are cautioned that usage of these properties is considered
+experimental.
+      </p>
+
+      <p class="issue" title="Reserved properties under debate">
+The following properties are under consideration for being marked as
+reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`, `evidence`,
+`render`, and `confirmationMethod`.
+      </p>
+    </section>
+  </section>
+
     <section>
       <h2>Syntaxes</h2>
 

--- a/index.html
+++ b/index.html
@@ -3267,7 +3267,7 @@ considered experimental.
         <p class="issue" title="Reserved properties under debate">
 The following extension point properties are under consideration for being
 marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,
-`evidence`, `render`, and `confirmationMethod`.
+`evidence`, `render`, `refreshService` and `confirmationMethod`.
         </p>
 
         <table class="simple">

--- a/index.html
+++ b/index.html
@@ -3255,17 +3255,21 @@ on top of this specification.
         <h3>Reserved Extension Points</h3>
 
         <p>
-This specification reserves a number of <a>properties</a> serving as possible extension points. While
-some implementers signaled interest in these, their inclusion in this specification
-was considered to be premature; these extension points might be more
-formally defined in future versions of this specification. It is important to note that they are not defined by this
-specification and implementers are cautioned that usage of these properties is
-considered experimental.
+This specification reserves a number of <a>properties</a> to serve as possible
+extension points. While some implementers signaled interest in these properties,
+their inclusion in this specification was considered to be premature; these
+extension points might be more formally defined in future versions of this
+specification. It is important to note that these properties are not defined by
+this specification and implementers are cautioned that usage of these properties
+is considered experimental.
         </p>
-Implementers MAY use these properties, but SHOULD expect these terms and/or
+        <p>
+Implementers MAY use these properties, but SHOULD expect them and/or
 their meanings to change during the process to normatively specify them.
-Implementers SHOULD NOT use these terms without a publicly disclosed
+Implementers SHOULD NOT use these properties without a publicly disclosed
 specification describing their implementation.
+        </p>
+
         <p class="issue" title="Reserved properties under debate">
 The following extension point properties are under consideration for being
 marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,
@@ -3294,11 +3298,11 @@ An example entry for a reserved property.
         </table>
 
         <p>
-A non-normative list of specifications that stem from the extension points defined
-in this specification, as well as the reserved extension points, can be found in
-the Verifiable Credentials Specifications Directory [[VC-SPECS-DIR]]. Items in
-the directory that refer to reserved extension points SHOULD be treated as
-experimental.
+An unofficial list of specifications that are associated with the extension
+points defined in this specification, as well as the reserved extension points
+defined in this section, can be found in the Verifiable Credentials
+Specifications Directory [[?VC-SPECS]]. Items in the directory that refer to
+reserved extension points SHOULD be treated as experimental.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -3280,7 +3280,8 @@ see Section <a href="#types"></a>.
         <p class="issue" title="Reserved properties under debate">
 The following extension point properties are under consideration for being
 marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,
-`evidence`, `render`, `refreshService` and `confirmationMethod`.
+`evidence`, `renderMethod`, `refreshService`, and
+`confirmationMethod/confidenceMethod`.
         </p>
 
         <table class="simple">

--- a/index.html
+++ b/index.html
@@ -3250,12 +3250,11 @@ this specification and is pursuing that work as an architectural layer built
 on top of this specification.
         </p>
       </section>
-    </section>
 
-    <section class="informative">
-      <h3>Reserved Properties</h3>
+      <section class="informative">
+        <h3>Reserved Properties</h3>
 
-      <p>
+        <p>
 This specification reserves a number of <a>properties</a> that implementers
 signalled interest in, where their inclusion in this specification was
 considered to be premature, and where these properties might be more formally
@@ -3263,13 +3262,35 @@ defined in future versions of this specification. While these properties are
 reserved in the base context, their usage is undefined by this specification
 and implementers are cautioned that usage of these properties is considered
 experimental.
-      </p>
+        </p>
 
-      <p class="issue" title="Reserved properties under debate">
+        <p class="issue" title="Reserved properties under debate">
 The following properties are under consideration for being marked as
 reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`, `evidence`,
 `render`, and `confirmationMethod`.
-      </p>
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>Reserved&nbsp;Property</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <tr>
+              <td>
+`example`
+              </td>
+              <td>
+An example entry for a reserved property.
+              </td>
+            </tr>
+
+          </tbody>
+        </table>
+
     </section>
   </section>
 


### PR DESCRIPTION
This PR attempts to address PRs #987, #1035, #1054, #1068, and other potential future PRs of a similar nature by establishing a table of reserved properties.

The group is currently struggling to achieve consensus around extension points, mostly due to workload, that some would argue as being good for subsets of the ecosystem. Similarly, the group is concerned around defending extension points that it has previously standardized, but for which there are not a minimum of two demonstrably interoperable implementations.

In an effort to provide these extension points, but without needing to standardize implementations for each extension point, the current PR establishes a "table of reserved properties". The expectation is that each of these reserved properties would be listed in the [vc-specs-dir](https://w3c.github.io/vc-specs-dir/#property-extensions) as a potential extension point category, but without there being any normative guidance in the core specification regarding their usage (the guidance would be in the extension specifications). 

If an extension point becomes used over time and can demonstrate a minimum of two demonstrably interoperable implementations, then it would be considered for inclusion in the core specification. If an extension point ends up not being used, then the next WG can make a decision to remove the reserved property or keep it reserved for another implementation cycle.

If this PR is merged, then it's possible for PRs #987, #1035, #1054, and #1068 to be closed and be replaced by reserved property registrations for each property. The upsides being:

1. Reduced possibility of a failure to exit Candidate Recommendation phase.
2. Reduced chance of Formal Objections due to insufficient implementations of extension points.
3. Ability to establish a common extension point while providing more time for the market to sort out the details around the extension point.
4. A more clear process around when an extension point feature should be included in the core VCDM specification (an extension point needs two demonstrably interoperable implementations before normative guidance is added about the extension point).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1082.html" title="Last updated on Apr 22, 2023, 4:34 PM UTC (2d75b77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1082/4af7219...2d75b77.html" title="Last updated on Apr 22, 2023, 4:34 PM UTC (2d75b77)">Diff</a>