### PR TITLE
Update the credentialStatus example to a real world one.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1821,13 +1821,13 @@ type.
         </dl>
 
         <p>
-The precise contents of the <a>credential</a> status information is determined
+The precise content of the <a>credential</a> status information is determined
 by the specific <code>credentialStatus</code> <a>type</a> definition, and varies
 depending on factors such as whether it is simple to implement or if it is
 privacy-enhancing. It is expected that the value will provide enough information
 to determine the current status of the <a>credential</a> and that machine
-readable information needs to be retrievable from the URL. For example, the
-object could contain a link to an external document noting whether or not the
+readable information will be retrievable from the URL. For example, the
+object could contain a link to an external document which notes whether or not the
 <a>credential</a> is suspended or revoked.
         </p>
 
@@ -1850,7 +1850,7 @@ object could contain a link to an external document noting whether or not the
     }
   },
   <span class="highlight">"credentialStatus": {
-    "id": "https://example.edu/credentials/status/3#94567"
+    "id": "https://example.edu/credentials/status/3#94567",
     "type": "StatusList2021Entry",
     "statusPurpose": "revocation",
     "statusListIndex": "94567",

--- a/index.html
+++ b/index.html
@@ -1392,7 +1392,7 @@ A valid proof <a>type</a>. For example,<br>
               </td>
               <td>
 A valid <a>credential</a> status <a>type</a>. For example,<br>
-<code>"type": "CredentialStatusList2017"</code>
+<code>"type": "StatusList2021Entry"</code>
               </td>
             </tr>
 
@@ -1814,7 +1814,7 @@ dereferenced.
               </li>
               <li>
 <code>type</code> <a>property</a>, which expresses the <a>credential</a> status
-type (also referred to as the <a>credential</a> status method).
+type.
               </li>
             </ul>
           </dd>
@@ -1824,12 +1824,11 @@ type (also referred to as the <a>credential</a> status method).
 The precise contents of the <a>credential</a> status information is determined
 by the specific <code>credentialStatus</code> <a>type</a> definition, and varies
 depending on factors such as whether it is simple to implement or if it is
-privacy-enhancing.
-It is expected that the value will provide enough information to determine the
-current status of the <a>credential</a> and that machine readable information
-needs to be retrievable from the URL. For example, the object could contain a
-link to an external document noting whether or not the <a>credential</a> is
-suspended or revoked.
+privacy-enhancing. It is expected that the value will provide enough information
+to determine the current status of the <a>credential</a> and that machine
+readable information needs to be retrievable from the URL. For example, the
+object could contain a link to an external document noting whether or not the
+<a>credential</a> is suspended or revoked.
         </p>
 
         <pre class="example nohighlight"
@@ -1837,7 +1836,7 @@ suspended or revoked.
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://w3id.org/vc/status-list/2021/v1"
   ],
   "id": "http://example.edu/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
@@ -1851,8 +1850,11 @@ suspended or revoked.
     }
   },
   <span class="highlight">"credentialStatus": {
-    "id": "https://example.edu/status/24",
-    "type": "CredentialStatusList2017"
+    "id": "https://example.edu/credentials/status/3#94567"
+    "type": "StatusList2021Entry",
+    "statusPurpose": "revocation",
+    "statusListIndex": "94567",
+    "statusListCredential": "https://example.edu/credentials/status/3"
   }</span>
 }
         </pre>


### PR DESCRIPTION
This PR updates the credentialStatus example in the spec, which used to use a fictional credential status value, to use the standards-track specification that this group has adopted.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1085.html" title="Last updated on Apr 22, 2023, 3:35 PM UTC (8b80339)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1085/fdbf89e...8b80339.html" title="Last updated on Apr 22, 2023, 3:35 PM UTC (8b80339)">Diff</a>