### PR TITLE
Fix references to old and outdated specifications.

### DIFF
--- a/common.js
+++ b/common.js
@@ -14,14 +14,14 @@ var vcwg = {
       ],
       publisher: "University of California, Irvine."
     },
-    "VC-EXTENSION-REGISTRY": {
-      title: "Verifiable Credentials Extension Registry",
-      href: "https://w3c-ccg.github.io/vc-extension-registry/",
+    "VC-SPECS": {
+      title: "Verifiable Credential Specifications Directory",
+      href: "https://w3c.github.io/vc-specs-dir/",
       authors: [
         "Manu Sporny"
       ],
-      status: "CG-DRAFT",
-      publisher: "Credentials Community Group"
+      status: "ED",
+      publisher: "W3C Verifiable Credentials Working Group"
     },
     "STRING-META": {
       title: "Strings on the Web: Language and Direction Metadata",

--- a/index.html
+++ b/index.html
@@ -590,10 +590,10 @@ At the time of publication, Working Group members had implemented
 
         <ul>
           <li>
-JSON Web Tokens [[RFC7519]] secured using JSON Web Signatures [[RFC7515]]
+Securing Verifiable Credentials using JSON Web Tokens [[VC-JWT]].
           </li>
           <li>
-Data Integrity Proofs [[VC-DATA-INTEGRITY]]
+Securing Verifiable Credentials using Data Integrity Proofs [[VC-DATA-INTEGRITY]].
           </li>
           <li>
 Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
@@ -1036,10 +1036,8 @@ the <a>verifier</a> and <a>verified</a>.
 Implementers that are interested in understanding more about the
 <code>proof</code> mechanism used above can learn more in Section <a
 href="#proofs-signatures"></a> and by reading the following specifications:
-Data Integrity [[VC-DATA-INTEGRITY]], Linked Data Cryptographic Suites
-Registry [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded Payload Option
-[[RFC7797]]. A list of proof mechanisms is available in the Verifiable
-Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
+Data Integrity [[VC-DATA-INTEGRITY]] and the "Proofs" section of the Verifiable
+Credential Specifications Directory [[VC-SPECS]].
         </p>
       </section>
     </section>
@@ -1784,10 +1782,9 @@ As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
 single proof mechanism for use with <a>verifiable credentials</a>. For more
 information about the <code>proof</code> mechanism, see the following
-specifications: Data Integrity [[VC-DATA-INTEGRITY]], Linked Data Cryptographic
-Suites Registries [[?LDP-REGISTRY]], and JSON Web Signature (JWS) Unencoded
-Payload Option [[RFC7797]]. A list of proof mechanisms is available in the
-Verifiable Credentials Extension Registry [[VC-EXTENSION-REGISTRY]].
+specifications: Data Integrity [[VC-DATA-INTEGRITY]], Securing Verifiable
+Credentials using JSON Web Tokens [VC-JWT], and the "Proofs" section of
+the Verifiable Credential Specifications Directory [[VC-SPECS]].
         </p>
 
       </section>
@@ -1859,8 +1856,8 @@ suspended or revoked.
 
         <p>
 Defining the data model, formats, and protocols for status schemes are out of
-scope for this specification. A Verifiable Credential Extension Registry
-[[?VC-EXTENSION-REGISTRY]] exists that contains available status schemes
+scope for this specification. A Verifiable Credential Specifications Directory
+[[?VC-SPECS]] exists that contains available status schemes
 for implementers who want to implement <a>verifiable credential</a>
 status checking.
         </p>
@@ -2231,8 +2228,9 @@ use of [[?LINKED-DATA]].
           </li>
           <li>
 Support multiple types of cryptographic proof formats through the use of
-Data Integrity Proofs [[VC-DATA-INTEGRITY]] and a variety of signature suites
-listed in the Linked Data Cryptographic Suites Registry [[?LDP-REGISTRY]]
+Data Integrity Proofs [[VC-DATA-INTEGRITY]] and a variety of cryptographic
+suites listed in the Verifiable Credential Specifications Directory
+[[?VC-SPECS]].
           </li>
           <li>
 Provide all of the extensibility mechanisms outlined above in a data format that
@@ -2365,7 +2363,7 @@ specification, such as in Sections <a href="#proofs-signatures"></a>,
 <a href="#status"></a>, <a href="#data-schemas"></a>,<a href="#refreshing"></a>,
 <a href="#terms-of-use"></a>, and <a href="#evidence"></a>. While this
 specification does not define concrete implementations for those extension
-points, the Verifiable Credentials Extension Registry [[?VC-EXTENSION-REGISTRY]]
+points, the Verifiable Credential Specifications Directory [[?VC-SPECS]]
 provides an unofficial, curated list of extensions that developers can use from
 these extension points.
         </p>
@@ -2999,7 +2997,7 @@ credential</a> in a way that supports the privacy of the
 <a>holder</a> and <a>subject</a> through the use of selective disclosure of the
 <a>verifiable credential</a> values. Some other cryptographic systems which rely
 upon zero-knowledge proofs to selectively disclose attributes can be found in the
-[[?LDP-REGISTRY]] as well.
+Verifiable Credential Specifications Directory [[?VC-SPECS]] as well.
         </p>
 
         <pre class="example nohighlight" title="A verifiable credential that supports CL Signatures">
@@ -3482,7 +3480,7 @@ being actively utilized to issue <a>verifiable credentials</a> are:
 
         <ul>
           <li>
-Verifiable Credentials using JSON Web Tokens [[?VC-JWT]], and
+Verifiable Credentials using JSON Web Tokens [[VC-JWT]], and
           </li>
           <li>
 Verifiable Credential Data Integrity [[VC-DATA-INTEGRITY]].

--- a/index.html
+++ b/index.html
@@ -2228,7 +2228,7 @@ use of [[?LINKED-DATA]].
           </li>
           <li>
 Support multiple types of cryptographic proof formats through the use of
-Data Integrity Proofs [[VC-DATA-INTEGRITY]] and a variety of cryptographic
+JSON Web Tokens [[VC-JWT]] and Data Integrity Proofs [[VC-DATA-INTEGRITY]] and a variety of cryptographic
 suites listed in the Verifiable Credential Specifications Directory
 [[?VC-SPECS]].
           </li>


### PR DESCRIPTION
This PR fixes old and outdated references to external specifications.

I went back and forth on whether or not references to VC-JWT and VC-DATA-INTEGRITY should be normative or informative. The argument for normative is: we are providing normative guidance to implementers to use at least one of those mechanisms. The argument for informative is to not have those dependencies in the spec, but then the argument becomes "then how do you accomplish the 'Verifiable' part of the spec?" (folks that remember history will note that informative references worked against us during the v1.0 work, and will likely work against us this time since we are normatively defining those mechanisms).

My suggestion is that we keep these normative until it looks like it might bite us (like, when trying to go to PR or REC)... and then re-evaluate then.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1086.html" title="Last updated on Apr 22, 2023, 3:53 PM UTC (1013531)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1086/fdbf89e...1013531.html" title="Last updated on Apr 22, 2023, 3:53 PM UTC (1013531)">Diff</a>