### PR TITLE
Remove JSON section in lieu of `application/vc+ld+json`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3261,11 +3261,11 @@ The data model as described in Sections
 <a href="#advanced-concepts"></a> is the canonical structural representation of
 a <a>verifiable credential</a> or <a>verifiable presentation</a>. All
 serializations are representations of that data model in a specific format. This
-section specifies how the data model is realized in JSON-LD for the base
-media type (`application/vc+ld+json`).
-Although syntactic mappings are provided for JSON-LD,
+section specifies how the data model is realized in JSON-LD for
+`application/vc+ld+json`, the base media type for Verifiable Credentials.
+Although syntactic mappings are only provided for JSON-LD,
 applications and services can use any other data representation syntax (such as
-XML, YAML, or CBOR) that is capable of being mapped back to the base media type.
+XML, YAML, or CBOR) that is capable of being mapped back to `application/vc+ld+json`.
 As the <a>verification</a> and <a>validation</a> requirements are defined in terms
 of the data model, all serialization syntaxes have to be deterministically
 translated to the data model for processing, <a>validation</a>, or comparison.

--- a/index.html
+++ b/index.html
@@ -3261,15 +3261,14 @@ The data model as described in Sections
 <a href="#advanced-concepts"></a> is the canonical structural representation of
 a <a>verifiable credential</a> or <a>verifiable presentation</a>. All
 serializations are representations of that data model in a specific format. This
-section specifies how the data model is realized in JSON-LD and plain JSON.
-Although syntactic mappings are provided for only these two syntaxes,
+section specifies how the data model is realized in JSON-LD for the base
+media type (`application/vc+ld+json`).
+Although syntactic mappings are provided for JSON-LD,
 applications and services can use any other data representation syntax (such as
-XML, YAML, or CBOR) that is capable of expressing the data model. As the
-<a>verification</a> and <a>validation</a> requirements are defined in terms of
-the data model, all serialization syntaxes have to be deterministically
+XML, YAML, or CBOR) that is capable of being mapped back to the base media type.
+As the <a>verification</a> and <a>validation</a> requirements are defined in terms
+of the data model, all serialization syntaxes have to be deterministically
 translated to the data model for processing, <a>validation</a>, or comparison.
-This specification makes no requirements for support of any specific
-serialization format.
       </p>
 
       <p>
@@ -3299,47 +3298,6 @@ or an array of values.
       </p>
 
       <section>
-        <h3>JSON</h3>
-
-        <p>
-The data model, as described in Section <a href="#core-data-model"></a>, can be
-encoded in JavaScript Object Notation (JSON) [[!RFC8259]] by mapping property
-values to JSON types as follows:
-        </p>
-
-        <ul>
-          <li>
-Numeric values representable as IEEE754 SHOULD be represented as a Number type.
-          </li>
-          <li>
-Boolean values SHOULD be represented as a Boolean type.
-          </li>
-          <li>
-Sequence value SHOULD be represented as an Array type.
-          </li>
-          <li>
-Unordered sets of values SHOULD be represented as an Array type.
-          </li>
-          <li>
-Sets of <a>properties</a> SHOULD be represented as an Object type.
-          </li>
-          <li>
-Empty values SHOULD be represented as a null value.
-          </li>
-          <li>
-Other values MUST be represented as a String type.
-          </li>
-        </ul>
-
-        <p class="note">
-As the transformations listed herein have potentially incompatible
-interpretations, additional profiling of the JSON format is required to provide
-a deterministic transformation to the data model.
-        </p>
-
-      </section>
-
-      <section>
         <h3>JSON-LD</h3>
 
         <p>
@@ -3354,9 +3312,8 @@ storage engines.
 
         <p>
 [[!JSON-LD]] is useful when extending the data model described in this
-specification. Instances of the data model are encoded in [[!JSON-LD]] in the
-same way they are encoded in JSON (Section <a href="#json"></a>), with the
-addition of the <code>@context</code> <a>property</a>. The
+specification. Instances of the data model are encoded in [[!JSON-LD]]
+and include the <code>@context</code> <a>property</a>. The
 <a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD context</a>
 is described in detail in the [[!JSON-LD]] specification and its use is
 elaborated on in Section <a href="#extensibility"></a>.

--- a/index.html
+++ b/index.html
@@ -3312,8 +3312,8 @@ storage engines.
 
         <p>
 [[!JSON-LD]] is useful when extending the data model described in this
-specification. Instances of the data model are encoded in [[!JSON-LD]]
-and include the <code>@context</code> <a>property</a>. The
+specification. Instances of the data model are encoded in JSON-LD compact
+form [[!JSON-LD]] and include the <code>@context</code> <a>property</a>. The
 <a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD context</a>
 is described in detail in the [[!JSON-LD]] specification and its use is
 elaborated on in Section <a href="#extensibility"></a>.


### PR DESCRIPTION
Based on the resolution of the WG to use one base media type (`application/vc+ld+json`), this PR removes the old "JSON" section in the spec, which was always of very questionable value. The prose has been updated to specify that the base media type is `application/vc+ld+json`, and other syntaxes can be used as long as they can map to the base media type.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1088.html" title="Last updated on Apr 22, 2023, 4:30 PM UTC (3ef0175)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1088/5ae6a29...3ef0175.html" title="Last updated on Apr 22, 2023, 4:30 PM UTC (3ef0175)">Diff</a>