### PR TITLE
Clarify language around ZKP data format

### DIFF
--- a/index.html
+++ b/index.html
@@ -2552,10 +2552,9 @@ see Section <a href="#zero-knowledge-proofs"></a>.
 
         <p>
 In the example above, the <a>issuer</a> is specifying a
-<code>credentialSchema</code> pointing to a zero-knowledge packed binary data
-format that is capable of transforming the input data into a format, which can
-then be used by a <a>verifier</a> to determine if the proof provided with the
-<a>verifiable credential</a> is valid.
+<code>credentialSchema</code> that describes the method of transforming the
+input data, which can then be used by a <a>verifier</a> to determine if the
+proof provided with the <a>verifiable credential</a> is valid.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2440,7 +2440,7 @@ published schema.
           <li>
 Data encoding schemas, which are used to map the contents of a
 <a>verifiable credential</a> to an alternative representation format, such as a
-binary format used in a zero-knowledge proof.
+format used in a zero-knowledge proof.
           </li>
         </ul>
 
@@ -2519,9 +2519,9 @@ Implementation Guidelines [[VC-IMP-GUIDE]] document.
         </p>
 
         <p>
-Data schemas can also be used to specify mappings to other binary formats, such
-as those used to perform zero-knowledge proofs. For more information on using
-the <code>credentialSchema</code> <a>property</a> with zero-knowledge proofs,
+Data schemas can also be used to specify mappings to other formats, such as
+those used to perform zero-knowledge proofs. For more information on using the
+<code>credentialSchema</code> <a>property</a> with zero-knowledge proofs,
 see Section <a href="#zero-knowledge-proofs"></a>.
         </p>
 
@@ -2552,9 +2552,9 @@ see Section <a href="#zero-knowledge-proofs"></a>.
 
         <p>
 In the example above, the <a>issuer</a> is specifying a
-<code>credentialSchema</code> that describes the method of transforming the
-input data, which can then be used by a <a>verifier</a> to determine if the
-proof provided with the <a>verifiable credential</a> is valid.
+<code>credentialSchema</code> pointing to a means of transforming the input
+data into a format which can then be used by a <a>verifier</a> to determine if
+the proof provided with the <a>verifiable credential</a> is valid.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2543,7 +2543,7 @@ see Section <a href="#zero-knowledge-proofs"></a>.
     }
   },
   <span class="highlight">"credentialSchema": {
-    "id": "https://example.org/examples/degree.zkp",
+    "id": "https://example.org/examples/degree",
     "type": "ZkpExampleSchema2018"
   }</span>,
   "proof": { <span class="comment">...</span> }


### PR DESCRIPTION
Fixes #949 

This PR suggests some editorial changes to reduce confusion around some examples showing the use of `credentialSchema` with ZKPs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1096.html" title="Last updated on Apr 24, 2023, 6:15 PM UTC (e12db49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1096/42ceab2...brentzundel:e12db49.html" title="Last updated on Apr 24, 2023, 6:15 PM UTC (e12db49)">Diff</a>