### PR TITLE
Add first pass at reserved properties table

### DIFF
--- a/index.html
+++ b/index.html
@@ -3211,6 +3211,10 @@ see Section <a href="#types"></a>.
 A property used for specifying how a <a>verifier</a> can confirm, or
 gain more confidence in, the presentation of the credential being associated
 with a particular <a>subject</a>.
+
+                <p class="issue" title="Bikeshedding confirmation/confidence">
+The name of this property is currently being debated by the Working Group.
+                </p>
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -3204,17 +3204,47 @@ see Section <a href="#types"></a>.
               <th>Description</th>
             </tr>
           </thead>
-
           <tbody>
             <tr>
+              <td>`confirmationMethod` / `confidenceMethod`</td>
               <td>
-`example`
-              </td>
-              <td>
-An example entry for a reserved property.
+A property used for specifying how a <a>verifier</a> can confirm, or
+gain more confidence in, the presentation of the credential being associated
+with a particular <a>subject</a>.
               </td>
             </tr>
-
+            <tr>
+              <td>`evidence`</td>
+              <td>
+A property used for specifying the evidence that was presented in order to
+issue the credential.
+              </td>
+            </tr>
+            <tr>
+              <td>`presentationSchema`</td>
+              <td>
+A property used for specifying the schema for presentations.
+              </td>
+            </tr>
+            <tr>
+              <td>`renderMethod`</td>
+              <td>
+A property used for specifying how to render a credential into a visual,
+auditory, or haptic format.
+              </td>
+            </tr>
+            <tr>
+              <td>`refreshService`</td>
+              <td>
+A property used for specifying how a credential can be refreshed.
+              </td>
+            </tr>
+            <tr>
+              <td>`termsOfUse`</td>
+              <td>
+A property used for specifying the terms of use for a credential.
+              </td>
+            </tr>
           </tbody>
         </table>
 

--- a/index.html
+++ b/index.html
@@ -3209,22 +3209,23 @@ see Section <a href="#types"></a>.
               <td>`evidence`</td>
               <td>
 A property used for specifying the evidence that was presented in order to
-issue the credential.<br>
-Vocabulary URL: `https://www.w3.org/2018/credentials#evidence`
+issue the credential. The associated vocabulary URL MUST be
+`https://www.w3.org/2018/credentials#evidence`.
               </td>
             </tr>
             <tr>
               <td>`refreshService`</td>
               <td>
-A property used for specifying how a credential can be refreshed.<br>
-Vocabulary URL: `https://www.w3.org/2018/credentials#refreshService`
+A property used for specifying how a credential can be refreshed. The
+associated vocabulary URL MUST be
+`https://www.w3.org/2018/credentials#refreshService`.
               </td>
             </tr>
             <tr>
               <td>`termsOfUse`</td>
               <td>
-A property used for specifying the terms of use for a credential.<br>
-Vocabulary URL: `https://www.w3.org/2018/credentials#termsOfUse`
+A property used for specifying the terms of use for a credential. The associated
+vocabulary URL MUST be `https://www.w3.org/2018/credentials#termsOfUse`.
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -3206,47 +3206,25 @@ see Section <a href="#types"></a>.
           </thead>
           <tbody>
             <tr>
-              <td>`confirmationMethod` / `confidenceMethod`</td>
-              <td>
-A property used for specifying how a <a>verifier</a> can confirm, or
-gain more confidence in, the presentation of the credential being associated
-with a particular <a>subject</a>.
-
-                <p class="issue" title="Bikeshedding confirmation/confidence">
-The name of this property is currently being debated by the Working Group.
-                </p>
-              </td>
-            </tr>
-            <tr>
               <td>`evidence`</td>
               <td>
 A property used for specifying the evidence that was presented in order to
-issue the credential.
-              </td>
-            </tr>
-            <tr>
-              <td>`presentationSchema`</td>
-              <td>
-A property used for specifying the schema for presentations.
-              </td>
-            </tr>
-            <tr>
-              <td>`renderMethod`</td>
-              <td>
-A property used for specifying how to render a credential into a visual,
-auditory, or haptic format.
+issue the credential.<br>
+Vocabulary URL: `https://www.w3.org/2018/credentials#evidence`
               </td>
             </tr>
             <tr>
               <td>`refreshService`</td>
               <td>
-A property used for specifying how a credential can be refreshed.
+A property used for specifying how a credential can be refreshed.<br>
+Vocabulary URL: `https://www.w3.org/2018/credentials#refreshService`
               </td>
             </tr>
             <tr>
               <td>`termsOfUse`</td>
               <td>
-A property used for specifying the terms of use for a credential.
+A property used for specifying the terms of use for a credential.<br>
+Vocabulary URL: `https://www.w3.org/2018/credentials#termsOfUse`
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -3197,13 +3197,6 @@ reserved property. For more information related to adding `type` information,
 see Section <a href="#types"></a>.
         </p>
 
-        <p class="issue" title="Reserved properties under debate">
-The following extension point properties are under consideration for being
-marked as reserved: `presentationSchema`, `credentialRefresh`, `termsOfUse`,
-`evidence`, `renderMethod`, `refreshService`, and
-`confirmationMethod/confidenceMethod`.
-        </p>
-
         <table class="simple">
           <thead>
             <tr>


### PR DESCRIPTION
This adds a first pass at the reserved properties table (as suggested in PR https://github.com/w3c/vc-data-model/pull/1082/files#r1170186655 by @mprorock).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1097.html" title="Last updated on Apr 28, 2023, 3:35 PM UTC (dd7666c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1097/c964156...dd7666c.html" title="Last updated on Apr 28, 2023, 3:35 PM UTC (dd7666c)">Diff</a>