### PR TITLE
Clarify relationship bx securing mechanisms and media types

### DIFF
--- a/index.html
+++ b/index.html
@@ -3402,7 +3402,14 @@ There is one media type associated with the core data model:
 `application/vc+ld+json`. Other specifications, such as [[?VC-JWT]],
 define other media types that contain transformation rules that allow for
 those other syntaxes to be transformed to the `application/vc+ld+json`
-media type.
+media type. Media types that allow for transformation into
+`application/vc+ld+json` SHOULD begin with `application/vc+`.
+        </p>
+        <p>
+The media type `application/vc+ld+json` does not imply any particular securing
+mechanism. It describes an object that is securable. Other specifications
+defining media types that begin with `application/vc+` SHOULD NOT define those
+media types to imply any particular securing mechanism.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -3400,7 +3400,7 @@ media type.
         <p>
 The media type `application/vc+ld+json` does not imply any particular securing
 mechanism. It describes an object that is securable, but a securing mechanism
-needs to be applied to enable validation of integrity. This also applies to
+needs to be applied to enable verification of integrity. This also applies to
 media types that allow for transformation into `application/vc+ld+json`. Do not
 assume security of content regardless of the media type used to communicate it.
         </p>

--- a/index.html
+++ b/index.html
@@ -3390,13 +3390,6 @@ Working Group is seeking implementation experience related to the use of media
 types and the expectation related to whether or not a particular media type
 is expected to be secure with a particular proof.
         </p>
-        <p class="issue" data-number="1065">
-The VCWG is currently debating whether all media types that start with
-`application/vc+` indicate an expectation around the securing mechanism or not.
-Working Group is seeking implementation experience related to the use of media
-types and the expectation related to whether or not a particular media type
-is expected to be secure with a particular proof.
-        </p>
         <p>
 There is one media type associated with the core data model:
 `application/vc+ld+json`. Other specifications, such as [[?VC-JWT]],

--- a/index.html
+++ b/index.html
@@ -3395,14 +3395,14 @@ There is one media type associated with the core data model:
 `application/vc+ld+json`. Other specifications, such as [[?VC-JWT]],
 define other media types that contain transformation rules that allow for
 those other syntaxes to be transformed to the `application/vc+ld+json`
-media type. Media types that allow for transformation into
-`application/vc+ld+json` SHOULD begin with `application/vc+`.
+media type.
         </p>
         <p>
 The media type `application/vc+ld+json` does not imply any particular securing
-mechanism. It describes an object that is securable. Other specifications
-defining media types that begin with `application/vc+` SHOULD NOT define those
-media types to imply any particular securing mechanism.
+mechanism. It describes an object that is securable, but a securing mechanism
+needs to be applied to enable validation of integrity. This also applies to
+media types that allow for transformation into `application/vc+ld+json`. Do not
+assume security of content regardless of the media type used to communicate it.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -3399,10 +3399,11 @@ media type.
         </p>
         <p>
 The media type `application/vc+ld+json` does not imply any particular securing
-mechanism. It describes an object that is securable, but a securing mechanism
-needs to be applied to enable verification of integrity. This also applies to
-media types that allow for transformation into `application/vc+ld+json`. Do not
-assume security of content regardless of the media type used to communicate it.
+mechanism, but is intended to be used in conjunction with a securing mechanism.
+A securing mechanism needs to be applied to enable verification of integrity.
+This also applies to media types that allow for transformation into
+`application/vc+ld+json`. Do not assume security of content regardless of the
+media type used to communicate it.
         </p>
       </section>
 


### PR DESCRIPTION
This PR attempts to add some clarity around the relationship between securing mechanisms and media types.

It primarily uses language suggested in Issue #1065. 
It adds that media types defined that allow for transformation into application/vc+ld+json should begin with application/vc+
It states that application/vc+ld+json does not imply any securing mechanism
it states that other media types should not imply any securing mechanism
I removes the note about Issue #1065

fixes #1065


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1107.html" title="Last updated on May 4, 2023, 9:48 PM UTC (1e350e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1107/c964156...brentzundel:1e350e3.html" title="Last updated on May 4, 2023, 9:48 PM UTC (1e350e3)">Diff</a>