### PR TITLE
Add `renderMethod` as reserved extension point.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3255,13 +3255,34 @@ see Section <a href="#types"></a>.
               <th>Description</th>
             </tr>
           </thead>
+
           <tbody>
+            <tr>
+              <td>`confirmationMethod` / `confidenceMethod`</td>
+              <td>
+A property used for specifying how a <a>verifier</a> can confirm, or
+gain more confidence in, the presentation of the credential being associated
+with a particular <a>subject</a>. The associated vocabulary URL MUST be
+`https://www.w3.org/2018/credentials#confirmationMethodORconfidenceMethod`.
+
+                <p class="issue" title="Bikeshedding confirmation/confidence">
+The name of this property is currently being debated by the Working Group.
+                </p>
+              </td>
+            </tr>
             <tr>
               <td>`evidence`</td>
               <td>
 A property used for specifying the evidence that was presented in order to
 issue the credential. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#evidence`.
+              </td>
+            </tr>
+            <tr>
+              <td>`presentationSchema`</td>
+              <td>
+A property used for specifying the schema for presentations. The associated
+vocabulary URL MUST be `https://www.w3.org/2018/credentials#presentationSchema`.
               </td>
             </tr>
             <tr>
@@ -3273,14 +3294,24 @@ associated vocabulary URL MUST be
               </td>
             </tr>
             <tr>
+              <td>`renderMethod`</td>
+              <td>
+A property used for specifying how to render a credential into a visual,
+auditory, or haptic format. The associated vocabulary URL MUST be
+`https://www.w3.org/2018/credentials#renderMethod`.
+              </td>
+            </tr>
+            <tr>
               <td>`termsOfUse`</td>
               <td>
+An example entry for a reserved property.
 A property used for specifying the terms of use for a credential. The associated
 vocabulary URL MUST be `https://www.w3.org/2018/credentials#termsOfUse`.
               </td>
             </tr>
           </tbody>
         </table>
+
 
         <p>
 An unofficial list of specifications that are associated with the extension

--- a/index.html
+++ b/index.html
@@ -3252,7 +3252,7 @@ see Section <a href="#types"></a>.
 The following reserved properties are at risk and will be removed from the
 specification if at least one specification with two independent implementations
 are not demonstrated by the end of the Candidate Recommendation Phase:
-`confirmationMethod` / `confidenceMethod`, `presentationSchema`, and
+`confidenceMethod`, `presentationSchema`, and
 `renderMethod`.
         </p>
 
@@ -3266,16 +3266,13 @@ are not demonstrated by the end of the Candidate Recommendation Phase:
 
           <tbody>
             <tr>
-              <td>`confirmationMethod` / `confidenceMethod`</td>
+              <td>`confidenceMethod`</td>
               <td>
-A property used for specifying how a <a>verifier</a> can confirm, or
-gain more confidence in, the presentation of the credential being associated
-with a particular <a>subject</a>. The associated vocabulary URL MUST be
-`https://www.w3.org/2018/credentials#confirmationMethodORconfidenceMethod`.
+A property used for specifying how a <a>verifier</a> can gain more confidence
+in, the presentation of the credential being associated with a particular
+<a>subject</a>. The associated vocabulary URL MUST be
+`https://www.w3.org/2018/credentials#confidenceMethod`.
 
-                <p class="issue" title="Bikeshedding confirmation/confidence">
-The name of this property is currently being debated by the Working Group.
-                </p>
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -3312,7 +3312,6 @@ auditory, or haptic format. The associated vocabulary URL MUST be
             <tr>
               <td>`termsOfUse`</td>
               <td>
-An example entry for a reserved property.
 A property used for specifying the terms of use for a credential. The associated
 vocabulary URL MUST be `https://www.w3.org/2018/credentials#termsOfUse`.
               </td>

--- a/index.html
+++ b/index.html
@@ -3258,37 +3258,11 @@ see Section <a href="#types"></a>.
 
           <tbody>
             <tr>
-              <td>`confidenceMethod`</td>
-              <td>
-A property used for specifying how a <a>verifier</a> can gain more confidence
-in, the presentation of the credential being associated with a particular
-<a>subject</a>. The associated vocabulary URL MUST be
-`https://www.w3.org/2018/credentials#confidenceMethod`.
-                <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property is at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase.
-                </p>
-              </td>
-            </tr>
-            <tr>
               <td>`evidence`</td>
               <td>
 A property used for specifying the evidence that was presented in order to
 issue the credential. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#evidence`.
-              </td>
-            </tr>
-            <tr>
-              <td>`presentationSchema`</td>
-              <td>
-A property used for specifying the schema for presentations. The associated
-vocabulary URL MUST be `https://www.w3.org/2018/credentials#presentationSchema`.
-                <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property is at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase.
-                </p>
               </td>
             </tr>
             <tr>

--- a/index.html
+++ b/index.html
@@ -3248,6 +3248,14 @@ reserved property. For more information related to adding `type` information,
 see Section <a href="#types"></a>.
         </p>
 
+        <p class="issue" title="(AT RISK) Reserved properties">
+The following reserved properties are at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase:
+`confirmationMethod` / `confidenceMethod`, `presentationSchema`, and
+`renderMethod`.
+        </p>
+
         <table class="simple">
           <thead>
             <tr>

--- a/index.html
+++ b/index.html
@@ -3248,14 +3248,6 @@ reserved property. For more information related to adding `type` information,
 see Section <a href="#types"></a>.
         </p>
 
-        <p class="issue" title="(AT RISK) Reserved properties">
-The following reserved properties are at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase:
-`confidenceMethod`, `presentationSchema`, and
-`renderMethod`.
-        </p>
-
         <table class="simple">
           <thead>
             <tr>
@@ -3272,7 +3264,11 @@ A property used for specifying how a <a>verifier</a> can gain more confidence
 in, the presentation of the credential being associated with a particular
 <a>subject</a>. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#confidenceMethod`.
-
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This reserved property is at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase.
+                </p>
               </td>
             </tr>
             <tr>
@@ -3288,6 +3284,11 @@ issue the credential. The associated vocabulary URL MUST be
               <td>
 A property used for specifying the schema for presentations. The associated
 vocabulary URL MUST be `https://www.w3.org/2018/credentials#presentationSchema`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This reserved property is at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase.
+                </p>
               </td>
             </tr>
             <tr>
@@ -3304,6 +3305,11 @@ associated vocabulary URL MUST be
 A property used for specifying how to render a credential into a visual,
 auditory, or haptic format. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#renderMethod`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This reserved property is at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase.
+                </p>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This PR builds upon PR 1097 and adds three new properties (and their reserved URLs) to the reserved properties table: 

* `confirmationMethod` / `confidenceMethod`
* `presentationSchema`
* `renderMethod`

There is now also an example specification that demonstrates how these reserved properties could be leveraged by external specifications: [Verifiable Credential Rendering Methods](https://digitalbazaar.github.io/vc-render-method/)

The specification notes that it [utilizes the reserved property](https://digitalbazaar.github.io/vc-render-method/#the-rendermethod-property) in the VC Data Model, and then [defines a type](https://digitalbazaar.github.io/vc-render-method/#svgrenderingtemplate2023) that can be used with the extension point.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1108.html" title="Last updated on May 13, 2023, 5:53 PM UTC (d4d935b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1108/354036f...d4d935b.html" title="Last updated on May 13, 2023, 5:53 PM UTC (d4d935b)">Diff</a>