### PR TITLE
Add examples v2 context and landing page

### DIFF
--- a/contexts/credentials/examples/v2
+++ b/contexts/credentials/examples/v2
@@ -1,0 +1,5 @@
+{
+  "@context": {
+    "@vocab": "https://www.w3.org/ns/credentials/examples#"
+  }
+}

--- a/vocab/credentials/v2/examples.html
+++ b/vocab/credentials/v2/examples.html
@@ -1,0 +1,76 @@
+<html lang="en">
+  <head>
+    <meta charset='utf-8'/>
+    <title>Verifiable Credentials Example Vocabulary</title>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
+    <script>
+      function remove_status_remark() {
+          const sotd = document.getElementById("sotd");
+          const p = sotd.getElementsByTagName('p')[0];
+          sotd.removeChild(p);
+      }
+    </script>
+    <script class="remove">
+      var respecConfig = {
+        localBiblio: {
+          "vc-data-model": {
+            title: "Verifiable Credentials Data Model v2.0",
+            href: "https://www.w3.org/TR/vc-data-model-2.0/",
+            authors: [
+              "Manu Sporny", "Grant Noble", "Dave Longley",
+              "Daniel C. Burnett", "Brent Zundel", "Kyle Den Hartog",
+              "Orie Steel", "Michael B. Jones", "Gabe Cohen"
+            ],
+            publisher: "W3C"
+          }
+        },
+        specStatus:  "base",
+        shortName:   "ns/credentials/examples",
+        thisVersion: "https://www.w3.org/ns/credentials/examples",
+        doJsonLd:    true,
+        editors: [{
+          name: "Manu Sporny", url: "https://www.linkedin.com/in/manusporny/",
+          company: "Digital Bazaar", companyURL: "https://digitalbazaar.com/",
+          note: "v1.0, v2.0", w3cid: 41758},],
+        postProcess : [remove_status_remark],
+        inlineCSS: true,
+        doRDFa: false,
+        noIDLIn: true,
+        noLegacyStyle: false
+      };
+    </script>
+  </head>
+  <body>
+    <section id="abstract">
+        <p>
+This is the vocabulary document for the example properties used in the
+family of Verifiable Credential Data Model specifications [[vc-data-model]].
+This vocabulary is only to be used for examples and is not intended for
+production usage.
+        </p>
+    </section>
+    <section id="sotd">
+        <p>
+This namespace has been defined by the <a href="https://www.w3.org/2017/vc/WG/">W3C Verifiable Credentials Working Group</a>.
+Comments regarding this document are welcome. Please file issues
+directly on <a href="https://github.com/w3c/vc-data-model/issues/">GitHub</a>, or send them to
+<a href="mailto:public-vc-comments@w3.org">public-vc-comments@w3.org</a>
+(<a href="mailto:public-vc-comments-request@w3.org?subject=subscribe">subscribe</a>,
+<a href="https://lists.w3.org/Archives/Public/public-vc-comments/">archives</a>).
+        </p>
+    </section>
+    <section id="conformance"></section>
+    <section>
+        <h2>Example Terms</h2>
+        <p>
+This is the vocabulary document for the example properties used in the
+family of Verifiable Credential Data Model specifications [[vc-data-model]].
+This vocabulary is only to be used for examples and is not intended for
+production usage. The only purpose of this vocabulary document is to provide a
+proper landing place for any example URLs that might be used while demonstrating
+features in the Verifiable Credentials specifications.
+        </p>
+    </section>
+
+</body>
+</html>


### PR DESCRIPTION
We need to be able to provide examples in the VC Data Model specification that are well formed VCs, but are constructed in such a way as to highlight certain features of the data  model. We have traditionally maintained an examples context that defined all the terms that were used in the examples in the specification. In this iteration of the specification, it has been requested that we use more real-world examples in the specification. While that is a good goal, there have been objections to the types of examples that we would use. For example, some argue that the examples in the specification are too focused on education use cases, others believe that focusing on government identity use cases is not appropriate, still others feel that supply chain examples might be too complicated when certain sections in the specification are attempting to highlight a single feature.

This PR is being raised to address those concerns:

* It establishes a "Switzerland" of examples in the core specification, so we can use properties like "ExampleType" and "exampleProperty", keeping certain examples in the spec simple.
* It uses `@vocab` so we don't have to maintain every single "example*" type or property in the examples context like we did for v1.
* It establishes an "examples vocabulary landing page" such that if people click through on the example URLs, they will end up on a page that explains to them that they are looking at an example term that shouldn't be used in production.

Where we can use real-world examples, we will do so. Where we can't (or it muddies the waters wrt. what we're trying to show in the example), we will use the VC example vocabulary.