### PR TITLE
Add note to describe use of credentialschema with selective disclosure

### DIFF
--- a/common.js
+++ b/common.js
@@ -145,6 +145,13 @@ var vcwg = {
       authors: ['Manu Sporny'],
       status: 'ED',
       publisher: 'W3C Verifiable Credentials Working Group'
+    },
+    'PRES-EX': {
+      title: 'Presentation Exchange 2.0.0',
+      href: 'https://identity.foundation/presentation-exchange/spec/v2.0.0/',
+      authors: ['Daniel Buchner', 'Brent Zundel', 'Martin Riedel', 'Kim Hamilton Duffy'],
+      status: 'DIF Ratified Specification',
+      publisher: 'Decentralized Identity Foundation'
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -2996,6 +2996,11 @@ not define such a request schema in this specification, but an example of one
 method for doing so is [[?PRES-EX]].
         </p>
         <p>
+<code>credentialSchema</code> implementers are encouraged to consider the
+implications of selective disclosure credentials and provide guidance for
+processing depending on the construction.
+        </p>
+        <p>
 The examples below highlight how the data model might be used to issue and
 present <a>verifiable credentials</a> in zero-knowledge.
         </p>

--- a/index.html
+++ b/index.html
@@ -2983,6 +2983,18 @@ so that it can be used by all parties to perform various cryptographic
 operations in zero-knowledge.
           </li>
         </ul>
+        <p class="note">
+When a <a>holder</a> has selectively disclosed a portion of a
+<a>verifiable credential</a>, it is important that the <a>verifier</a> compare
+the information provided in the derived <a>verifiable credential</a> and make
+sure it is compatible with the schema in the <code>credentialSchema</code>
+<a>property</a> provided by the <a>issuer</a>. It is also possible for the
+<a>verifier</a> to provide a schema to the <a>holder</a> as part of a request
+for the <a>holder</a>'s data, and for the <a>verifier</a> to ensure that the
+derived <verifiable credential</a> is compatible with that schema as well. We do
+not define such a request schema in this specification, but an example of one
+method for doing so is [[?PRES-EX]].
+        </p>
         <p>
 The examples below highlight how the data model might be used to issue and
 present <a>verifiable credentials</a> in zero-knowledge.

--- a/index.html
+++ b/index.html
@@ -2983,7 +2983,7 @@ so that it can be used by all parties to perform various cryptographic
 operations in zero-knowledge.
           </li>
         </ul>
-        <p class="note">
+        <p>
 When a <a>holder</a> has selectively disclosed a portion of a
 <a>verifiable credential</a>, it is important that the <a>verifier</a> check
 whether the information provided in the derived <a>verifiable credential</a> is
@@ -2995,10 +2995,11 @@ derived <verifiable credential</a> is compatible with that schema as well. We do
 not define such a request schema in this specification, but an example of one
 method for doing so is [[?PRES-EX]].
         </p>
-        <p>
+        <p class="note">
 <code>credentialSchema</code> implementers are encouraged to consider the
 implications of selective disclosure credentials and provide guidance for
-processing depending on the construction.
+processing depending on the construction. If a schema is not formed with
+selective disclosure in mind, then validation is likely to fail.
         </p>
         <p>
 The examples below highlight how the data model might be used to issue and

--- a/index.html
+++ b/index.html
@@ -2991,7 +2991,7 @@ compatible with the schema in the <code>credentialSchema</code>
 <a>property</a> provided by the <a>issuer</a>. It is also possible for the
 <a>verifier</a> to provide a schema to the <a>holder</a> as part of a request
 for the <a>holder</a>'s data, and for the <a>verifier</a> to ensure that the
-derived <verifiable credential</a> is compatible with that schema as well. We do
+derived <a>verifiable credential</a> is compatible with that schema as well. We do
 not define such a request schema in this specification, but an example of one
 method for doing so is [[?PRES-EX]].
         </p>

--- a/index.html
+++ b/index.html
@@ -2985,9 +2985,9 @@ operations in zero-knowledge.
         </ul>
         <p class="note">
 When a <a>holder</a> has selectively disclosed a portion of a
-<a>verifiable credential</a>, it is important that the <a>verifier</a> compare
-the information provided in the derived <a>verifiable credential</a> and make
-sure it is compatible with the schema in the <code>credentialSchema</code>
+<a>verifiable credential</a>, it is important that the <a>verifier</a> check
+whether the information provided in the derived <a>verifiable credential</a> is
+compatible with the schema in the <code>credentialSchema</code>
 <a>property</a> provided by the <a>issuer</a>. It is also possible for the
 <a>verifier</a> to provide a schema to the <a>holder</a> as part of a request
 for the <a>holder</a>'s data, and for the <a>verifier</a> to ensure that the


### PR DESCRIPTION
The PR attempts to fix #890 

It adds a note to the specification that cautions the verifier to pay attention to the `credentialSchema` when presented with selectively disclosed information. 
It describes the notion of a request schema and non-normatively points to Presentation Exchange as an example for what a verifier might use to make one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1112.html" title="Last updated on May 4, 2023, 5:03 PM UTC (6c29fb4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1112/c964156...brentzundel:6c29fb4.html" title="Last updated on May 4, 2023, 5:03 PM UTC (6c29fb4)">Diff</a>