### PR TITLE
Add usage guidance related to the `id` property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1176,7 +1176,7 @@ allows for the expression of statements about specific things in the
 objects in a <a>verifiable credential</a> or a <a>holder</a> when expressing
 objects in a <a>verifiable presentation</a>. Example <code>id</code> values
 include UUIDs (`urn:uuid:0c07c1ce-57cb-41af-bef2-1b932b986873`), HTTP URLs
-(`https://id.example/123`), and DIDs (`did:example:1234abcd`).
+(`https://id.example/things#123`), and DIDs (`did:example:1234abcd`).
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -1166,14 +1166,17 @@ This concept is further expanded on in Section <a href="#extensibility"></a>.
         <h3>Identifiers</h3>
 
         <p>
-When expressing statements about a specific thing, such as a person, product,
-or organization, it is often useful to use some kind of identifier so that
-others can express statements about the same thing. This specification defines
-the optional <code>id</code> <a>property</a> for such identifiers. The
-<code>id</code> <a>property</a> is intended to unambiguously refer to an object,
-such as a person, product, or organization. Using the <code>id</code>
-<a>property</a> allows for the expression of statements about specific things in
-the <a>verifiable credential</a>.
+When expressing statements about a specific thing, such as a person, product, or
+organization, it is often useful to use a globally unique identifier for it.
+Globally unique identifiers are useful so that others can express statements
+about the same thing. This specification defines the optional <code>id</code>
+<a>property</a> for such identifiers. Using the <code>id</code> <a>property</a>
+allows for the expression of statements about specific things in the
+<a>verifiable credential</a> and is set by an <a>issuer</a> when creating
+objects in a <a>verifiable credential</a> or a <a>holder</a> when creating
+objects in a <a>verifiable presentation</a>. Examples of <code>id</code>s
+include UUIDs (`urn:uuid:0c07c1ce-57cb-41af-bef2-1b932b986873`), HTTP URLs
+(`https://id.example/123`), and DIDs (`did:example:1234abcd`).
         </p>
 
         <p>
@@ -1202,7 +1205,8 @@ where pseudonymity is required. Developers are encouraged to read Section
 scenarios. There are also other types of correlation mechanisms documented in
 Section <a href="#privacy-considerations"></a> that create privacy concerns.
 Where privacy is a strong consideration, the <code>id</code> <a>property</a>
-MAY be omitted.
+MAY be omitted. Not all use cases require the usage of the <code>id</code>
+<a>property</a>.
         </p>
 
         <dl>

--- a/index.html
+++ b/index.html
@@ -1167,14 +1167,14 @@ This concept is further expanded on in Section <a href="#extensibility"></a>.
 
         <p>
 When expressing statements about a specific thing, such as a person, product, or
-organization, it is often useful to use a globally unique identifier for it.
-Globally unique identifiers are useful so that others can express statements
+organization, it can be useful to use a globally unique identifier for that thing.
+Globally unique identifiers enable others to express statements
 about the same thing. This specification defines the optional <code>id</code>
-<a>property</a> for such identifiers. Using the <code>id</code> <a>property</a>
+<a>property</a> for such identifiers. The <code>id</code> <a>property</a>
 allows for the expression of statements about specific things in the
-<a>verifiable credential</a> and is set by an <a>issuer</a> when creating
-objects in a <a>verifiable credential</a> or a <a>holder</a> when creating
-objects in a <a>verifiable presentation</a>. Examples of <code>id</code>s
+<a>verifiable credential</a> and is set by an <a>issuer</a> when expressing
+objects in a <a>verifiable credential</a> or a <a>holder</a> when expressing
+objects in a <a>verifiable presentation</a>. Example <code>id</code> values
 include UUIDs (`urn:uuid:0c07c1ce-57cb-41af-bef2-1b932b986873`), HTTP URLs
 (`https://id.example/123`), and DIDs (`did:example:1234abcd`).
         </p>
@@ -1205,7 +1205,7 @@ where pseudonymity is required. Developers are encouraged to read Section
 scenarios. There are also other types of correlation mechanisms documented in
 Section <a href="#privacy-considerations"></a> that create privacy concerns.
 Where privacy is a strong consideration, the <code>id</code> <a>property</a>
-MAY be omitted. Not all use cases require the usage of the <code>id</code>
+MAY be omitted. Some use cases do not require, or explicitly require omitting, the <code>id</code>
 <a>property</a>.
         </p>
 


### PR DESCRIPTION
This PR addresses issue #946 by describing what the `id` property is used for, some example values for it, and whether or not it should be optional.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1114.html" title="Last updated on May 13, 2023, 6:49 PM UTC (4af336e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1114/d167254...4af336e.html" title="Last updated on May 13, 2023, 6:49 PM UTC (4af336e)">Diff</a>