### PR TITLE
Mark `evidence`, `termsOfUse`, and `refreshService` extension points at risk

### DIFF
--- a/index.html
+++ b/index.html
@@ -2616,10 +2616,10 @@ the proof provided with the <a>verifiable credential</a> is valid.
         <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
-single extension type by the end of the Candidate Recommendation Phase.
-If this feature is removed, the property will be included in the Reserved
-Properties section, in anticipation of future implementation and inclusion
-in the specification.
+single extension type by the end of the Candidate Recommendation Phase. If
+this feature is removed, the property will be included in Section
+<a href="#reserved-extension-points"></a>, in anticipation of future
+implementation and inclusion in the specification.
         </p>
 
         <p>
@@ -2711,9 +2711,9 @@ the <a>verifier</a> to <code>https://example.edu/refresh/3732</code>.
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase.
-If this feature is removed, the property will be included in the Reserved
-Properties section, in anticipation of future implementation and inclusion
-in the specification.
+If this feature is removed, the property will be included in Section
+<a href="#reserved-extension-points"></a>, in anticipation of future
+implementation and inclusion in the specification.
         </p>
 
         <p>
@@ -2883,9 +2883,9 @@ appropriate section of the Verifiable Credentials Implementation Guidelines
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase. If
-this feature is removed, the property will be included in the Reserved
-Properties section, in anticipation of future implementation and inclusion
-in the specification.
+this feature is removed, the property will be included in Section
+<a href="#reserved-extension-points"></a>, in anticipation of future
+implementation and inclusion in the specification.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3318,18 +3318,6 @@ section in the specification will be removed.
               </td>
             </tr>
             <tr>
-              <td>`presentationSchema`</td>
-              <td>
-A property used for specifying the schema for presentations. The associated
-vocabulary URL MUST be `https://www.w3.org/2018/credentials#presentationSchema`.
-                <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property is at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase.
-                </p>
-              </td>
-            </tr>
-            <tr>
               <td>`refreshService`</td>
               <td>
 A property used for specifying how a credential can be refreshed. The

--- a/index.html
+++ b/index.html
@@ -3313,9 +3313,11 @@ A property used for specifying how a credential can be refreshed. The
 associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#refreshService`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property is at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase.
+This reserved property might be deleted in favor of an existing section
+in the specification if at least one specification with two independent
+implementations are demonstrated by the end of the Candidate Recommendation
+Phase. If that does not occur, this reservation will remain, but the existing
+section in the specification will be removed.
                 </p>
               </td>
             </tr>
@@ -3338,9 +3340,11 @@ are not demonstrated by the end of the Candidate Recommendation Phase.
 A property used for specifying the terms of use for a credential. The associated
 vocabulary URL MUST be `https://www.w3.org/2018/credentials#termsOfUse`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property is at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase.
+This reserved property might be deleted in favor of an existing section
+in the specification if at least one specification with two independent
+implementations are demonstrated by the end of the Candidate Recommendation
+Phase. If that does not occur, this reservation will remain, but the existing
+section in the specification will be removed.
                 </p>
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -2613,6 +2613,12 @@ the proof provided with the <a>verifiable credential</a> is valid.
       <section>
         <h3>Refreshing</h3>
 
+        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+This feature is at risk and will be removed from the specification if at least
+two independent, interoperable implementations are not demonstrated for a
+single extension type by the end of the Candidate Recommendation Phase.
+        </p>
+
         <p>
 It is useful for systems to enable the manual or automatic refresh of an expired
 <a>verifiable credential</a>. For more information about validity periods for
@@ -2697,6 +2703,12 @@ the <a>verifier</a> to <code>https://example.edu/refresh/3732</code>.
 
       <section>
         <h3>Terms of Use</h3>
+
+        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+This feature is at risk and will be removed from the specification if at least
+two independent, interoperable implementations are not demonstrated for a
+single extension type by the end of the Candidate Recommendation Phase.
+        </p>
 
         <p>
 Terms of use can be utilized by an <a>issuer</a> or a <a>holder</a> to
@@ -2860,6 +2872,12 @@ appropriate section of the Verifiable Credentials Implementation Guidelines
 
       <section>
         <h3>Evidence</h3>
+
+        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+This feature is at risk and will be removed from the specification if at least
+two independent, interoperable implementations are not demonstrated for a
+single extension type by the end of the Candidate Recommendation Phase.
+        </p>
 
         <p>
 Evidence can be included by an <a>issuer</a> to provide the <a>verifier</a> with
@@ -3281,6 +3299,11 @@ see Section <a href="#types"></a>.
 A property used for specifying the evidence that was presented in order to
 issue the credential. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#evidence`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This reserved property is at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase.
+                </p>
               </td>
             </tr>
             <tr>
@@ -3289,6 +3312,11 @@ issue the credential. The associated vocabulary URL MUST be
 A property used for specifying how a credential can be refreshed. The
 associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#refreshService`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This reserved property is at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase.
+                </p>
               </td>
             </tr>
             <tr>
@@ -3309,6 +3337,11 @@ are not demonstrated by the end of the Candidate Recommendation Phase.
               <td>
 A property used for specifying the terms of use for a credential. The associated
 vocabulary URL MUST be `https://www.w3.org/2018/credentials#termsOfUse`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This reserved property is at risk and will be removed from the
+specification if at least one specification with two independent implementations
+are not demonstrated by the end of the Candidate Recommendation Phase.
+                </p>
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -2617,6 +2617,9 @@ the proof provided with the <a>verifiable credential</a> is valid.
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase.
+If this feature is removed, the property will be included in the Reserved
+Properties section, in anticipation of future implementation and inclusion
+in the specification.
         </p>
 
         <p>
@@ -2708,6 +2711,9 @@ the <a>verifier</a> to <code>https://example.edu/refresh/3732</code>.
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase.
+If this feature is removed, the property will be included in the Reserved
+Properties section, in anticipation of future implementation and inclusion
+in the specification.
         </p>
 
         <p>
@@ -2876,7 +2882,10 @@ appropriate section of the Verifiable Credentials Implementation Guidelines
         <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
-single extension type by the end of the Candidate Recommendation Phase.
+single extension type by the end of the Candidate Recommendation Phase. If
+this feature is removed, the property will be included in the Reserved
+Properties section, in anticipation of future implementation and inclusion
+in the specification.
         </p>
 
         <p>
@@ -3300,6 +3309,20 @@ A property used for specifying the evidence that was presented in order to
 issue the credential. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#evidence`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This property reservation might be deleted in favor of an existing section
+in the specification if at least one specification with two independent
+implementations are demonstrated by the end of the Candidate Recommendation
+Phase. If that does not occur, this reservation will remain, but the existing
+section in the specification will be removed.
+                </p>
+              </td>
+            </tr>
+            <tr>
+              <td>`presentationSchema`</td>
+              <td>
+A property used for specifying the schema for presentations. The associated
+vocabulary URL MUST be `https://www.w3.org/2018/credentials#presentationSchema`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
 This reserved property is at risk and will be removed from the
 specification if at least one specification with two independent implementations
 are not demonstrated by the end of the Candidate Recommendation Phase.
@@ -3313,7 +3336,7 @@ A property used for specifying how a credential can be refreshed. The
 associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#refreshService`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property might be deleted in favor of an existing section
+This property reservation might be deleted in favor of an existing section
 in the specification if at least one specification with two independent
 implementations are demonstrated by the end of the Candidate Recommendation
 Phase. If that does not occur, this reservation will remain, but the existing
@@ -3340,7 +3363,7 @@ are not demonstrated by the end of the Candidate Recommendation Phase.
 A property used for specifying the terms of use for a credential. The associated
 vocabulary URL MUST be `https://www.w3.org/2018/credentials#termsOfUse`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
-This reserved property might be deleted in favor of an existing section
+This property reservation might be deleted in favor of an existing section
 in the specification if at least one specification with two independent
 implementations are demonstrated by the end of the Candidate Recommendation
 Phase. If that does not occur, this reservation will remain, but the existing


### PR DESCRIPTION
This PR marks the `evidence`, `termsOfUse`, and `refreshService` extension points at risk. It does this in two places: 1) the existing section, so implementers know the feature is going away if they can't demonstrate two interoperable implementations, and 2) the reserved properties table such that the reservation will be deleted, but the section will remain in the spec, if there are enough implementations.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1115.html" title="Last updated on May 13, 2023, 6:29 PM UTC (54fb7b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1115/6108bad...54fb7b5.html" title="Last updated on May 13, 2023, 6:29 PM UTC (54fb7b5)">Diff</a>