### PR TITLE
Make things easier for developers

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -92,6 +92,56 @@
       }
     },
 
+    "StatusList2021Credential": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021Credential",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "description": "http://schema.org/description",
+        "name": "http://schema.org/name"
+      }
+    },
+
+    "StatusList2021": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusPurpose":
+          "https://w3id.org/vc/status-list#statusPurpose",
+        "encodedList": "https://w3id.org/vc/status-list#encodedList"
+      }
+    },
+
+    "StatusList2021Entry": {
+      "@id":
+        "https://w3id.org/vc/status-list#StatusList2021Entry",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusPurpose":
+          "https://w3id.org/vc/status-list#statusPurpose",
+        "statusListIndex":
+          "https://w3id.org/vc/status-list#statusListIndex",
+        "statusListCredential": {
+          "@id":
+            "https://w3id.org/vc/status-list#statusListCredential",
+          "@type": "@id"
+        }
+      }
+    },
+
     "DataIntegrityProof": {
       "@id": "https://w3id.org/security#DataIntegrityProof",
       "@context": {

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -101,8 +101,8 @@
         "id": "@id",
         "type": "@type",
 
-        "description": "http://schema.org/description",
-        "name": "http://schema.org/name"
+        "description": "https://schema.org/description",
+        "name": "https://schema.org/name"
       }
     },
 


### PR DESCRIPTION
After this PR, you will be able to issue revocable verifiable credentials using data integrity proofs with only 1 context.

Or 2 if you don't like issuer dependent terms.

Today, you need at least 3:

```
  "@context": [
    "https://www.w3.org/ns/credentials/v2",
    "https://www.w3.org/ns/credentials/examples/v2",
    "https://w3id.org/vc/status-list/2021/v1"
  ],
```