### PR TITLE
add context integrity capabilities to the core data model

### DIFF
--- a/index.html
+++ b/index.html
@@ -2596,30 +2596,38 @@ the proof provided with the <a>verifiable credential</a> is valid.
       </section>
 
       <section>
-        <h2>Context Integrity</h2>
+        <h2>External Resource Integrity</h2>
         <p>
-          In some cases it is desirable to know that the contents of the
-          context(s) utilized in the verifiable credential are the same as
-          used by both the issuer and verifier.  
+          When including a link to an external resource in a VC it is 
+          desireable to know if the resource that is pointed to, is the
+          same at signing time, as at verification time.  This applies to
+          both cases where there is an external resource that is 
+          remotely retrieved, as well as to cases where the issuer and/or
+          verifier may have local cached copies of a resource.
         </p>
         <p>
-          To validate that a context included in a Verifiable Credential is
+          It is also desirable to know that the contents of the
+          context(s) utilized in the verifiable credential are the same as
+          used by both the issuer and verifier. 
+        </p>
+        <p>
+          To validate that a resource referenced by a Verifiable Credential is
           the same at verification time as at issuing time an implementer
-          MAY include a property named <code>contextIntegrity</code> that
+          MAY include a property named <code>resourceIntegrity</code> that
           stores an array of objects that describe additional integrity
-          metadata about each context used by the VC. If
-          <code>contextIntegrity</code>
+          metadata about each resource referenced by the VC. If
+          <code>resourceIntegrity</code>
           is present there MUST be an object in the array for each remote
-          context.
+          resource.
         </p>
         <p>
           Each object in the
-          <code>contextIntegrity</code> array MUST contain the following:
-          the URL to the context named <code>context</code>, a
+          <code>resourceIntegrity</code> array MUST contain the following:
+          the URL to the resource named <code>resource</code>, a
           <code>timestamp</code>
           that indicates the time at which the hash was computed, the
           <code>hash</code>
-          of the context, and the <code>method</code> which indicates what
+          of the resource, and the <code>method</code> which indicates what
           hashing algorithm was used as listed as the 'Hash Name String'
           property from the <a
           href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
@@ -2648,20 +2656,36 @@ the proof provided with the <a>verifiable credential</a> is valid.
         <p>
           <aside
             class="example"
-            title="context integrity"
+            title="resource integrity"
           >
-            <p>An example of a context integrity object</p>
+            <p>An example of a resource integrity object referencing contexts</p>
             <pre>
-              "contextIntegrity": [{
-                "@context": "https://www.w3.org/ns/credentials/v2",
+              "resourceIntegrity": [{
+                "resource": "https://www.w3.org/ns/credentials/v2",
                 "timestamp": "2020-01-01T19:23:24Z", 
                 "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
                 "method": "sha3-384"  
               },{
-                "@context": "https://www.w3.org/ns/credentials/examples/v2",
+                "resource": "https://www.w3.org/ns/credentials/examples/v2",
                 "timestamp": "2019-02-04T17:32:15Z", 
                 "hash": "ac996ae492f9a987c84f109f2118d3f6632e2259455d30c455a9ecd66c3c4959", 
                 "method": "sha2-256"  
+              }]
+            </pre>
+          </aside>
+        </p>
+        <p>
+          <aside
+            class="example"
+            title="resource integrity over image"
+          >
+            <p>An example of a resource integrity object refering to an image</p>
+            <pre>
+              "resourceIntegrity": [{
+                "resource": "https://www.w3.org/Icons/w3c_home.png",
+                "timestamp": "2023-06-05T19:23:24Z", 
+                "hash": "d727ecbc780ef52b029e0013677afa36c14e0f31b30dfb6d946739800dd0926ff4f3225be1f7a94d76c02ba2116760be", 
+                "method": "sha3-384"  
               }]
             </pre>
           </aside>

--- a/index.html
+++ b/index.html
@@ -2649,7 +2649,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           An object in the <code>resourceIntegrity</code> array MAY contain
           a property named <code>mediaType</code> that indicates the 
           expected media type for the indicated <code>resource</code>.
-          If a <code>mediaType</code> is included it must be a valid
+          If a <code>mediaType</code> is included it SHOULD be a valid
           media type as listed in the 
           <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
             IANA Media Types

--- a/index.html
+++ b/index.html
@@ -2634,7 +2634,9 @@ The requirement that contexts be listed in `relatedResource` is currently being 
           href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource
           Integrity</a>.
         </p>
-        <p>
+        <p class="issue" title="Unification of cryptographic hash expression formats are under discussion">
+The Working Group is currently attempting to determine if cryptographic hash expression formats can be unified across all of the VCWG core specifications. Candidates for this mechanism include `digestSRI` and `digestMultibase`. There are arguments for and against unification that the WG is currently debating.
+        </p>
           There MUST NOT be more than one object in the
           <code>relatedResource</code> per <code>id</code>. 
         </p>

--- a/index.html
+++ b/index.html
@@ -2656,10 +2656,6 @@ the proof provided with the <a>verifiable credential</a> is valid.
           </a> registry.
         </p>
         <p>
-          An object in the <code>resourceIntegrity</code> array MAY contain
-          additional properties.
-        </p>
-        <p>
           In any object in the <code>credential.credentialSubject</code>
           that contains a [[URL]], a property named
           <code>integrity</code> may be included with the integrity

--- a/index.html
+++ b/index.html
@@ -2618,28 +2618,29 @@ the proof provided with the <a>verifiable credential</a> is valid.
           metadata about each resource referenced by the VC. If
           <code>resourceIntegrity</code>
           is present, there MUST be an object in the array for each remote
-          resource. 
+          resource for each context used in the verifiable credential. 
         </p>
         <p>
           Each object in the
           <code>resourceIntegrity</code> array MUST contain the following:
-          the [[URL]] to the resource named <code>resource</code>, the
-          <code>digest</code>
-          of the resource, and the <code>method</code> which indicates what
-          hashing algorithm was used as listed as the 'Hash Name String'
-          property from the <a
-          href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
-          Named Information Hash Algorithm Registry</a>.  
-          The <code>digest</code> property MUST be the base64url [[RFC 4648]]
-          encoded digest of the hash with no trailing characters.
-          The <code>timestamp</code> property MUST be a string value of an
-          [[XMLSCHEMA11-2]] combined date-time string. An implementer MAY
-          include other fields in each object.
+          the [[URL]] to the resource named <code>id</code> and the 
+          <code>integrity</code> information for the resource
+          constructed using the method specified in <a
+          href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource
+          Integrity</a>.
         </p>
         <p>
-          An object in the <code>resourceIntegrity</code> array MAY contain
-          a property named <code>timestamp</code>
-          that indicates the time at which the hash was computed. 
+          There may be only one object in the <code>resourceIntegrity</code>
+          per <code>id</code>. When performing integrity checking the
+          strongest hash algorithm available SHOULD be used to confirm
+          integrity of the resource.
+        </p>
+        <p>
+          An object in the <code>resourceIntegrity</code> array MAY
+          contain a property named <code>timestamp</code>
+          that indicates the time at which the hash was computed. The
+          <code>timestamp</code> property if included MUST be a string
+          value of an [[XMLSCHEMA11-2]] combined date-time string.
         </p>
         <p>
           An object in the <code>resourceIntegrity</code> array MAY contain
@@ -2656,6 +2657,13 @@ the proof provided with the <a>verifiable credential</a> is valid.
           additional properties.
         </p>
         <p>
+          In any object in the <code>credential.credentialSubject</code>
+          that contains a [[URL]], a property named
+          <code>integrity</code> may be included with the integrity
+          information as specified above, with the [[URL]] in the
+          <code>id</code> property. 
+        </p>
+        <p>
           Implementers SHOULD consult appropriate sources, such as the 
           <a href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a> to ensure that they
@@ -2663,13 +2671,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           this writing `sha-256` SHOULD be considered the minimum strength
           hash algorithm for use by implemnters.
         </p>
-        <p>
-          If there is more than one object in <code>resourceIntegrity</code>
-          that refers to the same <code>resource</code> the <code>method</code>
-          MUST be different for each object.  When performing integrity
-          checking the strongest hash algorithm available SHOULD be used
-          to confirm integrity of the resource.
-        </p>
+        
         <p class="issue">
           The working group is discussing if we will adopt subresource
           integrity as defined in [[SRI]] is adopted into the [[JSON-LD]]
@@ -2688,15 +2690,11 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a resource integrity object referencing contexts</p>
             <pre>
               "resourceIntegrity": [{
-                "resource": "https://www.w3.org/ns/credentials/v2",
-                "timestamp": "2023-06-07T19:23:24Z", 
-                "digest": "zMxXZRc9wGRgtsdFaCaqluKtZbyEz-emTp4Y1k1wBvgKNYguD7qTACwjWOTUgB-A", 
-                "method": "sha3-384"  
-              },{
-                "resource": "https://www.w3.org/ns/credentials/examples/v2",
-                "timestamp": "2023-06-07T17:32:15Z", 
-                "digest": "STCt_TVvy-QH6PCA8IDH7tw0dsBsgkewEl9VjCDwvUCVPz5M10dUhrMG9f2Q82MA", 
-                "method": "sha2-256"  
+                "id": "https://www.w3.org/ns/credentials/v2",
+                "integrity": "sha384-lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK", 
+              },{  
+                "id": "https://www.w3.org/ns/credentials/examples/v2",  
+                "integrity": "sha384-zNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26", 
               }]
             </pre>
           </aside>
@@ -2706,13 +2704,16 @@ the proof provided with the <a>verifiable credential</a> is valid.
             class="example"
             title="resource integrity over image"
           >
-            <p>An example of a resource integrity object refering to an image</p>
+            <p>An example of a resource integrity object in a credentialSubject refering to an image</p>
             <pre>
-              "resourceIntegrity": [{
-                "resource": "https://www.w3.org/Icons/w3c_home.png",
-                "digest": "1yfsvHgO9SsCngATZ3r6NsFODzGzDfttlGc5gA3Qkm_08yJb4fepTXbAK6IRZ2C-", 
-                "method": "sha3-384"  
-              }]
+              "credentialSubject": {
+                "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+                "image": {
+                    "id": "https://university.example/images/58473",
+                    "integrity": "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J"
+                },
+                ...
+              }
             </pre>
           </aside>
         </p>

--- a/index.html
+++ b/index.html
@@ -2653,7 +2653,10 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a context integrity object</p>
             <pre>
               "contextIntegrity": [{
-                "context":"https://example.org/v1/context", 
+                "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
                 "timestamp": "2020-01-01T19:23:24Z", 
                 "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
                 "method": "sha3-384"  

--- a/index.html
+++ b/index.html
@@ -2618,12 +2618,12 @@ the proof provided with the <a>verifiable credential</a> is valid.
           metadata about each resource referenced by the VC. If
           <code>resourceIntegrity</code>
           is present, there MUST be an object in the array for each remote
-          resource.
+          resource. 
         </p>
         <p>
           Each object in the
           <code>resourceIntegrity</code> array MUST contain the following:
-          the URL to the resource named <code>id</code>, a
+          the [[URL]] to the resource named <code>resource</code>, a
           <code>timestamp</code>
           that indicates the time at which the hash was computed, the
           <code>digest</code>
@@ -2653,21 +2653,29 @@ the proof provided with the <a>verifiable credential</a> is valid.
           additional properties.
         </p>
         <p>
-          Implementers SHOULD consult appropriate sources, such as the <a
-          href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
+          Implementers SHOULD consult appropriate sources, such as the 
+          <a href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a> to ensure that they
           are chosing a current and reliable hash algorithm.  At the time of
           this writing `sha-256` SHOULD be considered the minimum strength
           hash algorithm for use by implemnters.
         </p>
+        <p>
+          If there is more than one object in <code>resourceIntegrity</code>
+          that refers to the same <code>resource</code> the <code>method</code>
+          MUST be different for each object.  When performing integrity
+          checking the strongest hash algorithm available SHOULD be used
+          to confirm integrity of the resource.
+        </p>
         <p class="issue">
-         The working group is discussing if we will adopt subresource integrity as defined in [[SRI]] is
-          adopted into the [[JSON-LD]] specification as noted in that
-          specifications <a
-          href="https://www.w3.org/TR/json-ld11/#security">current security
-          considerations</a> of that specification, this hash in the VC can
-          serve as an additional check towards ensuring that a cached
-          context used when issuing the VC matches the remote resource.
+          The working group is discussing if we will adopt subresource
+          integrity as defined in [[SRI]] is adopted into the [[JSON-LD]]
+          specification as noted in that specifications <a
+          href="https://www.w3.org/TR/json-ld11/#security">current
+          security considerations</a> of that specification, this hash in
+          the VC can serve as an additional check towards ensuring that a
+          cached context used when issuing the VC matches the remote
+          resource.
         </p>
         <p>
           <aside
@@ -2677,12 +2685,12 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a resource integrity object referencing contexts</p>
             <pre>
               "resourceIntegrity": [{
-                "id": "https://www.w3.org/ns/credentials/v2",
+                "resource: "https://www.w3.org/ns/credentials/v2",
                 "timestamp": "2023-06-07T19:23:24Z", 
                 "digest": "zMxXZRc9wGRgtsdFaCaqluKtZbyEz-emTp4Y1k1wBvgKNYguD7qTACwjWOTUgB-A", 
                 "method": "sha3-384"  
               },{
-                "id": "https://www.w3.org/ns/credentials/examples/v2",
+                "resource": "https://www.w3.org/ns/credentials/examples/v2",
                 "timestamp": "2023-06-07T17:32:15Z", 
                 "digest": "STCt_TVvy-QH6PCA8IDH7tw0dsBsgkewEl9VjCDwvUCVPz5M10dUhrMG9f2Q82MA", 
                 "method": "sha2-256"  
@@ -2698,7 +2706,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a resource integrity object refering to an image</p>
             <pre>
               "resourceIntegrity": [{
-                "id": "https://www.w3.org/Icons/w3c_home.png",
+                "resource": "https://www.w3.org/Icons/w3c_home.png",
                 "timestamp": "2023-06-05T19:23:24Z", 
                 "digest": "1yfsvHgO9SsCngATZ3r6NsFODzGzDfttlGc5gA3Qkm_08yJb4fepTXbAK6IRZ2C-", 
                 "method": "sha3-384"  

--- a/index.html
+++ b/index.html
@@ -2653,7 +2653,8 @@ The Working Group is currently attempting to determine if cryptographic hash exp
         <p>
           Any object in the <a>verifiable credential</a>
           that contains an `id` [[URL]] property MAY be annotated with 
-          integrity information as specified in this section.
+          integrity information as specified in this section by inclusion
+          of <code>digestSRI</code> in the object.
         </p>
         <p>
           Any objects for which selective disclosure is desired SHOULD

--- a/index.html
+++ b/index.html
@@ -2653,12 +2653,15 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a context integrity object</p>
             <pre>
               "contextIntegrity": [{
-                "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-  ],
+                "@context": "https://www.w3.org/ns/credentials/v2",
                 "timestamp": "2020-01-01T19:23:24Z", 
                 "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
                 "method": "sha3-384"  
+              },{
+                "@context": "https://www.w3.org/ns/credentials/examples/v2",
+                "timestamp": "2019-02-04T17:32:15Z", 
+                "hash": "ac996ae492f9a987c84f109f2118d3f6632e2259455d30c455a9ecd66c3c4959", 
+                "method": "sha2-256"  
               }]
             </pre>
           </aside>

--- a/index.html
+++ b/index.html
@@ -2635,7 +2635,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           The <code>hash</code> property MUST be the base64url [[RFC 4648]]
           encoded digest of the hash.
           The <code>timestamp</code> property MUST be a string value of an
-          [[XMLSCHEMA11-2]] combined date-time string. An implementer may
+          [[XMLSCHEMA11-2]] combined date-time string. An implementer MAY
           include other fields in each object.
         </p>
         <p>
@@ -2653,15 +2653,15 @@ the proof provided with the <a>verifiable credential</a> is valid.
           additional properties.
         </p>
         <p>
-          Implementers should consult appropriate sources, such as the <a
+          Implementers SHOULD consult appropriate sources, such as the <a
           href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a> to ensure that they
           are chosing a current and reliable hash algorithm.  At the time of
-          this writing `sha-256` should be considered the minimum strength
+          this writing `sha-256` SHOULD be considered the minimum strength
           hash algorithm for use by implemnters.
         </p>
-        <p class="note">
-          If at a later date subresource integrity as defined in [[SRI]] is
+        <p class="issue">
+         The working group is discussing if we will adopt subresource integrity as defined in [[SRI]] is
           adopted into the [[JSON-LD]] specification as noted in that
           specifications <a
           href="https://www.w3.org/TR/json-ld11/#security">current security
@@ -2677,14 +2677,14 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a resource integrity object referencing contexts</p>
             <pre>
               "resourceIntegrity": [{
-                "resource": "https://www.w3.org/ns/credentials/v2",
+                "id": "https://www.w3.org/ns/credentials/v2",
                 "timestamp": "2023-06-07T19:23:24Z", 
-                "hash": "zMxXZRc9wGRgtsdFaCaqluKtZbyEz-emTp4Y1k1wBvgKNYguD7qTACwjWOTUgB-A", 
+                "digest": "zMxXZRc9wGRgtsdFaCaqluKtZbyEz-emTp4Y1k1wBvgKNYguD7qTACwjWOTUgB-A", 
                 "method": "sha3-384"  
               },{
-                "resource": "https://www.w3.org/ns/credentials/examples/v2",
+                "id": "https://www.w3.org/ns/credentials/examples/v2",
                 "timestamp": "2023-06-07T17:32:15Z", 
-                "hash": "STCt_TVvy-QH6PCA8IDH7tw0dsBsgkewEl9VjCDwvUCVPz5M10dUhrMG9f2Q82MA", 
+                "digest": "STCt_TVvy-QH6PCA8IDH7tw0dsBsgkewEl9VjCDwvUCVPz5M10dUhrMG9f2Q82MA", 
                 "method": "sha2-256"  
               }]
             </pre>
@@ -2698,9 +2698,9 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a resource integrity object refering to an image</p>
             <pre>
               "resourceIntegrity": [{
-                "resource": "https://www.w3.org/Icons/w3c_home.png",
+                "id": "https://www.w3.org/Icons/w3c_home.png",
                 "timestamp": "2023-06-05T19:23:24Z", 
-                "hash": "1yfsvHgO9SsCngATZ3r6NsFODzGzDfttlGc5gA3Qkm_08yJb4fepTXbAK6IRZ2C-", 
+                "digest": "1yfsvHgO9SsCngATZ3r6NsFODzGzDfttlGc5gA3Qkm_08yJb4fepTXbAK6IRZ2C-", 
                 "method": "sha3-384"  
               }]
             </pre>

--- a/index.html
+++ b/index.html
@@ -2632,6 +2632,8 @@ the proof provided with the <a>verifiable credential</a> is valid.
           property from the <a
           href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a>.  
+          The <code>hash</code> property MUST be the base64url [[RFC 4648]]
+          encoded digest of the hash.
           The <code>timestamp</code> property MUST be a string value of an
           [[XMLSCHEMA11-2]] combined date-time string. An implementer may
           include other fields in each object.
@@ -2662,13 +2664,13 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <pre>
               "resourceIntegrity": [{
                 "resource": "https://www.w3.org/ns/credentials/v2",
-                "timestamp": "2020-01-01T19:23:24Z", 
-                "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
+                "timestamp": "2023-06-07T19:23:24Z", 
+                "hash": "zMxXZRc9wGRgtsdFaCaqluKtZbyEz-emTp4Y1k1wBvgKNYguD7qTACwjWOTUgB-A", 
                 "method": "sha3-384"  
               },{
                 "resource": "https://www.w3.org/ns/credentials/examples/v2",
-                "timestamp": "2019-02-04T17:32:15Z", 
-                "hash": "ac996ae492f9a987c84f109f2118d3f6632e2259455d30c455a9ecd66c3c4959", 
+                "timestamp": "2023-06-07T17:32:15Z", 
+                "hash": "STCt_TVvy-QH6PCA8IDH7tw0dsBsgkewEl9VjCDwvUCVPz5M10dUhrMG9f2Q82MA", 
                 "method": "sha2-256"  
               }]
             </pre>
@@ -2684,7 +2686,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
               "resourceIntegrity": [{
                 "resource": "https://www.w3.org/Icons/w3c_home.png",
                 "timestamp": "2023-06-05T19:23:24Z", 
-                "hash": "d727ecbc780ef52b029e0013677afa36c14e0f31b30dfb6d946739800dd0926ff4f3225be1f7a94d76c02ba2116760be", 
+                "hash": "1yfsvHgO9SsCngATZ3r6NsFODzGzDfttlGc5gA3Qkm_08yJb4fepTXbAK6IRZ2C-", 
                 "method": "sha3-384"  
               }]
             </pre>

--- a/index.html
+++ b/index.html
@@ -2601,7 +2601,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           When including a link to an external resource in a
           <a>verifiable credential</a>, it is desirable to know whether
           the resource that is pointed to is the same at signing time as
-          it is at verification time.  This applies to cases where there
+          it is at verification time. This applies to cases where there
           is an external resource that is remotely retrieved as well as
           to cases where the <a>issuer</a> and/or
           <a>verifier</a> may have local cached copies of a resource.
@@ -2669,7 +2669,7 @@ The Working Group is currently attempting to determine if cryptographic hash exp
           <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
             Commercial National Security Algorithm Suite 2.0</a>
           to ensure that they are chosing a current and reliable hash
-          algorithm.  At the time of this writing `sha384` SHOULD be
+          algorithm. At the time of this writing `sha384` SHOULD be
           considered the minimum strength hash algorithm for use by
           implementers.
         </p>

--- a/index.html
+++ b/index.html
@@ -2624,7 +2624,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           Each object in the
           <code>relatedResource</code> array MUST contain the following:
           the [[URL]] to the resource named <code>id</code> and the 
-          <code>integrity</code> information for the resource
+          <code>digestSRI</code> information for the resource
           constructed using the method specified in <a
           href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource
           Integrity</a>.
@@ -2655,21 +2655,24 @@ the proof provided with the <a>verifiable credential</a> is valid.
         </p>
         <p>
           Implementers are urged to consult appropriate sources, such as the 
-          <a href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
-          Named Information Hash Algorithm Registry</a> to ensure that they
-          are chosing a current and reliable hash algorithm.  At the time of
-          this writing `sha-256` SHOULD be considered the minimum strength
-          hash algorithm for use by implemnters.
+          <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">
+            FIPS 180-4 Secure Hash Standard</a> and the 
+          <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
+            Commercial National Security Algorithm Suite 2.0</a>
+          to ensure that they are chosing a current and reliable hash
+          algorithm.  At the time of this writing `sha384` SHOULD be
+          considered the minimum strength hash algorithm for use by
+          implemnters.
         </p>
         <p class="issue">
-          The working group is discussing if we will adopt subresource
-          integrity as defined in [[SRI]] is adopted into the [[JSON-LD]]
-          specification as noted in that specifications <a
-          href="https://www.w3.org/TR/json-ld11/#security">current
-          security considerations</a> of that specification, this hash in
-          the VC can serve as an additional check towards ensuring that a
-          cached context used when issuing the VC matches the remote
-          resource.
+          The working group is discussing if we will adopt more aspects
+          of subresource integrity as defined in [[SRI]] is adopted into
+          the [[JSON-LD]] specification as noted in that specifications
+          <a href="https://www.w3.org/TR/json-ld11/#security">current
+          security considerations</a> of that specification, this hash
+          in the VC can serve as an additional check towards ensuring
+          that a cached context used when issuing the VC matches the
+          remote resource.
         </p>
         <p>
           <aside
@@ -2680,10 +2683,10 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <pre>
               "resourceIntegrity": [{
                 "id": "https://www.w3.org/ns/credentials/v2",
-                "integrity": "sha384-lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK", 
+                "digestSRI": "sha384-lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK", 
               },{  
                 "id": "https://www.w3.org/ns/credentials/examples/v2",  
-                "integrity": "sha384-zNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26", 
+                "digestSRI": "sha384-zNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26", 
               }]
             </pre>
           </aside>
@@ -2698,8 +2701,8 @@ the proof provided with the <a>verifiable credential</a> is valid.
               "credentialSubject": {
                 "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
                 "image": {
-                    "id": "https://university.example/images/58473",
-                    "integrity": "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
+                    "id": "https://university.example.org/images/58473",
+                    "digestSRI": "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
                     "mediaType": "application/svg+xml",
                 },
                 ...

--- a/index.html
+++ b/index.html
@@ -2630,8 +2630,11 @@ the proof provided with the <a>verifiable credential</a> is valid.
           Integrity</a>.
         </p>
         <p>
-          There may be only one object in the <code>resourceIntegrity</code>
-          per <code>id</code>. When performing integrity checking the
+          There MUST NOT be more than one object in the
+          <code>resourceIntegrity</code> per <code>id</code>. 
+        </p>
+        <p>
+          When performing integrity checking the
           strongest hash algorithm available SHOULD be used to confirm
           integrity of the resource.
         </p>

--- a/index.html
+++ b/index.html
@@ -2598,26 +2598,26 @@ the proof provided with the <a>verifiable credential</a> is valid.
       <section>
         <h2>External Resource Integrity</h2>
         <p>
-          When including a link to an external resource in a VC it is 
-          desireable to know if the resource that is pointed to, is the
-          same at signing time, as at verification time.  This applies to
-          both cases where there is an external resource that is 
-          remotely retrieved, as well as to cases where the issuer and/or
+          When including a link to an external resource in a VC, it is 
+          desirable to know whether the resource that is pointed to is the
+          same at signing time as at verification time.  This applies
+          to cases where there is an external resource that is
+          remotely retrieved as well as to cases where the issuer and/or
           verifier may have local cached copies of a resource.
         </p>
         <p>
           It is also desirable to know that the contents of the
-          context(s) utilized in the verifiable credential are the same as
+          context(s) used in the verifiable credential are the same when
           used by both the issuer and verifier. 
         </p>
         <p>
           To validate that a resource referenced by a Verifiable Credential is
-          the same at verification time as at issuing time an implementer
+          the same at verification time as at issuing time, an implementer
           MAY include a property named <code>resourceIntegrity</code> that
           stores an array of objects that describe additional integrity
           metadata about each resource referenced by the VC. If
           <code>resourceIntegrity</code>
-          is present there MUST be an object in the array for each remote
+          is present, there MUST be an object in the array for each remote
           resource.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -2688,7 +2688,7 @@ The requirement that contexts be listed in `relatedResource` is currently being 
             <p>An example of related resource integrity object referencing
             contexts</p>
             <pre>
-              "resourceIntegrity": [{
+              "relatedResource": [{
                 "id": "https://www.w3.org/ns/credentials/v2",
                 "digestSRI": "sha384-lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK", 
               },{  

--- a/index.html
+++ b/index.html
@@ -2639,6 +2639,20 @@ the proof provided with the <a>verifiable credential</a> is valid.
           include other fields in each object.
         </p>
         <p>
+          An object in the <code>resourceIntegrity</code> array MAY contain
+          a property named <code>mediaType</code> that indicates the 
+          expected media type for the indicated <code>resource</code>.
+          If a <code>mediaType</code> is included it must be a valid
+          media type as listed in the 
+          <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
+            IANA Media Types
+          </a> registry.
+        </p>
+        <p>
+          An object in the <code>resourceIntegrity</code> array MAY contain
+          additional properties.
+        </p>
+        <p>
           Implementers should consult appropriate sources, such as the <a
           href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a> to ensure that they

--- a/index.html
+++ b/index.html
@@ -2631,19 +2631,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
         </p>
         <p>
           There MUST NOT be more than one object in the
-          <code>resourceIntegrity</code> per <code>id</code>. 
-        </p>
-        <p>
-          When performing integrity checking the
-          strongest hash algorithm available SHOULD be used to confirm
-          integrity of the resource.
-        </p>
-        <p>
-          An object in the <code>relatedResource</code> array MAY
-          contain a property named <code>timestamp</code>
-          that indicates the time at which the hash was computed. The
-          <code>timestamp</code> property if included MUST be a string
-          value of an [[XMLSCHEMA11-2]] combined date-time string.
+          <code>relatedResource</code> per <code>id</code>. 
         </p>
         <p>
           An object in the <code>relatedResource</code> array MAY contain
@@ -2713,7 +2701,6 @@ the proof provided with the <a>verifiable credential</a> is valid.
                     "id": "https://university.example/images/58473",
                     "integrity": "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
                     "mediaType": "application/svg+xml",
-                    "timestamp": "2023-06-16T17:10:24Z"
                 },
                 ...
               }

--- a/index.html
+++ b/index.html
@@ -2633,7 +2633,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a>.  
           The <code>digest</code> property MUST be the base64url [[RFC 4648]]
-          encoded digest of the hash.
+          encoded digest of the hash with no trailing characters.
           The <code>timestamp</code> property MUST be a string value of an
           [[XMLSCHEMA11-2]] combined date-time string. An implementer MAY
           include other fields in each object.

--- a/index.html
+++ b/index.html
@@ -2596,7 +2596,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
       </section>
 
       <section>
-        <h2>External Resource Integrity</h2>
+        <h2>Integrity of Related Resources</h2>
         <p>
           When including a link to an external resource in a <a>verifiable credential</a>, it is 
           desirable to know whether the resource that is pointed to is the
@@ -2607,22 +2607,22 @@ the proof provided with the <a>verifiable credential</a> is valid.
         </p>
         <p>
           It is also desirable to know that the contents of the
-          context(s) used in the <a>verifiable credential</a> are the same when
+          JSON-LD context(s) used in the <a>verifiable credential</a> are the same when
           used by both the <a>issuer</a> and <a>verifier</a>. 
         </p>
         <p>
           To validate that a resource referenced by a <a>verifiable credential</a> is
           the same at verification time as it is at issuing time, an implementer
-          MAY include a property named <code>resourceIntegrity</code> that
+          MAY include a property named <code>relatedResource</code> that
           stores an array of objects that describe additional integrity
           metadata about each resource referenced by the <a>verifiable credential</a>. If
-          <code>resourceIntegrity</code>
+          <code>relatedResource</code>
           is present, there MUST be an object in the array for each remote
           resource for each context used in the verifiable credential. 
         </p>
         <p>
           Each object in the
-          <code>resourceIntegrity</code> array MUST contain the following:
+          <code>relatedResource</code> array MUST contain the following:
           the [[URL]] to the resource named <code>id</code> and the 
           <code>integrity</code> information for the resource
           constructed using the method specified in <a
@@ -2639,14 +2639,14 @@ the proof provided with the <a>verifiable credential</a> is valid.
           integrity of the resource.
         </p>
         <p>
-          An object in the <code>resourceIntegrity</code> array MAY
+          An object in the <code>relatedResource</code> array MAY
           contain a property named <code>timestamp</code>
           that indicates the time at which the hash was computed. The
           <code>timestamp</code> property if included MUST be a string
           value of an [[XMLSCHEMA11-2]] combined date-time string.
         </p>
         <p>
-          An object in the <code>resourceIntegrity</code> array MAY contain
+          An object in the <code>relatedResource</code> array MAY contain
           a property named <code>mediaType</code> that indicates the 
           expected media type for the indicated <code>resource</code>.
           If a <code>mediaType</code> is included it SHOULD be a valid
@@ -2656,15 +2656,13 @@ the proof provided with the <a>verifiable credential</a> is valid.
           </a> registry.
         </p>
         <p>
-          In any object in the <code>credential.credentialSubject</code>
-          that contains a [[URL]], a property named
-          <code>integrity</code> may be included with the integrity
-          information as specified above, with the [[URL]] in the
-          <code>id</code> property. 
+          Any object in the <a>verifiable credential</a>
+          that contains an `id` [[URL]] property MAY be annotated with 
+          integrity information as specified in this section.
         </p>
         <p>
           Any objects for which selective disclosure is desired SHOULD NOT
-          be included as an object in the <code>resourceIntegrity</code>
+          be included as an object in the <code>relatedResource</code>
           array.
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -2671,7 +2671,7 @@ The Working Group is currently attempting to determine if cryptographic hash exp
           to ensure that they are chosing a current and reliable hash
           algorithm.  At the time of this writing `sha384` SHOULD be
           considered the minimum strength hash algorithm for use by
-          implemnters.
+          implementers.
         </p>
         <p class="issue">
           The working group is discussing if we will adopt more aspects

--- a/index.html
+++ b/index.html
@@ -2717,7 +2717,9 @@ the proof provided with the <a>verifiable credential</a> is valid.
                 "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
                 "image": {
                     "id": "https://university.example/images/58473",
-                    "integrity": "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J"
+                    "integrity": "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
+                    "mediaType": "application/svg+xml",
+                    "timestamp": "2023-06-16T17:10:24Z"
                 },
                 ...
               }

--- a/index.html
+++ b/index.html
@@ -2680,9 +2680,9 @@ the proof provided with the <a>verifiable credential</a> is valid.
         <p>
           <aside
             class="example"
-            title="resource integrity"
+            title="related resource integrity"
           >
-            <p>An example of a resource integrity object referencing
+            <p>An example of related resource integrity object referencing
             contexts</p>
             <pre>
               "resourceIntegrity": [{
@@ -2698,9 +2698,9 @@ the proof provided with the <a>verifiable credential</a> is valid.
         <p>
           <aside
             class="example"
-            title="resource integrity over image"
+            title="related resource integrity over image"
           >
-            <p>An example of a resource integrity object in a
+            <p>An example of a related resource integrity object in a
             credentialSubject refering to an image</p>
             <pre class="example" title="An integrity-protected image that is associated with a credentialSubject">
               "credentialSubject": {

--- a/index.html
+++ b/index.html
@@ -2622,6 +2622,9 @@ the proof provided with the <a>verifiable credential</a> is valid.
           is present, there MUST be an object in the array for each remote
           resource for each context used in the verifiable credential. 
         </p>
+        <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
+The requirement that contexts be listed in `relatedResource` is currently being debated in the VCWG. This requirement might be removed in future iterations of the specification. 
+        </p>
         <p>
           Each object in the
           <code>relatedResource</code> array MUST contain the following:

--- a/index.html
+++ b/index.html
@@ -2688,7 +2688,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <p>An example of a resource integrity object referencing contexts</p>
             <pre>
               "resourceIntegrity": [{
-                "resource: "https://www.w3.org/ns/credentials/v2",
+                "resource": "https://www.w3.org/ns/credentials/v2",
                 "timestamp": "2023-06-07T19:23:24Z", 
                 "digest": "zMxXZRc9wGRgtsdFaCaqluKtZbyEz-emTp4Y1k1wBvgKNYguD7qTACwjWOTUgB-A", 
                 "method": "sha3-384"  

--- a/index.html
+++ b/index.html
@@ -2598,24 +2598,24 @@ the proof provided with the <a>verifiable credential</a> is valid.
       <section>
         <h2>External Resource Integrity</h2>
         <p>
-          When including a link to an external resource in a VC, it is 
+          When including a link to an external resource in a <a>verifiable credential</a>, it is 
           desirable to know whether the resource that is pointed to is the
-          same at signing time as at verification time.  This applies
+          same at signing time as it is at verification time.  This applies
           to cases where there is an external resource that is
-          remotely retrieved as well as to cases where the issuer and/or
-          verifier may have local cached copies of a resource.
+          remotely retrieved as well as to cases where the <a>issuer</a> and/or
+          <a>verifier</a> may have local cached copies of a resource.
         </p>
         <p>
           It is also desirable to know that the contents of the
-          context(s) used in the verifiable credential are the same when
-          used by both the issuer and verifier. 
+          context(s) used in the <a>verifiable credential</a> are the same when
+          used by both the <a>issuer</a> and <a>verifier</a>. 
         </p>
         <p>
-          To validate that a resource referenced by a Verifiable Credential is
-          the same at verification time as at issuing time, an implementer
+          To validate that a resource referenced by a <a>verifiable credential</a> is
+          the same at verification time as it is at issuing time, an implementer
           MAY include a property named <code>resourceIntegrity</code> that
           stores an array of objects that describe additional integrity
-          metadata about each resource referenced by the VC. If
+          metadata about each resource referenced by the <a>verifiable credential</a>. If
           <code>resourceIntegrity</code>
           is present, there MUST be an object in the array for each remote
           resource for each context used in the verifiable credential. 
@@ -2672,7 +2672,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
           array.
         </p>
         <p>
-          Implementers SHOULD consult appropriate sources, such as the 
+          Implementers are urged to consult appropriate sources, such as the 
           <a href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a> to ensure that they
           are chosing a current and reliable hash algorithm.  At the time of
@@ -2712,7 +2712,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
             title="resource integrity over image"
           >
             <p>An example of a resource integrity object in a credentialSubject refering to an image</p>
-            <pre>
+            <pre class="example" title="An integrity-protected image that is associated with a credentialSubject">
               "credentialSubject": {
                 "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
                 "image": {

--- a/index.html
+++ b/index.html
@@ -2655,7 +2655,6 @@ the proof provided with the <a>verifiable credential</a> is valid.
               "contextIntegrity": [{
                 "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
   ],
                 "timestamp": "2020-01-01T19:23:24Z", 
                 "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 

--- a/index.html
+++ b/index.html
@@ -2623,16 +2623,16 @@ the proof provided with the <a>verifiable credential</a> is valid.
         <p>
           Each object in the
           <code>resourceIntegrity</code> array MUST contain the following:
-          the URL to the resource named <code>resource</code>, a
+          the URL to the resource named <code>id</code>, a
           <code>timestamp</code>
           that indicates the time at which the hash was computed, the
-          <code>hash</code>
+          <code>digest</code>
           of the resource, and the <code>method</code> which indicates what
           hashing algorithm was used as listed as the 'Hash Name String'
           property from the <a
           href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a>.  
-          The <code>hash</code> property MUST be the base64url [[RFC 4648]]
+          The <code>digest</code> property MUST be the base64url [[RFC 4648]]
           encoded digest of the hash.
           The <code>timestamp</code> property MUST be a string value of an
           [[XMLSCHEMA11-2]] combined date-time string. An implementer MAY

--- a/index.html
+++ b/index.html
@@ -2623,9 +2623,7 @@ the proof provided with the <a>verifiable credential</a> is valid.
         <p>
           Each object in the
           <code>resourceIntegrity</code> array MUST contain the following:
-          the [[URL]] to the resource named <code>resource</code>, a
-          <code>timestamp</code>
-          that indicates the time at which the hash was computed, the
+          the [[URL]] to the resource named <code>resource</code>, the
           <code>digest</code>
           of the resource, and the <code>method</code> which indicates what
           hashing algorithm was used as listed as the 'Hash Name String'
@@ -2637,6 +2635,11 @@ the proof provided with the <a>verifiable credential</a> is valid.
           The <code>timestamp</code> property MUST be a string value of an
           [[XMLSCHEMA11-2]] combined date-time string. An implementer MAY
           include other fields in each object.
+        </p>
+        <p>
+          An object in the <code>resourceIntegrity</code> array MAY contain
+          a property named <code>timestamp</code>
+          that indicates the time at which the hash was computed. 
         </p>
         <p>
           An object in the <code>resourceIntegrity</code> array MAY contain
@@ -2707,7 +2710,6 @@ the proof provided with the <a>verifiable credential</a> is valid.
             <pre>
               "resourceIntegrity": [{
                 "resource": "https://www.w3.org/Icons/w3c_home.png",
-                "timestamp": "2023-06-05T19:23:24Z", 
                 "digest": "1yfsvHgO9SsCngATZ3r6NsFODzGzDfttlGc5gA3Qkm_08yJb4fepTXbAK6IRZ2C-", 
                 "method": "sha3-384"  
               }]

--- a/index.html
+++ b/index.html
@@ -2598,24 +2598,26 @@ the proof provided with the <a>verifiable credential</a> is valid.
       <section>
         <h2>Integrity of Related Resources</h2>
         <p>
-          When including a link to an external resource in a <a>verifiable credential</a>, it is 
-          desirable to know whether the resource that is pointed to is the
-          same at signing time as it is at verification time.  This applies
-          to cases where there is an external resource that is
-          remotely retrieved as well as to cases where the <a>issuer</a> and/or
+          When including a link to an external resource in a
+          <a>verifiable credential</a>, it is desirable to know whether
+          the resource that is pointed to is the same at signing time as
+          it is at verification time.  This applies to cases where there
+          is an external resource that is remotely retrieved as well as
+          to cases where the <a>issuer</a> and/or
           <a>verifier</a> may have local cached copies of a resource.
         </p>
         <p>
-          It is also desirable to know that the contents of the
-          JSON-LD context(s) used in the <a>verifiable credential</a> are the same when
-          used by both the <a>issuer</a> and <a>verifier</a>. 
+          It is also desirable to know that the contents of the JSON-LD
+          context(s) used in the <a>verifiable credential</a> are the
+          same when used by both the <a>issuer</a> and <a>verifier</a>. 
         </p>
         <p>
-          To validate that a resource referenced by a <a>verifiable credential</a> is
-          the same at verification time as it is at issuing time, an implementer
-          MAY include a property named <code>relatedResource</code> that
-          stores an array of objects that describe additional integrity
-          metadata about each resource referenced by the <a>verifiable credential</a>. If
+          To validate that a resource referenced by a <a>verifiable
+          credential</a> is the same at verification time as it is at
+          issuing time, an implementer MAY include a property named
+          <code>relatedResource</code> that stores an array of objects
+          that describe additional integrity metadata about each
+          resource referenced by the <a>verifiable credential</a>. If
           <code>relatedResource</code>
           is present, there MUST be an object in the array for each remote
           resource for each context used in the verifiable credential. 
@@ -2634,11 +2636,11 @@ the proof provided with the <a>verifiable credential</a> is valid.
           <code>relatedResource</code> per <code>id</code>. 
         </p>
         <p>
-          An object in the <code>relatedResource</code> array MAY contain
-          a property named <code>mediaType</code> that indicates the 
-          expected media type for the indicated <code>resource</code>.
-          If a <code>mediaType</code> is included it SHOULD be a valid
-          media type as listed in the 
+          An object in the <code>relatedResource</code> array MAY
+          contain a property named <code>mediaType</code> that indicates
+          the expected media type for the indicated
+          <code>resource</code>. If a <code>mediaType</code> is included
+          it SHOULD be a valid media type as listed in the 
           <a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
             IANA Media Types
           </a> registry.
@@ -2649,12 +2651,13 @@ the proof provided with the <a>verifiable credential</a> is valid.
           integrity information as specified in this section.
         </p>
         <p>
-          Any objects for which selective disclosure is desired SHOULD NOT
-          be included as an object in the <code>relatedResource</code>
-          array.
+          Any objects for which selective disclosure is desired SHOULD
+          NOT be included as an object in the
+          <code>relatedResource</code> array.
         </p>
         <p>
-          Implementers are urged to consult appropriate sources, such as the 
+          Implementers are urged to consult appropriate sources, such as
+          the 
           <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">
             FIPS 180-4 Secure Hash Standard</a> and the 
           <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
@@ -2679,7 +2682,8 @@ the proof provided with the <a>verifiable credential</a> is valid.
             class="example"
             title="resource integrity"
           >
-            <p>An example of a resource integrity object referencing contexts</p>
+            <p>An example of a resource integrity object referencing
+            contexts</p>
             <pre>
               "resourceIntegrity": [{
                 "id": "https://www.w3.org/ns/credentials/v2",
@@ -2696,7 +2700,8 @@ the proof provided with the <a>verifiable credential</a> is valid.
             class="example"
             title="resource integrity over image"
           >
-            <p>An example of a resource integrity object in a credentialSubject refering to an image</p>
+            <p>An example of a resource integrity object in a
+            credentialSubject refering to an image</p>
             <pre class="example" title="An integrity-protected image that is associated with a credentialSubject">
               "credentialSubject": {
                 "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",

--- a/index.html
+++ b/index.html
@@ -2667,6 +2667,11 @@ the proof provided with the <a>verifiable credential</a> is valid.
           <code>id</code> property. 
         </p>
         <p>
+          Any objects for which selective disclosure is desired SHOULD NOT
+          be included as an object in the <code>resourceIntegrity</code>
+          array.
+        </p>
+        <p>
           Implementers SHOULD consult appropriate sources, such as the 
           <a href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
           Named Information Hash Algorithm Registry</a> to ensure that they
@@ -2674,7 +2679,6 @@ the proof provided with the <a>verifiable credential</a> is valid.
           this writing `sha-256` SHOULD be considered the minimum strength
           hash algorithm for use by implemnters.
         </p>
-        
         <p class="issue">
           The working group is discussing if we will adopt subresource
           integrity as defined in [[SRI]] is adopted into the [[JSON-LD]]

--- a/index.html
+++ b/index.html
@@ -2596,6 +2596,74 @@ the proof provided with the <a>verifiable credential</a> is valid.
       </section>
 
       <section>
+        <h2>Context Integrity</h2>
+        <p>
+          In some cases it is desirable to know that the contents of the
+          context(s) utilized in the verifiable credential are the same as
+          used by both the issuer and verifier.  
+        </p>
+        <p>
+          To validate that a context included in a Verifiable Credential is
+          the same at verification time as at issuing time an implementer
+          MAY include a property named <code>contextIntegrity</code> that
+          stores an array of objects that describe additional integrity
+          metadata about each context used by the VC. If
+          <code>contextIntegrity</code>
+          is present there MUST be an object in the array for each remote
+          context.
+        </p>
+        <p>
+          Each object in the
+          <code>contextIntegrity</code> array MUST contain the following:
+          the URL to the context named <code>context</code>, a
+          <code>timestamp</code>
+          that indicates the time at which the hash was computed, the
+          <code>hash</code>
+          of the context, and the <code>method</code> which indicates what
+          hashing algorithm was used as listed as the 'Hash Name String'
+          property from the <a
+          href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
+          Named Information Hash Algorithm Registry</a>.  
+          The <code>timestamp</code> property MUST be a string value of an
+          [[XMLSCHEMA11-2]] combined date-time string. An implementer may
+          include other fields in each object.
+        </p>
+        <p>
+          Implementers should consult appropriate sources, such as the <a
+          href="https://www.iana.org/assignments/named-information/named-information.xhtml">IANA
+          Named Information Hash Algorithm Registry</a> to ensure that they
+          are chosing a current and reliable hash algorithm.  At the time of
+          this writing `sha-256` should be considered the minimum strength
+          hash algorithm for use by implemnters.
+        </p>
+        <p class="note">
+          If at a later date subresource integrity as defined in [[SRI]] is
+          adopted into the [[JSON-LD]] specification as noted in that
+          specifications <a
+          href="https://www.w3.org/TR/json-ld11/#security">current security
+          considerations</a> of that specification, this hash in the VC can
+          serve as an additional check towards ensuring that a cached
+          context used when issuing the VC matches the remote resource.
+        </p>
+        <p>
+          <aside
+            class="example"
+            title="context integrity"
+          >
+            <p>An example of a context integrity object</p>
+            <pre>
+              "contextIntegrity": [{
+                "context":"https://example.org/v1/context", 
+                "timestamp": "2020-01-01T19:23:24Z", 
+                "hash": "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004", 
+                "method": "sha3-384"  
+              }]
+            </pre>
+          </aside>
+        </p>
+      </section>
+
+      <section>
         <h3>Refreshing</h3>
 
         <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">


### PR DESCRIPTION
per conversation and feedback [on this pr on vc-jwt](https://github.com/w3c/vc-jwt/pull/90) this is probably better suited to be available in the core data model for all securing formats


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mesur-io/vc-data-model/pull/1140.html" title="Last updated on Jun 27, 2023, 4:05 PM UTC (a4ef5eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1140/cff30d3...mesur-io:a4ef5eb.html" title="Last updated on Jun 27, 2023, 4:05 PM UTC (a4ef5eb)">Diff</a>