### PR TITLE
Add graph node identifiers for registered claims

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -26,7 +26,6 @@
       "@id": "https://www.iana.org/assignments/jose#x5u",
       "@type": "@id"
     },
-    
 
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -4,7 +4,14 @@
     "@vocab": "https://www.w3.org/ns/credentials/issuer-dependent#",
 
     "id": "@id",
+    "kid": "@id",
+    "iss": "@id",
+    "sub": "@id",
+    "jku": "@id",
+    "x5u": "@id",
+    
     "type": "@type",
+    
 
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -11,7 +11,7 @@
       "@type": "@id"
     },
     "iss": {
-      "@id": "https://www.iana.org/assignments/jwt#iss",
+      "@id": "https://www.iana.org/assignments/jose#iss",
       "@type": "@id"
     },
     "sub": {

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -7,7 +7,7 @@
     "type": "@type",
     
     "kid": {
-      "@id": "https://www.iana.org/assignments/jwt#kid",
+      "@id": "https://www.iana.org/assignments/jose#kid",
       "@type": "@id"
     },
     "iss": {

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -23,7 +23,7 @@
       "@type": "@id"
     },
     "x5u": {
-      "@id": "https://www.iana.org/assignments/jwt#x5u",
+      "@id": "https://www.iana.org/assignments/jose#x5u",
       "@type": "@id"
     },
     

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -5,7 +5,6 @@
 
     "id": "@id",
     "type": "@type",
-    
     "kid": {
       "@id": "https://www.iana.org/assignments/jose#kid",
       "@type": "@id"

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -19,7 +19,7 @@
       "@type": "@id"
     },
     "jku": {
-      "@id": "https://www.iana.org/assignments/jwt#jku",
+      "@id": "https://www.iana.org/assignments/jose#jku",
       "@type": "@id"
     },
     "x5u": {

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -15,7 +15,7 @@
       "@type": "@id"
     },
     "sub": {
-      "@id": "https://www.iana.org/assignments/jwt#sub",
+      "@id": "https://www.iana.org/assignments/jose#sub",
       "@type": "@id"
     },
     "jku": {

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -4,13 +4,28 @@
     "@vocab": "https://www.w3.org/ns/credentials/issuer-dependent#",
 
     "id": "@id",
-    "kid": "@id",
-    "iss": "@id",
-    "sub": "@id",
-    "jku": "@id",
-    "x5u": "@id",
-    
     "type": "@type",
+    
+    "kid": {
+      "@id": "https://www.iana.org/assignments/jwt#kid",
+      "@type": "@id"
+    },
+    "iss": {
+      "@id": "https://www.iana.org/assignments/jwt#iss",
+      "@type": "@id"
+    },
+    "sub": {
+      "@id": "https://www.iana.org/assignments/jwt#sub",
+      "@type": "@id"
+    },
+    "jku": {
+      "@id": "https://www.iana.org/assignments/jwt#jku",
+      "@type": "@id"
+    },
+    "x5u": {
+      "@id": "https://www.iana.org/assignments/jwt#x5u",
+      "@type": "@id"
+    },
     
 
     "VerifiableCredential": {


### PR DESCRIPTION
Since the v2 context contains terms specific to data integrity proofs.

And I have closed the PR attempting to remove those terms: https://github.com/w3c/vc-data-model/pull/1091

It stands to reason we will need to add terms related to all proof formats to the v2 context, in the spirit of making things easier for developers.



