### PR TITLE
Make the value of the base context normative.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4928,13 +4928,21 @@ franchise. Policy information expressed by the <a>issuer</a> in the
     <section class="appendix informative">
       <h2>Contexts, Types, and Credential Schemas</h2>
 
-      <section class="informative">
+      <section class="normative">
         <h3>Base Context</h3>
+
+        <p class="issue" title="(AT RISK) Hash values might change during Candidate Recommendation">
+This section lists cryptographic hash values that might change during the
+Candidate Recommendation phase based on implementer feedback that requires
+the referenced files to be modified.
+        </p>
           <p>
-The base context, located at <code>https://www.w3.org/ns/credentials/v2</code>
-with a SHA-256 digest of
-<strong><code>ff1fdfa8d3f07547ec149b6652fe3f5a4276b9f0c48344dc29400763ba7b44fa</code></strong>,
-can be used to implement a local cached copy. It is possible to confirm the
+Implementations MUST ensure that the base context value, located at
+<code>https://www.w3.org/ns/credentials/v2</code>, matches the following
+SHA-256 digest of the value:
+<strong><code>dc28cf86d8a3199beb9d14e29d1da662346b8660abf2edca873098c88ca2a457</code></strong>.
+The base context value matching the digest previously stated can be used to
+implement a local cached copy. It is possible to confirm the
 SHA-256 digest by running the following command from a modern Unix command
 interface line:
 `curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha256 -hex -r`.

--- a/index.html
+++ b/index.html
@@ -4947,7 +4947,7 @@ SHA-384 digest by running the following command from a modern Unix command
 interface line:
 `curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`.
 
-More details regarding this hash encoding and methods may be found in the <a href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a> 
+More details regarding this hash encoding method may be found in the <a href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a> 
 section of [[SRI]].
 It is strongly advised that all JSON-LD Contexts used in an application utilize
 a similar mechanism to ensure end-to-end security.

--- a/index.html
+++ b/index.html
@@ -4946,7 +4946,10 @@ implement a local cached copy. It is possible to confirm the
 SHA-384 digest by running the following command from a modern Unix command
 interface line:
 `curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`.
-
+                </p>
+                <p class="issue" data-number="1177">
+The Working Group is currently discussing what a processor should do if a hash value differs from one that is listed in the specification. 
+                </p>
 More details regarding this hash encoding method may be found in the <a href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a> 
 section of [[SRI]].
 It is strongly advised that all JSON-LD Contexts used in an application utilize

--- a/index.html
+++ b/index.html
@@ -4939,13 +4939,16 @@ the referenced files to be modified.
           <p>
 Implementations MUST ensure that the base context value, located at
 <code>https://www.w3.org/ns/credentials/v2</code>, matches the following
-SHA-256 digest of the value:
-<strong><code>dc28cf86d8a3199beb9d14e29d1da662346b8660abf2edca873098c88ca2a457</code></strong>.
+SHA-384 digest of the value computed and encoded according to the [[SRI]] definition of `digest`:
+<strong><code>lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK</code></strong>.
 The base context value matching the digest previously stated can be used to
 implement a local cached copy. It is possible to confirm the
-SHA-256 digest by running the following command from a modern Unix command
+SHA-384 digest by running the following command from a modern Unix command
 interface line:
-`curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha256 -hex -r`.
+`curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`.
+
+More details regarding this hash encoding and methods may be found in the <a href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a> 
+section of [[SRI]].
 It is strongly advised that all JSON-LD Contexts used in an application utilize
 a similar mechanism to ensure end-to-end security.
           </p>


### PR DESCRIPTION
This PR implements two resolutions made during the last special topic call:

1. https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-06-13-vcwg-special#resolution1
2. https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-06-13-vcwg-special#resolution2

Namely:

[Resolution #1](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-06-13-vcwg-special#resolution1): The v2 context URL will remain normative (https://www.w3.org/ns/credentials/v2), its value will be made normative through the use of a hash digest.

[Resolution #2](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-06-13-vcwg-special#resolution2): Add issue markers saying that the value of the hash digest for the v2 context may change before PR and that’s expected.

One editorial fix the Editor's might make after this PR is to move the Base Context section from the appendix into the main specification (given that having a normative appendix section is a bit strange).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1158.html" title="Last updated on Jun 30, 2023, 9:15 AM UTC (b84134c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1158/9fea3cc...b84134c.html" title="Last updated on Jun 30, 2023, 9:15 AM UTC (b84134c)">Diff</a>