### PR TITLE
Make the vocabulary URLs and values normative

### DIFF
--- a/index.html
+++ b/index.html
@@ -5052,7 +5052,7 @@ franchise. Policy information expressed by the <a>issuer</a> in the
     </section>
 
     <section class="appendix informative">
-      <h2>Contexts, Types, and Credential Schemas</h2>
+      <h2>Contexts, Vocabularies, Types, and Credential Schemas</h2>
 
       <section class="normative">
         <h3>Base Context</h3>
@@ -5116,6 +5116,93 @@ as what the <a>issuer</a> or <a>holder</a> intended.
         </p>
       </section>
 
+      <section class="normative">
+        <h3>Vocabularies</h3>
+
+        <p>
+Implementations MUST ensure that the following vocabulary URLs used in the base
+context ultimately resolve to the following files, which are normative:
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>URL</th>
+              <th>Media Type</th>
+              <th>Content</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+https://www.w3.org/2018/credentials#
+              </td>
+              <td>
+text/html
+              </td>
+              <td>
+https://www.w3.org/2018/credentials/index.html
+              </td>
+            </tr>
+            <tr>
+              <td>
+https://www.w3.org/2018/credentials#
+              </td>
+              <td>
+application/ld+json
+              </td>
+              <td>
+https://www.w3.org/2018/credentials/index.jsonld
+              </td>
+            </tr>
+            <tr>
+              <td>
+https://schema.org/
+              </td>
+              <td>
+text/html
+              </td>
+              <td>
+https://schema.org/
+              </td>
+            </tr>
+            <tr>
+              <td>
+https://schema.org/
+              </td>
+              <td>
+application/ld+json
+              </td>
+              <td>
+https://schema.org/version/latest/schemaorg-current-https.jsonld
+              </td>
+            </tr>
+            <tr>
+              <td>
+https://w3id.org/security#
+              </td>
+              <td>
+text/html
+              </td>
+              <td>
+https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html
+              </td>
+            </tr>
+            <tr>
+              <td>
+https://w3id.org/security#
+              </td>
+              <td>
+application/ld+json
+              </td>
+              <td>
+https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </section>
       <section class="informative">
         <h3>Differences between Contexts, Types, and CredentialSchemas</h3>
 

--- a/index.html
+++ b/index.html
@@ -5123,8 +5123,7 @@ as what the <a>issuer</a> or <a>holder</a> intended.
 This section lists URL values that might change during the Candidate
 Recommendation phase based on migration of documents to the W3C Technical
 Reports namespace and implementer feedback that requires the referenced URLs to
-be modified. Specifically, it is expected that the github.io links listed
-below will eventually point to W3C TR space.
+be modified.
         </p>
 
         <p>
@@ -5209,6 +5208,13 @@ https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld
             </tr>
           </tbody>
         </table>
+
+        <p class="issue" title="w3c.github.io links expected to change">
+The URLs listed above that start with
+`https://w3c.github.io/vc-data-integrity/vocab/security/` are expected to change
+to `https://www.w3.org/ns/security/` or an equally normative and archived
+location under W3C control.
+        </p>
 
       </section>
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -5216,6 +5216,14 @@ to `https://www.w3.org/ns/security/` or an equally normative and archived
 location under W3C control.
         </p>
 
+        <p class="issue" title="How to normatively refer to vocabulary files">
+The Working Group is currently discussing how it might want to normatively
+refer to the vocabulary files that are under the control of the Working Group.
+Current options are: inclusion of the files directly into the specification or
+publishing the files in W3C TR space and referring to them by using a
+cryptographic hash.
+        </p>
+
       </section>
       <section class="informative">
         <h3>Differences between Contexts, Types, and CredentialSchemas</h3>

--- a/index.html
+++ b/index.html
@@ -5119,6 +5119,14 @@ as what the <a>issuer</a> or <a>holder</a> intended.
       <section class="normative">
         <h3>Vocabularies</h3>
 
+        <p class="issue" title="(AT RISK) URL values might change during Candidate Recommendation">
+This section lists URL values that might change during the Candidate
+Recommendation phase based on migration of documents to the W3C Technical
+Reports namespace and implementer feedback that requires the referenced URLs to
+be modified. Specifically, it is expected that the github.io links listed
+below will eventually point to W3C TR space.
+        </p>
+
         <p>
 Implementations MUST ensure that the following vocabulary URLs used in the base
 context ultimately resolve to the following files, which are normative:


### PR DESCRIPTION
This PR is an attempt to address issue #1103 by making the vocabulary URLs and content at those URLs normative. I will note that this PR is experimental, as it's not clear if it addresses all of the concerns raised in #1103.

One thing the PR does not do is refer to each vocabulary by hash (like we do for context files). It doesn't do this because doing so with vocabularies like schema.org is not possible (because the vocabulary is updated on a regular basis and thus the hashes would change on a regular basis). The same is true for the WG's vocabulary files (over time). If we were to refer to them by hash, then the next iteration of the vocabulary would break previous releases. The same is true if we included the vocabulary, verbatim, in the core specification.

So, this PR attempts to make it not matter what the URLs used in the context file are -- the WG specifies exactly which vocabulary each URL included in the context should refer to such that the meaning of the terms (both human readable and machine readable) is under the control of the WG (or delegated to an entity that the WG feels is adequate).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1159.html" title="Last updated on Jun 30, 2023, 10:37 AM UTC (f3d32dd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1159/491ab78...f3d32dd.html" title="Last updated on Jun 30, 2023, 10:37 AM UTC (f3d32dd)">Diff</a>