### PR TITLE
Add language clarifying VP is short-lived

### DIFF
--- a/index.html
+++ b/index.html
@@ -1918,7 +1918,7 @@ They can be packaged in such a way that the authorship of the data is
 <a>verifiable presentations</a>.
         </p>
         <p>
-<a>Verifiable presentations</a> MAY be extremely short-lived, and
+<a>Verifiable presentations</a> SHOULD be extremely short-lived, and
 bound to a challenge provided by a <a>verifier</a>. Details for accomplishing
 this depend on the securing mechanism, the transport protocol, and
 <a>verifier</a> policies. Unless additional requirements are defined by the

--- a/index.html
+++ b/index.html
@@ -1918,7 +1918,7 @@ They can be packaged in such a way that the authorship of the data is
 <a>verifiable presentations</a>.
         </p>
         <p>
-<a>Verifiable presentations</a> are intended to be extremely short-lived, and
+<a>Verifiable presentations</a> MAY be extremely short-lived, and
 bound to a challenge provided by a <a>verifier</a>. Details for accomplishing
 this depend on the securing mechanism, the transport protocol, and
 <a>verifier</a> policies. Unless additional requirements are defined by the

--- a/index.html
+++ b/index.html
@@ -1917,7 +1917,12 @@ They can be packaged in such a way that the authorship of the data is
 <a>verifiable credentials</a> is a typical use of
 <a>verifiable presentations</a>.
         </p>
-
+        <p>
+<a>Verifiable presentations</a> are intended to be extremely short-lived, and
+bound to a challenge provided by a <a>verifier</a>. Details for accomplishing
+this depend on the securing mechanism, the transport protocol, and
+<a>verifier</a> policies.
+        </p>
         <p>
 A <a>verifiable presentation</a> is typically composed of the following
 properties:

--- a/index.html
+++ b/index.html
@@ -1921,7 +1921,11 @@ They can be packaged in such a way that the authorship of the data is
 <a>Verifiable presentations</a> are intended to be extremely short-lived, and
 bound to a challenge provided by a <a>verifier</a>. Details for accomplishing
 this depend on the securing mechanism, the transport protocol, and
-<a>verifier</a> policies.
+<a>verifier</a> policies. Unless additional requirements are defined by the
+particular securing mechanism or embedding protocol, a <a>Verifier</a> cannot
+generally assume that the <a>Verifiable Presentation</a> has any correlation
+with the presented <a>Verifiable Credentials</a> beyond preservation of their
+data integrity.
         </p>
         <p>
 A <a>verifiable presentation</a> is typically composed of the following

--- a/index.html
+++ b/index.html
@@ -1922,10 +1922,9 @@ They can be packaged in such a way that the authorship of the data is
 bound to a challenge provided by a <a>verifier</a>. Details for accomplishing
 this depend on the securing mechanism, the transport protocol, and
 <a>verifier</a> policies. Unless additional requirements are defined by the
-particular securing mechanism or embedding protocol, a <a>Verifier</a> cannot
-generally assume that the <a>Verifiable Presentation</a> has any correlation
-with the presented <a>Verifiable Credentials</a> beyond preservation of their
-data integrity.
+particular securing mechanism or embedding protocol, a <a>verifier</a> cannot
+generally assume that the <a>verifiable presentation</a> has any correlation
+with the presented <a>verifiable credentials</a>.
         </p>
         <p>
 A <a>verifiable presentation</a> is typically composed of the following


### PR DESCRIPTION
Fixes #937 

This PR uses language suggested in #937 to clarify that VPs are intended to be short-lived.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1164.html" title="Last updated on Jun 23, 2023, 9:46 PM UTC (116a7e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1164/329d6f8...brentzundel:116a7e0.html" title="Last updated on Jun 23, 2023, 9:46 PM UTC (116a7e0)">Diff</a>