### PR TITLE
made validFrom optional, fixes #1133

### DIFF
--- a/index.html
+++ b/index.html
@@ -1724,6 +1724,14 @@ at which the information associated with the <code>credentialSubject</code>
 }
         </pre>
 
+        <p class="note">
+If <code>validFrom</code> and <code>validUntil</code> are not present, the
+<a>verifiable credential</a> validity period is considered valid
+indefinitely. In such cases, the <a>verifiable credential</a> is assumed to be
+valid from the time the <code>proof</code> was created or activated until
+further notice or until it is explicitly revoked or invalidated.
+        </p>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -1682,10 +1682,9 @@ when a <a>credential</a> ceases to be valid.
         <dl>
           <dt><var>validFrom</var></dt>
           <dd>
-A <a>credential</a> MUST have an <code>validFrom</code> <a>property</a>. The
-value of the <code>validFrom</code> <a>property</a> MUST be a string value of
-an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>] combined
-<code>date-time</code> string representing the date and time the
+If present, the value of the <code>validFrom</code> <a>property</a> MUST be
+a string value of an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
+combined <code>date-time</code> string representing the date and time the
 <a>credential</a> becomes valid, which could be a date and time in the future.
 Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>

--- a/index.html
+++ b/index.html
@@ -1728,8 +1728,7 @@ at which the information associated with the <code>credentialSubject</code>
 If <code>validFrom</code> and <code>validUntil</code> are not present, the
 <a>verifiable credential</a> validity period is considered valid
 indefinitely. In such cases, the <a>verifiable credential</a> is assumed to be
-valid from the time the <code>proof</code> was created or activated until
-further notice or until it is explicitly revoked or invalidated.
+valid from the time the <code>verifiable credential</code> was created.
         </p>
 
       </section>

--- a/schema/verifiable-credential/verifiable-credential-schema.json
+++ b/schema/verifiable-credential/verifiable-credential-schema.json
@@ -287,7 +287,6 @@
     "@context",
     "type",
     "issuer",
-    "validFrom",
     "credentialSubject"
   ],
   "additionalProperties": true

--- a/schema/verifiable-presentation/example-25.json
+++ b/schema/verifiable-presentation/example-25.json
@@ -16,7 +16,6 @@
         "type": "did:example:schema:22KpkXgecryx9k7N6XN1QoN3gXwBkSU8SfyyYQG"
       },
       "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
-      "validFrom": "2017-12-05T14:27:42Z",
       "credentialSubject": {
         "degreeType": "BachelorDegree",
         "degreeSchool": "College of Engineering"

--- a/schema/verifiable-presentation/verifiable-presentation-schema-test.js
+++ b/schema/verifiable-presentation/verifiable-presentation-schema-test.js
@@ -18,7 +18,7 @@ describe('Verifiable Presentation', function () {
     });
 
     // Note: this example fails because the dependent VC is not valid;
-    // it is missing an validFrom. Both the VP and VC proofs are missing
+    // Both the VP and VC proofs are missing
     // created, proofPurpose, and verificationMethod fields. The example has
     // been modified to get the test to pass.
     it('should validate example 25 using JSON Schema 2020-12 ', function () {


### PR DESCRIPTION
closes #1133, made `validFrom` optional (also fixed JSON schema)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1168.html" title="Last updated on Jul 5, 2023, 4:00 PM UTC (c75a122)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1168/7c44300...c75a122.html" title="Last updated on Jul 5, 2023, 4:00 PM UTC (c75a122)">Diff</a>