### PR TITLE
Update example types

### DIFF
--- a/index.html
+++ b/index.html
@@ -1392,7 +1392,7 @@ MUST have a <a>type</a> specified.
               <td>
 <code>VerifiablePresentation</code> and, optionally, a more specific
 <a>verifiable presentation</a> <a>type</a>. For example,<br>
-<code>"type": ["VerifiablePresentation", "CredentialManagerPresentation"]</code>
+<code>"type": ["VerifiablePresentation", "ExamplePresentation"]</code>
               </td>
             </tr>
 
@@ -1403,7 +1403,7 @@ MUST have a <a>type</a> specified.
               <td>
 <code>VerifiablePresentation</code> and, optionally, a more specific
 <a>verifiable presentation</a> <a>type</a>. For example,<br>
-<code>"type": ["VerifiablePresentation", "CredentialManagerPresentation"]</code>
+<code>"type": ["VerifiablePresentation", "ExamplePresentation"]</code>
               </td>
             </tr>
 
@@ -1433,7 +1433,7 @@ A valid <a>credential</a> status <a>type</a>. For example,<br>
               </td>
               <td>
 A valid terms of use <a>type</a>. For example,<br>
-<code>"type": "OdrlPolicy2017"</code>)
+<code>"type": "ExampleTermsPolicy"</code>)
               </td>
             </tr>
 
@@ -1443,7 +1443,7 @@ A valid terms of use <a>type</a>. For example,<br>
               </td>
               <td>
 A valid evidence <a>type</a>. For example,<br>
-<code>"type": "DocumentVerification2018"</code>
+<code>"type": "ExampleEvidence"</code>
               </td>
             </tr>
 
@@ -1969,7 +1969,7 @@ The example below shows a <a>verifiable presentation</a> that embeds
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
-  "type": ["VerifiablePresentation", "CredentialManagerPresentation"],
+  "type": ["VerifiablePresentation", "ExamplePresentation"],
   <span class="highlight">"verifiableCredential": [{ <span class="comment">...</span> }],
   "proof": [{ <span class="comment">...</span> }]</span>
 }


### PR DESCRIPTION
This PR updates 3 example types used in the spec to make them clear they are examples.
It is editorial.

fixes #1125 
fixes #1124 
fixes #1123


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1170.html" title="Last updated on Jun 26, 2023, 8:13 PM UTC (053ed5f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1170/329d6f8...brentzundel:053ed5f.html" title="Last updated on Jun 26, 2023, 8:13 PM UTC (053ed5f)">Diff</a>