### PR TITLE
add issue numbers to at risk extension points

### DIFF
--- a/index.html
+++ b/index.html
@@ -2696,7 +2696,7 @@ the <a>verifier</a> to <code>https://university.example/refresh/3732</code>.
       <section>
         <h3>Terms of Use</h3>
 
-        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+        <p class="issue" data-number="1010" title="(AT RISK) Feature depends on demonstration of independent implementations">
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase.
@@ -2868,7 +2868,7 @@ appropriate section of the Verifiable Credentials Implementation Guidelines
       <section>
         <h3>Evidence</h3>
 
-        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+        <p class="issue" data-number="870" title="(AT RISK) Feature depends on demonstration of independent implementations">
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase. If


### PR DESCRIPTION
This PR is purely editorial, it adds issue numbers to at risk extension points `evidence` (#1010) and `termsOfUse` (#870)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1171.html" title="Last updated on Jun 26, 2023, 8:30 PM UTC (fa1c829)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1171/329d6f8...brentzundel:fa1c829.html" title="Last updated on Jun 26, 2023, 8:30 PM UTC (fa1c829)">Diff</a>