### PR TITLE
remove 'credential' and 'presentation' from 'type' examples table

### DIFF
--- a/index.html
+++ b/index.html
@@ -1363,8 +1363,7 @@ MUST have a <a>type</a> specified.
           <tbody>
             <tr>
               <td>
-<a>Verifiable credential</a>&nbsp;object <br />(a subclass of a
-<a href="#credentials">credential</a>&nbsp;object)
+<a>Verifiable credential</a>&nbsp;object
               </td>
               <td>
 <code>VerifiableCredential</code> and, optionally, a more specific
@@ -1375,30 +1374,7 @@ MUST have a <a>type</a> specified.
 
             <tr>
               <td>
-<a href="#credentials">Credential</a>&nbsp;object
-              </td>
-              <td>
-<code>VerifiableCredential</code> and, optionally, a more specific
-<a>verifiable credential</a> <a>type</a>. For example,<br>
-<code>"type": ["VerifiableCredential", "ExampleDegreeCredential"]</code>
-              </td>
-            </tr>
-
-            <tr>
-              <td>
-<a>Verifiable presentation</a>&nbsp;object <br />(a subclass of a
-<a href="#presentations">presentation</a>&nbsp;object)
-              </td>
-              <td>
-<code>VerifiablePresentation</code> and, optionally, a more specific
-<a>verifiable presentation</a> <a>type</a>. For example,<br>
-<code>"type": ["VerifiablePresentation", "CredentialManagerPresentation"]</code>
-              </td>
-            </tr>
-
-            <tr>
-              <td>
-<a href="#presentations">Presentation</a>&nbsp;object
+<a>Verifiable presentation</a>&nbsp;object
               </td>
               <td>
 <code>VerifiablePresentation</code> and, optionally, a more specific


### PR DESCRIPTION
This PR attempts to continue addressing PR #1126 by removing `credential` and `presentation` from the `type` example table.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1179.html" title="Last updated on Jul 3, 2023, 7:15 PM UTC (37269ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1179/54d87d7...brentzundel:37269ec.html" title="Last updated on Jul 3, 2023, 7:15 PM UTC (37269ec)">Diff</a>