### PR TITLE
fix typo in vp+ld+json IANA considerations

### DIFF
--- a/index.html
+++ b/index.html
@@ -5458,7 +5458,7 @@ Extensions of Verifiable Credentials Data Model 1.0</a>
   </p>
 
   <p>
-    This media type can be used with credentials secured using an <a>external proof</a>.
+    This media type can be used with presentations secured using an <a>external proof</a>.
   </p>
   <p>A [[JSON-LD]] context is expected to be present in the body of the document, and as indicated by the presence of `ld+json` in the media type, the credential is expected to be a valid <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD document</a>.</p>
 </section>


### PR DESCRIPTION
This PR fixes #1161 by changing the word `credential` to the word `presentation` in the IANA considerations section for the verifiable presentations media type `vp+ld+json`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1180.html" title="Last updated on Jul 5, 2023, 11:03 PM UTC (216941b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1180/7c44300...brentzundel:216941b.html" title="Last updated on Jul 5, 2023, 11:03 PM UTC (216941b)">Diff</a>