### PR TITLE
Add interoperable way for holder-asserted claims in a VP

### DIFF
--- a/diagrams/ecosystemdetail.svg
+++ b/diagrams/ecosystemdetail.svg
@@ -67,12 +67,12 @@
 
 <path class="link" d="m710 318l-550 20"/>
 <text x="390" y="370" role="heading" aria-level="2">Check Status</text>
-<text x="380" y="385" font-weight="bold">Does not preserve privacy</text>
+<text x="380" y="385" font-weight="bold">might NOT preserve privacy</text>
 <text x="430" y="400">repeatable</text>
 
 <path class="link" d="m730 345c-200 30 -240 140 -250 195"/>
 <text x="540" y="480" role="heading" aria-level="2">Check Status</text>
-<text x="540" y="495" font-weight="bold">MAY preserve privacy</text>
+<text x="540" y="495" font-weight="bold">MIGHT preserve privacy</text>
 <text x="580" y="510">repeatable</text>
 
 <rect fill="#fcc" x="410" y="570" width="135" height="85"/>

--- a/index.html
+++ b/index.html
@@ -2084,7 +2084,7 @@ mechanism as the <a>verifiable presentation</a>.
   "holder": "did:example:12345678",
   "verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
-    "type": ["VerifiableCredential", "SelfAssertedCredential", "ExampleFoodPreferenceCredential"],
+    "type": ["VerifiableCredential", "ExampleFoodPreferenceCredential"],
     "issuer": "did:example:12345678",
     "credentialSubject": {
       "favoriteCheese": "Gouda"
@@ -2108,14 +2108,14 @@ self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "type": ["VerifiablePresentation", "ExamplePresentation"],
-  <span class="highlight">"id": "http://example.com/presentation/5223"</span>,
+  <span class="highlight">"id": "urn:uuid:313801ba-24b7-11ee-be02-ff560265cf9b"</span>,
   "holder": "did:example:12345678",
   "verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
     "type": ["VerifiableCredential", "ExampleTimeLimitCredential"],
     "issuer": "did:example:12345678",
     "credentialSubject": {
-      <span class="highlight">"id": "http://example.com/presentation/5223"</span>,
+      <span class="highlight">"id": "urn:uuid:313801ba-24b7-11ee-be02-ff560265cf9b"</span>,
       "validUntil": "2024-01-01T19:23:24Z"
     },
     { <span class="comment">...</span> }

--- a/index.html
+++ b/index.html
@@ -2033,15 +2033,24 @@ encoding would be determined by the schema.
         <section>
           <h4>Presentations Including Holder Claims</h4>
           <p>
-A <a>holder</a> MAY use the <code>verifiableCredential</code>
-<a>property</a> in a <a>verifiable presentation</a> to include
-<a>verifiable credentials</a> from any <a>issuer</a>, including
-themselves. When the <a>issuer</a> of a <a>verifiable credential</a>
-is the <a>holder</a>, its <a>claims</a> are considered to be
-self-asserted. These self-asserted claims can be secured by their
-own mechanism like any other <a>verifiable credential</a> or by
-the same mechanism that secures the <a>verifiable presentation</a>
-in which they are included.
+A <a>holder</a> MAY use the <code>verifiableCredential</code> <a>property</a> in
+a <a>verifiable presentation</a> to include <a>verifiable credentials</a> from
+any <a>issuer</a>, including themselves. When the <a>issuer</a> of a
+<a>verifiable credential</a> is the <a>holder</a>, its <a>claims</a> are
+considered to be self-asserted. These self-asserted claims can be secured by
+their own mechanism like any other <a>verifiable credential</a> or by the same
+mechanism that secures the <a>verifiable presentation</a> in which they are
+included.
+          </p>
+          <p>
+The <a>subject</a> of these self-asserted <a>claims</a> is not limited and can
+include statements about the <a>holder</a>, one of the other included
+<a>verifiable credentials</a>, or even the <a>verifiable presentation</a> in
+which the self-asserted <a>verifiable credential</a> is included. In each of
+these cases the <code>CredentialSubject</code> would have an <code>id</code>
+<a>property</a> that matches the <code>id</code> of the <a>subject</a>. This is
+no different than how it is done in <a>verifiable credentials</a> that are not
+self-asserted.
           </p>
           <p>
 A <a>verifiable presentation</a> that includes a self-asserted

--- a/index.html
+++ b/index.html
@@ -2045,28 +2045,41 @@ secured by the same mechanism that secures the <a>verifiable presentation</a> in
 which they are included.
           </p>
           <p>
+A <a>verifiable presentation</a> that includes a self-asserted
+<a>verifiable credential</a> that is only secured using the same mechanism as
+the <a>verifiable presentation</a> MUST include a <code>holder</code>
+<a>property</a>.
+          </p>
+          <p>
 A self-asserted <a>verifiable credential</a> that has been included in the value
 of the <code>verifiableCredential</code> <a>property</a> of a
 <a>verifiable presentation</a> MUST include the following properties:
-        </p>
+          </p>
 
         <dl>
           <dt><var>type</var></dt>
           <dd>
 The <code>type</code> <a>property</a> is required. The value MUST be
-<code>VerifiableCredential</code> and IT IS RECOMMENDED that an additional value
-<code>SelfAssertedCredential</code> be included. For example,<br>
-<code>"type": ["VerifiableCredential", "SelfAssertedCredential"]</code>
+<code>VerifiableCredential</code> and IT IS RECOMMENDED that the additional
+value <code>SelfAssertedCredential</code> be included. Additional types are also
+acceptable. For example,<br>
+<code>"type": ["VerifiableCredential", "SelfAssertedCredential", "ExampleTypeCredential"]</code>
           </dd>
           <dt><var>issuer</var></dt>
           <dd>
-The <code>issuer</code> <a>property</a> is required. The value MUST be identical
-to the <code>holder</code> <a>property</a> of the <a>verifiable presentation</a>.
+The <code>issuer</code> <a>property</a> is required. For self-asserted
+<a>verifiable credentials</a> that are secured using the same mechanism as the
+<a>verifiable presentation</a>, the value MUST be identical to the
+<code>holder</code> <a>property</a> of the <a>verifiable presentation</a>.
+Self-asserted <a>verifiable credentials</a> that use their own securing
+mechanism MUST follow the normative guidance for the <code>issuer</code>
+<a>property</a> in Section <a href="#issuer"></a>.
           </dd>
         </dl>
         <p>
 The example below shows a <a>verifiable presentation</a> that embeds a
-self-asserted <a>verifiable credential</a>.
+self-asserted <a>verifiable credential</a> that is secured using the same
+mechanism as the <a>verifiable presentation</a>.
         </p>
 
         <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential">

--- a/index.html
+++ b/index.html
@@ -2039,7 +2039,8 @@ In addition to <a>claims</a> from an <a>issuer</a> in the form of
 are considered to be self-asserted. If present, these self-asserted
 <a>claims</a> MUST be formatted as a <a>verifiable credential</a> and included
 in the value of the <code>verifiableCredential</code> <a>property</a> of the
-<a>verifiable presentation</a>. These self-asserted claims are considered to be
+<a>verifiable presentation</a>. These self-asserted claims can either use their
+own securing mechanism like any other <a>verifiable credential</a> or be
 secured by the same mechanism that secures the <a>verifiable presentation</a> in
 which they are included.
           </p>

--- a/index.html
+++ b/index.html
@@ -2033,16 +2033,15 @@ encoding would be determined by the schema.
         <section>
           <h4>Presentations Including Holder Claims</h4>
           <p>
-In addition to <a>claims</a> from an <a>issuer</a> in the form of
-<a>verifiable credentials</a>, a <a>verifiable presentation</a> MAY include
-<a>claims</a> directly from the <a>holder</a>. These <a>holder</a> <a>claims</a>
-are considered to be self-asserted. If present, these self-asserted
-<a>claims</a> MUST be formatted as a <a>verifiable credential</a> and included
-in the value of the <code>verifiableCredential</code> <a>property</a> of the
-<a>verifiable presentation</a>. These self-asserted claims can be secured
-by their own mechanism like any other <a>verifiable credential</a> or by
-the same mechanism that secures the <a>verifiable presentation</a> in which
-they are included.
+A <a>holder</a> MAY use the <code>verifiableCredential</code>
+<a>property</a> in a <a>verifiable presentation</a> to include
+<a>verifiable credentials</a> from any <a>issuer</a>, including
+themselves. When the <a>issuer</a> of a <a>verifiable credential</a>
+is the <a>holder</a>, its <a>claims</a> are considered to be
+self-asserted. These self-asserted claims can be secured by their
+own mechanism like any other <a>verifiable credential</a> or by
+the same mechanism that secures the <a>verifiable presentation</a>
+in which they are included.
           </p>
           <p>
 A <a>verifiable presentation</a> that includes a self-asserted

--- a/index.html
+++ b/index.html
@@ -2053,8 +2053,8 @@ of the <code>verifiableCredential</code> <a>property</a> of a
           <dt><var>type</var></dt>
           <dd>
 The <code>type</code> <a>property</a> is required. The value MUST be
-<code>VerifiableCredential</code> and <code>SelfAssertedCredential</code>.For
-example,<br>
+<code>VerifiableCredential</code> and IT IS RECOMMENDED that an additional value
+<code>SelfAssertedCredential</code> be included. For example,<br>
 <code>"type": ["VerifiableCredential", "SelfAssertedCredential"]</code>
           </dd>
           <dt><var>issuer</var></dt>
@@ -2078,7 +2078,7 @@ self-asserted <a>verifiable credential</a>.
   "holder": "did:example:12345678",
   "verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
-    "type": ["VerifiableCredential", "SelfAssertedCredential"],
+    "type": ["VerifiableCredential", "SelfAssertedCredential", "ExampleFoodPreferenceCredential"],
     "issuer": "did:example:12345678",
     "credentialSubject": {
       "favoriteCheese": "Gouda"

--- a/index.html
+++ b/index.html
@@ -2030,6 +2030,65 @@ encoding would be determined by the schema.
             </figcaption>
           </figure>
         </section>
+        <section>
+          <h4>Presentations Including Holder Claims</h4>
+          <p>
+In addition to <a>claims</a> from an <a>issuer</a> in the form of
+<a>verifiable credentials</a>, a <a>verifiable presentation</a> MAY include
+<a>claims</a> directly from the <a>holder</a>. These <a>holder</a> <a>claims</a>
+are considered to be self-asserted. If present, these self-asserted
+<a>claims</a> MUST be formatted as a <a>verifiable credential</a> and included
+in the value of the <code>verifiableCredential</code> <a>property</a> of the
+<a>verifiable presentation</a>. These self-asserted claims are considered to be
+secured by the same mechanism that secures the <a>verifiable presentation</a> in
+which they are included.
+          </p>
+          <p>
+A self-asserted <a>verifiable credential</a> that has been included in the value
+of the <code>verifiableCredential</code> <a>property</a> of a
+<a>verifiable presentation</a> MUST include the following properties:
+        </p>
+
+        <dl>
+          <dt><var>type</var></dt>
+          <dd>
+The <code>type</code> <a>property</a> is required. The value MUST be
+<code>VerifiableCredential</code> and <code>SelfAssertedCredential</code>.For
+example,<br>
+<code>"type": ["VerifiableCredential", "SelfAssertedCredential"]</code>
+          </dd>
+          <dt><var>issuer</var></dt>
+          <dd>
+The <code>issuer</code> <a>property</a> is required. The value MUST be identical
+to the <code>holder</code> <a>property</a> of the <a>verifiable presentation</a>.
+          </dd>
+        </dl>
+        <p>
+The example below shows a <a>verifiable presentation</a> that embeds a
+self-asserted <a>verifiable credential</a>.
+        </p>
+
+        <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": ["VerifiablePresentation", "ExamplePresentation"],
+  "holder": "did:example:12345678",
+  "verifiableCredential": [{
+    "@context": "https://www.w3.org/ns/credentials/v2",
+    "type": ["VerifiableCredential", "SelfAssertedCredential"],
+    "issuer": "did:example:12345678",
+    "credentialSubject": {
+      "favoriteCheese": "Gouda"
+    },
+    { <span class="comment">...</span> }
+  }],
+  "proof": [{ <span class="comment">...</span> }]</span>
+}
+        </pre>
+        </section>
       </section>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -2047,7 +2047,7 @@ The <a>subject(s)</a> of these self-asserted <a>claims</a> are not limited, so
 these <a>claims</a> can include statements about the <a>holder</a>, one of the
 other included <a>verifiable credentials</a>, or even the <a>verifiable
 presentation</a> in which the self-asserted <a>verifiable credential</a> is
-included. In each of these cases, the <code>id</code> <a>property</a>
+included. In each case, the <code>id</code> <a>property</a>
 is used to identify the specific <a>subject</a>, in the object where the
 <a>claims</a> about it are made, just as it is done in
 <a>verifiable credentials</a> that are not self-asserted.
@@ -2063,10 +2063,11 @@ All of the normative requirements defined for <a>verifiable credentials</a>
 apply to self-asserted <a>verifiable credentials</a>.
           </p>
           <p>
-For self-asserted <a>verifiable credentials</a> that are secured using the same
+When a self-asserted <a>verifiable credential</a> is secured using the same
 mechanism as the <a>verifiable presentation</a>, the value of the
-<code>issuer</code> <a>property</a> MUST be identical to the <code>holder</code>
-<a>property</a> of the <a>verifiable presentation</a>.
+<code>issuer</code> <a>property</a> of the <a>verifiable credential</a>
+MUST be identical to the <code>holder</code> <a>property</a> of the
+<a>verifiable presentation</a>.
           </p>
           <p>
 The example below shows a <a>verifiable presentation</a> that embeds a
@@ -2074,7 +2075,7 @@ self-asserted <a>verifiable credential</a> that is secured using the same
 mechanism as the <a>verifiable presentation</a>.
           </p>
 
-          <pre class="example nohighlight" title="A secured verifiable presentation relying on an embedded proof, including a self-asserted verifiable credential">
+          <pre class="example nohighlight" title="A verifiable presentation, secured with an embedded proof, with a self-asserted verifiable credential">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2101,7 +2102,7 @@ self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
 <a>verifiable presentation</a>.
           </p>
 
-          <pre class="example nohighlight" title="A secured verifiable presentation, relying on an embedded proof, with a self-asserted verifiable credential about the verifiable presentation">
+          <pre class="example nohighlight" title="A verifiable presentation, secured with an embedded proof, with a self-asserted verifiable credential about the verifiable presentation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",

--- a/index.html
+++ b/index.html
@@ -2039,10 +2039,10 @@ In addition to <a>claims</a> from an <a>issuer</a> in the form of
 are considered to be self-asserted. If present, these self-asserted
 <a>claims</a> MUST be formatted as a <a>verifiable credential</a> and included
 in the value of the <code>verifiableCredential</code> <a>property</a> of the
-<a>verifiable presentation</a>. These self-asserted claims can either use their
-own securing mechanism like any other <a>verifiable credential</a> or be
-secured by the same mechanism that secures the <a>verifiable presentation</a> in
-which they are included.
+<a>verifiable presentation</a>. These self-asserted claims can be secured
+by their own mechanism like any other <a>verifiable credential</a> or by
+the same mechanism that secures the <a>verifiable presentation</a> in which
+they are included.
           </p>
           <p>
 A <a>verifiable presentation</a> that includes a self-asserted
@@ -2059,10 +2059,10 @@ of the <code>verifiableCredential</code> <a>property</a> of a
         <dl>
           <dt><var>type</var></dt>
           <dd>
-The <code>type</code> <a>property</a> is required. The value MUST be
-<code>VerifiableCredential</code> and IT IS RECOMMENDED that the additional
-value <code>SelfAssertedCredential</code> be included. Additional types are also
-acceptable. For example,<br>
+The <code>type</code> <a>property</a> is required. One value MUST be
+<code>VerifiableCredential</code>, and it is RECOMMENDED that another
+value be <code>SelfAssertedCredential</code>. Additional types MAY also
+be included. For example,<br>
 <code>"type": ["VerifiableCredential", "SelfAssertedCredential", "ExampleTypeCredential"]</code>
           </dd>
           <dt><var>issuer</var></dt>

--- a/index.html
+++ b/index.html
@@ -2060,32 +2060,21 @@ the <a>verifiable presentation</a> MUST include a <code>holder</code>
           </p>
           <p>
 All of the normative requirements defined for <a>verifiable credentials</a>
-apply to self-asserted <a>verifiable credentials</a>. Some additional
-considerations follow:
+apply to self-asserted <a>verifiable credentials</a>.
           </p>
-
-        <dl>
-          <dt><var>type</var></dt>
-          <dd>
-It is RECOMMENDED that <code>SelfAssertedCredential</code> be included as an
-additional <code>type</code> value. For example,<br>
-<code>"type": ["VerifiableCredential", "SelfAssertedCredential", "ExampleTypeCredential"]</code>
-          </dd>
-          <dt><var>issuer</var></dt>
-          <dd>
+          <p>
 For self-asserted <a>verifiable credentials</a> that are secured using the same
 mechanism as the <a>verifiable presentation</a>, the value of the
 <code>issuer</code> <a>property</a> MUST be identical to the <code>holder</code>
 <a>property</a> of the <a>verifiable presentation</a>.
-          </dd>
-        </dl>
-        <p>
+          </p>
+          <p>
 The example below shows a <a>verifiable presentation</a> that embeds a
 self-asserted <a>verifiable credential</a> that is secured using the same
 mechanism as the <a>verifiable presentation</a>.
-        </p>
+          </p>
 
-        <pre class="example nohighlight" title="A secured verifiable presentation relying on an embedded proof, including a self-asserted verifiable credential">
+          <pre class="example nohighlight" title="A secured verifiable presentation relying on an embedded proof, including a self-asserted verifiable credential">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2104,15 +2093,15 @@ mechanism as the <a>verifiable presentation</a>.
   }],
   "proof": [{ <span class="comment">...</span> }]</span>
 }
-        </pre>
-                <p>
+          </pre>
+          <p>
 The example below shows a <a>verifiable presentation</a> that embeds a
 self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
 <a>verifiable presentation</a>. It is secured using the same mechanism as the
 <a>verifiable presentation</a>.
-        </p>
+          </p>
 
-        <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential about the verifiable presentation">
+          <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential about the verifiable presentation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2133,7 +2122,7 @@ self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
   }],
   "proof": [{ <span class="comment">...</span> }]</span>
 }
-        </pre>
+          </pre>
         </section>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -2085,7 +2085,7 @@ self-asserted <a>verifiable credential</a> that is secured using the same
 mechanism as the <a>verifiable presentation</a>.
         </p>
 
-        <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential">
+        <pre class="example nohighlight" title="A secured verifiable presentation relying on an embedded proof, including a self-asserted verifiable credential">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",

--- a/index.html
+++ b/index.html
@@ -2813,7 +2813,7 @@ the <a>verifier</a> to <code>https://university.example/refresh/3732</code>.
       <section>
         <h3>Terms of Use</h3>
 
-        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+        <p class="issue" data-number="1010" title="(AT RISK) Feature depends on demonstration of independent implementations">
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase.
@@ -2985,7 +2985,7 @@ appropriate section of the Verifiable Credentials Implementation Guidelines
       <section>
         <h3>Evidence</h3>
 
-        <p class="issue" title="(AT RISK) Feature depends on demonstration of independent implementations">
+        <p class="issue" data-number="870" title="(AT RISK) Feature depends on demonstration of independent implementations">
 This feature is at risk and will be removed from the specification if at least
 two independent, interoperable implementations are not demonstrated for a
 single extension type by the end of the Candidate Recommendation Phase. If

--- a/index.html
+++ b/index.html
@@ -2113,11 +2113,11 @@ self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
   "holder": "did:example:12345678",
   "verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
-    "type": ["VerifiableCredential", "ExampleTimeLimitCredential"],
+    "type": ["VerifiableCredential", "ExampleAssertCredential"],
     "issuer": "did:example:12345678",
     "credentialSubject": {
       <span class="highlight">"id": "urn:uuid:313801ba-24b7-11ee-be02-ff560265cf9b"</span>,
-      "validUntil": "2024-01-01T19:23:24Z"
+      "assertion": "This VP is submitted by the subject as evidence of a legal right to drive"
     },
     { <span class="comment">...</span> }
   }],

--- a/index.html
+++ b/index.html
@@ -2101,7 +2101,7 @@ self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
 <a>verifiable presentation</a>.
           </p>
 
-          <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential about the verifiable presentation">
+          <pre class="example nohighlight" title="A secured verifiable presentation, relying on an embedded proof, with a self-asserted verifiable credential about the verifiable presentation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",

--- a/index.html
+++ b/index.html
@@ -2059,29 +2059,24 @@ the <a>verifiable presentation</a> MUST include a <code>holder</code>
 <a>property</a>.
           </p>
           <p>
-A self-asserted <a>verifiable credential</a> that has been included in the value
-of the <code>verifiableCredential</code> <a>property</a> of a
-<a>verifiable presentation</a> MUST include the following properties:
+All of the normative requirements defined for <a>verifiable credentials</a>
+apply to self-asserted <a>verifiable credentials</a>. Some additional
+considerations follow:
           </p>
 
         <dl>
           <dt><var>type</var></dt>
           <dd>
-The <code>type</code> <a>property</a> is required. One value MUST be
-<code>VerifiableCredential</code>, and it is RECOMMENDED that another
-value be <code>SelfAssertedCredential</code>. Additional types MAY also
-be included. For example,<br>
+It is RECOMMENDED that <code>SelfAssertedCredential</code> be included as an
+additional <code>type</code> value. For example,<br>
 <code>"type": ["VerifiableCredential", "SelfAssertedCredential", "ExampleTypeCredential"]</code>
           </dd>
           <dt><var>issuer</var></dt>
           <dd>
-The <code>issuer</code> <a>property</a> is required. For self-asserted
-<a>verifiable credentials</a> that are secured using the same mechanism as the
-<a>verifiable presentation</a>, the value MUST be identical to the
-<code>holder</code> <a>property</a> of the <a>verifiable presentation</a>.
-Self-asserted <a>verifiable credentials</a> that use their own securing
-mechanism MUST follow the normative guidance for the <code>issuer</code>
-<a>property</a> in Section <a href="#issuer"></a>.
+For self-asserted <a>verifiable credentials</a> that are secured using the same
+mechanism as the <a>verifiable presentation</a>, the value of the
+<code>issuer</code> <a>property</a> MUST be identical to the <code>holder</code>
+<a>property</a> of the <a>verifiable presentation</a>.
           </dd>
         </dl>
         <p>
@@ -2104,6 +2099,35 @@ mechanism as the <a>verifiable presentation</a>.
     "issuer": "did:example:12345678",
     "credentialSubject": {
       "favoriteCheese": "Gouda"
+    },
+    { <span class="comment">...</span> }
+  }],
+  "proof": [{ <span class="comment">...</span> }]</span>
+}
+        </pre>
+                <p>
+The example below shows a <a>verifiable presentation</a> that embeds a
+self-asserted <a>verifiable credential</a> that holds <a>claims</a> about the
+<a>verifiable presentation</a>. It is secured using the same mechanism as the
+<a>verifiable presentation</a>.
+        </p>
+
+        <pre class="example nohighlight" title="Verifiable presentation with a self-asserted verifiable credential about the verifiable presentation">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": ["VerifiablePresentation", "ExamplePresentation"],
+  <span class="highlight">"id": "http://example.com/presentation/5223"</span>,
+  "holder": "did:example:12345678",
+  "verifiableCredential": [{
+    "@context": "https://www.w3.org/ns/credentials/v2",
+    "type": ["VerifiableCredential", "ExampleTimeLimitCredential"],
+    "issuer": "did:example:12345678",
+    "credentialSubject": {
+      <span class="highlight">"id": "http://example.com/presentation/5223"</span>,
+      "validUntil": "2024-01-01T19:23:24Z"
     },
     { <span class="comment">...</span> }
   }],


### PR DESCRIPTION
This PR addresses #860 by introducing normative guidance for a holder to include self-asserted claims inside of a VP.
It is based on the conversation in #860 where it was suggested that the holder should construct a VC with the self-asserted claims and include that in the VP.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1186.html" title="Last updated on Jul 19, 2023, 4:55 PM UTC (9559c36)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1186/7c44300...brentzundel:9559c36.html" title="Last updated on Jul 19, 2023, 4:55 PM UTC (9559c36)">Diff</a>