### PR TITLE
Add section on media type precision.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3618,7 +3618,7 @@ This also applies to media types that allow for transformation into
 media type used to communicate it.
         </p>
 
-        <section>
+        <section class="informative">
           <h3>Media Type Precision</h3>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -3619,12 +3619,12 @@ media type used to communicate it.
         </p>
 
         <section>
-          <h3>Media Type Leniency</h3>
+          <h3>Media Type Precision</h3>
 
           <p>
-At times, developers or systems might utilize incorrect media types to convey
+At times, developers or systems might use lower precision media types to convey
 <a>verifiable credentials</a> or <a>verifiable presentations</a>. Some of the
-reasons for use of incorrect media types include:
+reasons for use of lower precision media types include:
           </p>
 
           <ul>
@@ -3639,18 +3639,20 @@ media type of `application/json` and `.jsonld` might result in a media type of
 `application/ld+json`.
             </li>
             <li>
-An implementer misimplements the media type that is transmitted over a protocol
-for a particular transaction. For example, using `application/json` instead of
-`application/vp+ld+json`.
+A protocol requires a less precise media type for a particular transaction; for
+example, `application/json` instead of `application/vp+ld+json`, 
             </li>
           </ul>
 
           <p>
 Implementers are urged to not raise errors when it is possible to determine the
-intended media type from a payload. For example, if an application is expecting
-an `application/vc+ld+json` payload, but `application/json` or
-`application/ld+json` is received instead, then the application might perform
-the following steps to determine a more accurate media type:
+intended media type from a payload, provided that the media type used is
+acceptable in the given protocol. For example, if an application only accepts
+payloads that conform to the rules associated with the `application/vc+ld+json`
+media type, but the payload is tagged with `application/json` or
+`application/ld+json` instead, the application might perform the following
+steps to determine whether the payload also conforms to the higher precision
+media type:
           </p>
 
           <ol>
@@ -3663,20 +3665,29 @@ Ensure that the first element of the `@context` field matches
             </li>
             <li>
 Assume an `application/vp+ld+json` media type if the JSON document contains a
-top-level `type` field containing a `VerifiablePresentation` element.
+top-level `type` field containing a `VerifiablePresentation` element. Additional
+subsequent checks are still expected to be performed (according to this
+specification) to ensure the payload expresses a conformant Verifiable Presentation.
             </li>
             <li>
 Assume an `application/vc+ld+json` media type if the JSON document contains a
-top-level `type` field containing a `VerifiableCredential` element.
+top-level `type` field containing a `VerifiableCredential` element. Additional
+subsequent checks are still expected to be performed (according to this
+specification) to ensure the payload expresses a conformant Verifiable Credential.
             </li>
           </ol>
 
           <p>
-Implementers are advised to, when possible, use the most accurate media type for
-all payloads defined by this specification. Implementers are also advised to be
-lenient in what they accept if it leads to better system robustness. In other
-words, implementers are to be conservative in what their software produces, but
-liberal in what their applications accept from other systems.
+Whenever possible, implementers are advised to use the most precise (the highest
+precision) media type for all payloads defined by this specification.
+Implementers are also advised to recognize that a payload tagged with a lower
+precision media type does not mean that the payload does not meet the rules
+necessary to tag it with a higher precision type. Similarly, a payload tagged
+with a higher precision media type does not mean that the payload will meet the
+requirements associated with the media type. Receivers of payloads, regardless
+of their associated media type, are expected to perform appropriate checks to
+ensure that payloads conform with the requirements for their use in a given
+system.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -3618,6 +3618,68 @@ This also applies to media types that allow for transformation into
 media type used to communicate it.
         </p>
 
+        <section>
+          <h3>Media Type Leniency</h3>
+
+          <p>
+At times, developers or systems might utilize incorrect media types to convey
+<a>verifiable credentials</a> or <a>verifiable presentations</a>. Some of the
+reasons for use of incorrect media types include:
+          </p>
+
+          <ul>
+            <li>
+A web server defaults to `text/plain` or `application/octet-stream` when a file
+extension is not available and it cannot determine the media type.
+            </li>
+            <li>
+A developer adds a file extension that leads to a media type that is less
+specific than the content of the file. For example, `.json` could result in a
+media type of `application/json` and `.jsonld` might result in a media type of
+`application/ld+json`.
+            </li>
+            <li>
+An implementer misimplements the media type that is transmitted over a protocol
+for a particular transaction. For example, using `application/json` instead of
+`application/vp+ld+json`.
+            </li>
+          </ul>
+
+          <p>
+Implementers are urged to not raise errors when it is possible to determine the
+intended media type from a payload. For example, if an application is expecting
+an `application/vc+ld+json` payload, but `application/json` or
+`application/ld+json` is received instead, then the application might perform
+the following steps to determine a more accurate media type:
+          </p>
+
+          <ol>
+            <li>
+Parse the payload as a JSON document.
+            </li>
+            <li>
+Ensure that the first element of the `@context` field matches
+`https://www.w3.org/2018/credentials/v2`.
+            </li>
+            <li>
+Assume an `application/vp+ld+json` media type if the JSON document contains a
+top-level `type` field containing a `VerifiablePresentation` element.
+            </li>
+            <li>
+Assume an `application/vc+ld+json` media type if the JSON document contains a
+top-level `type` field containing a `VerifiableCredential` element.
+            </li>
+          </ol>
+
+          <p>
+Implementers are advised to, when possible, use the most accurate media type for
+all payloads defined by this specification. Implementers are also advised to be
+lenient in what they accept if it leads to better system robustness. In other
+words, implementers are to be conservative in what their software produces, but
+liberal in what their applications accept from other systems.
+          </p>
+        </section>
+
       </section>
 
       <section>


### PR DESCRIPTION
This PR attempts to address issue #1015 and #1040 by adding guidance on being lenient when processing less precise media types. It does not go as far as providing normative guidance (as there are many correct ways to do content sniffing, and we probably don't want to suggest one way to do it unless we're really, really sure about it being the only correct way).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1189.html" title="Last updated on Jul 14, 2023, 8:02 PM UTC (9799e5c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1189/4b1cb24...9799e5c.html" title="Last updated on Jul 14, 2023, 8:02 PM UTC (9799e5c)">Diff</a>