### PR TITLE
Remove outdated v1.0 JWT claim registrations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5300,64 +5300,11 @@ and <a>verifiable presentation</a>.
 
     <section class="appendix informative">
       <h2>IANA Considerations</h2>
-      <section id="json-web-token-claim-registrations">
-        <h3>JSON Web Token Claim Registrations</h3>
-        <p>
-          This section will be submitted to the Internet Engineering Steering Group
-          (IESG) for review, approval, and registration with IANA in the
-          "JSON Web Token Claims Registry".
-        </p>
 
-          <section id="vc-json-web-token-claim">
-            <h4>`vc`</h4>
-            <table>
-              <tr>
-                <th>Claim Name: </th>
-                <td>"vc" </td>
-              </tr>
-              <tr>
-                <th>Claim Description: </th>
-                <td>Verifiable Credential</td>
-              </tr>
-              <tr>
-                <th>Change Controller:  </th>
-                <td>W3C</td>
-              </tr>
-              <tr>
-                <th>Specification Document(s): </th>
-                <td>
-                <a href="https://www.w3.org/TR/vc-data-model/">Section 6.3.1.2: JSON Web Token
-                  Extensions of Verifiable Credentials Data Model 1.0</a>
-                </td>
-              </tr>
-            </table>
-          </section>
-
-          <section id="vp-json-web-token-claim">
-            <h4>`vp`</h4>
-            <table>
-              <tr>
-                <th>Claim Name: </th>
-                <td>"vp"</td>
-              </tr>
-              <tr>
-                <th>Claim Description: </th>
-                <td>Verifiable Presentation</td>
-              </tr>
-              <tr>
-                <th>Change Controller: </th>
-                <td>W3C</td>
-              </tr>
-              <tr>
-                <th>Specification Document(s):</th>
-                <td>
-                  <a href="https://www.w3.org/TR/vc-data-model/">Section 6.3.1.2: JSON Web Token
-                    Extensions of Verifiable Credentials Data Model 1.0</a>
-                </td>
-              </tr>
-            </table>
-          </section>
-        </section>
+      <p>
+This section will be submitted to the Internet Engineering Steering Group (IESG)
+for review, approval, and registration with IANA.
+      </p>
 
       <section id="vc-ld-media-type">
         <h2>application/vc+ld+json</h2>


### PR DESCRIPTION
This PR removes the outdated v1.0 IANA registrations for "vc" and "vp" (since that happened a while ago and they now exist in the JWT Claims registry here):

https://www.iana.org/assignments/jwt/jwt.xhtml

We don't need to keep these registration requests around, as they've been processed by IANA, and the request exists here (in perpetuity): https://www.w3.org/TR/vc-data-model/#iana-considerations


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1195.html" title="Last updated on Jul 12, 2023, 2:06 AM UTC (64fa61f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1195/eb58625...64fa61f.html" title="Last updated on Jul 12, 2023, 2:06 AM UTC (64fa61f)">Diff</a>