### PR TITLE
Add language around multiple schemas; update example

### DIFF
--- a/common.js
+++ b/common.js
@@ -118,7 +118,7 @@ var vcwg = {
       href: 'https://en.wikipedia.org/wiki/InterPlanetary_File_System',
       publisher: 'Wikipedia'
     },
-    'CREDENTIAL-SCHEMA-2023': {
+    'VC-JSON-SCHEMA-2023': {
       title: 'Verifiable Credentials JSON Schema 2023',
       href: 'https://www.w3.org/TR/vc-json-schema/',
       authors: ['Gabe Cohen', 'Orie Steele'],

--- a/index.html
+++ b/index.html
@@ -2489,7 +2489,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
     "type": "VerifiableCredentialSchema2023"
   },
   {
-    "id": "https://example.org/examples/name.json",
+    "id": "https://example.org/examples/person.json",
     "type": "JsonSchema2023"
   }]</span>
 }

--- a/index.html
+++ b/index.html
@@ -2445,7 +2445,7 @@ that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
             </p>
             <p>
-If multiple schemas are present, validity MUST be determined according to the
+If multiple schemas are present, validity is determined according to the
 processing rules outlined by each associated <code>credentialSchema</code> 
 <code>type</code> property.
             </p>

--- a/index.html
+++ b/index.html
@@ -2435,13 +2435,20 @@ the <a>verifiable credentials</a> that it issues:
         <dl>
           <dt><var>credentialSchema</var></dt>
           <dd>
-The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
+            <p>
+The value of the <code>credentialSchema</code> <a>property</a> SHOULD be one or
 more data schemas that provide <a>verifiers</a> with enough information to
-determine if the provided data conforms to the provided schema. Each
+determine if the provided data conforms to the provided schema(s). Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code>CredentialSchema2022</code>), and an <code>id</code> <a>property</a>
+<code>VerifiableCredentialSchema2023</code>), and an <code>id</code> <a>property</a>
 that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
+            </p>
+            <p>
+If multiple schemas are present, validity MUST be determined according to the
+processing rules outlined by each associated <code>credentialSchema</code> 
+<code>type</code> property.
+            </p>
           </dd>
         </dl>
 
@@ -2453,7 +2460,7 @@ vocabulary using <code>credentialSchema</code> that is locked to some content
 integrity protection mechanism. The <code>credentialSchema</code>
 <a>property</a> also makes it possible to perform syntactic checking on the
 <a>credential</a> and to use <a>verification</a> mechanisms such as JSON Schema
-[[?CREDENTIAL-SCHEMA-2023]] validation.
+[[?VC-JSON-SCHEMA-2023]] validation.
         </p>
 
         <pre class="example nohighlight"
@@ -2472,24 +2479,32 @@ integrity protection mechanism. The <code>credentialSchema</code>
     "degree": {
       "type": "ExampleBachelorDegree",
       "name": "Bachelor of Science and Arts"
+    },
+    "university": {
+      "type": "ExampleUniversity",
+      "name": "University of Examples, W3C"
     }
   },
-  <span class="highlight">"credentialSchema": {
+  <span class="highlight">"credentialSchema": [{
     "id": "https://example.org/examples/degree.json",
-    "type": "CredentialSchema2023"
-  }</span>
+    "type": "VerifiableCredentialSchema2023"
+  },
+  {
+    "id": "https://example.org/examples/university.json",
+    "type": "JsonSchema2023"
+  }]</span>
 }
         </pre>
 
         <p>
 In the example above, the <a>issuer</a> is specifying a
-<code>credentialSchema</code>, which points to a [[?CREDENTIAL-SCHEMA-2023]] file that
+<code>credentialSchema</code>, which points to a [[?VC-JSON-SCHEMA-2023]] file that
 can be used by a <a>verifier</a> to determine if the
 <a>verifiable credential</a> is well formed.
         </p>
 
         <p class="note" >
-For information about linkages to JSON Schema [[?CREDENTIAL-SCHEMA-2023]] or other
+For information about linkages to JSON Schema [[?VC-JSON-SCHEMA-2023]] or other
 optional <a>verification</a> mechanisms, see the Verifiable Credentials
 Implementation Guidelines [[VC-IMP-GUIDE]] document.
         </p>
@@ -2532,6 +2547,7 @@ In the example above, the <a>issuer</a> is specifying a
 data into a format which can then be used by a <a>verifier</a> to determine if
 the proof provided with the <a>verifiable credential</a> is valid.
         </p>
+
 
       </section>
 
@@ -4960,7 +4976,7 @@ If the <code>credentialSchema</code> property is available, the schema of a
 according to the <code>credentialSchema</code> <a>type</a> definition for the
 <a>verifiable credential</a> and the <a>verifier's</a> own schema evaluation
 criteria. For example, if the <code>credentialSchema</code>'s <code>type</code> value is
-[[?CREDENTIAL-SCHEMA-2023]], then a <a>verifier</a> can ensure a credential's
+[[?VC-JSON-SCHEMA-2023]], then a <a>verifier</a> can ensure a credential's
 data is valid against the given JSON Schema.
         </p>
       </section>
@@ -5168,7 +5184,7 @@ cryptographic hash.
         <p>
 The <a>verifiable credential</a> and <a>verifiable presentation</a> data models
 leverage a variety of underlying technologies including [[JSON-LD]] and
-[[?CREDENTIAL-SCHEMA-2023]]. This section will provide a comparison of the
+[[?VC-JSON-SCHEMA-2023]]. This section will provide a comparison of the
 <code>@context</code>, <code>type</code>, and <code>credentialSchema</code>
 properties, and cover some of the more specific use cases where it is possible
 to use these features of the data model.

--- a/index.html
+++ b/index.html
@@ -2471,7 +2471,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "id": "http://university.example/credentials/3732",
-  "type": ["VerifiableCredential", "ExampleDegreeCredential", "ExampleNameCredential"],
+  "type": ["VerifiableCredential", "ExampleDegreeCredential", "ExamplePersonCredential"],
   "issuer": "https://university.example/issuers/14",
   "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
@@ -2480,9 +2480,8 @@ integrity protection mechanism. The <code>credentialSchema</code>
       "type": "ExampleBachelorDegree",
       "name": "Bachelor of Science and Arts"
     },
-    "name": {
-      "firstName": "John",
-      "lastName": "Doe"
+    "alumniOf": {
+      "name": "Example University"
     }
   },
   <span class="highlight">"credentialSchema": [{

--- a/index.html
+++ b/index.html
@@ -2471,7 +2471,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "id": "http://university.example/credentials/3732",
-  "type": ["VerifiableCredential", "ExampleDegreeCredential"],
+  "type": ["VerifiableCredential", "ExampleDegreeCredential", "ExampleNameCredential"],
   "issuer": "https://university.example/issuers/14",
   "validFrom": "2010-01-01T19:23:24Z",
   "credentialSubject": {
@@ -2480,9 +2480,9 @@ integrity protection mechanism. The <code>credentialSchema</code>
       "type": "ExampleBachelorDegree",
       "name": "Bachelor of Science and Arts"
     },
-    "university": {
-      "type": "ExampleUniversity",
-      "name": "University of Examples, W3C"
+    "name": {
+      "firstName": "John",
+      "lastName": "Doe"
     }
   },
   <span class="highlight">"credentialSchema": [{
@@ -2490,7 +2490,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
     "type": "VerifiableCredentialSchema2023"
   },
   {
-    "id": "https://example.org/examples/university.json",
+    "id": "https://example.org/examples/name.json",
     "type": "JsonSchema2023"
   }]</span>
 }

--- a/index.html
+++ b/index.html
@@ -2436,7 +2436,7 @@ the <a>verifiable credentials</a> that it issues:
           <dt><var>credentialSchema</var></dt>
           <dd>
             <p>
-The value of the <code>credentialSchema</code> <a>property</a> SHOULD be one or
+The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
 more data schemas that provide <a>verifiers</a> with enough information to
 determine if the provided data conforms to the provided schema(s). Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,

--- a/index.html
+++ b/index.html
@@ -2440,7 +2440,7 @@ The value of the <code>credentialSchema</code> <a>property</a> SHOULD be one or
 more data schemas that provide <a>verifiers</a> with enough information to
 determine if the provided data conforms to the provided schema(s). Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code>VerifiableCredentialSchema2023</code>), and an <code>id</code> <a>property</a>
+<code>JsonSchema2023</code>), and an <code>id</code> <a>property</a>
 that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
             </p>
@@ -2486,7 +2486,7 @@ integrity protection mechanism. The <code>credentialSchema</code>
   },
   <span class="highlight">"credentialSchema": [{
     "id": "https://example.org/examples/degree.json",
-    "type": "VerifiableCredentialSchema2023"
+    "type": "JsonSchema2023"
   },
   {
     "id": "https://example.org/examples/person.json",


### PR DESCRIPTION
Fix #950
- Updated reference name to include the short name (`vc-json-schema`)
- Revised language to note processing of multiple schemas should be handled according to each specific type's rules
- Updated example to show multiple schemas (there are now examples with one and more than one schema)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1198.html" title="Last updated on Jul 17, 2023, 6:25 PM UTC (a40c3ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1198/3a0e423...a40c3ce.html" title="Last updated on Jul 17, 2023, 6:25 PM UTC (a40c3ce)">Diff</a>