### PR TITLE
Better not set §B as non-normative (minor editorial)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4988,7 +4988,7 @@ franchise. Policy information expressed by the <a>issuer</a> in the
       </section>
     </section>
 
-    <section class="appendix informative">
+    <section class="appendix">
       <h2>Contexts, Vocabularies, Types, and Credential Schemas</h2>
 
       <section class="normative">


### PR DESCRIPTION
At the moment §B declares itself as non-normative, and this is, sort of, "inherited" by subsections unless stated otherwise. Ie, §B.1 and §B.2 may be considered as non-normative, which is not the intention. Better leave §B to normative (the default) and §B.3 explicitly declares itself as non-normative.

Just to avoid misunderstandings...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1200.html" title="Last updated on Jul 14, 2023, 10:15 AM UTC (b536d68)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1200/3a0e423...b536d68.html" title="Last updated on Jul 14, 2023, 10:15 AM UTC (b536d68)">Diff</a>