### PR TITLE
Add section on Ecosystem Compatibility.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3654,8 +3654,9 @@ If conceptually aligned digital credential formats can be transformed into a
 are considered <em>"compatible with the Verifiable Credentials ecosystem"</em>.
 A <a>conforming document</a> is either a <a>verifiable credential</a> serialized
 as the `application/vc+ld+json` media type or a <a>verifiable presentation</a>
-serialized as the `application/vp+ld+json` media type. Specifications that are
-compatible with the Verifiable Credentials ecosystem:
+serialized as the `application/vp+ld+json` media type. Specifications that
+describe how to perform transformations that enable compatibility with
+the Verifiable Credentials ecosystem:
         </p>
 
         <ul>

--- a/index.html
+++ b/index.html
@@ -3693,10 +3693,7 @@ for additional guidance.
 Readers are advised that a digital credential is only considered a
 <a>verifiable credential</a> or a <a>verifiable presentation</a> if it is a
 <a>conforming document</a> and it utilizes at least one securing mechanism, as
-described by this specification. Additionally, any <a>conforming document</a>,
-using any securing mechanism, where every claim in the <a>conforming
-document</a> is secured, is considered a <a>verifiable credential</a> or a
-<a>verifiable presentation</a>. While some communities might call some digital
+described by their respective requirements in this specification. While some communities might call some digital
 credential formats that are not <a>conforming documents</a>
 "verifiable credentials", doing so does NOT make that digital credential a
 <a>verifiable credential</a> or a <a>verifiable presentation</a> as defined by

--- a/index.html
+++ b/index.html
@@ -3625,6 +3625,58 @@ reserved extension points SHOULD be treated as experimental.
         </p>
 
       </section>
+
+      <section class="normative">
+        <h3>Ecosystem Compatibility</h3>
+
+        <p>
+There are a number of digital credential formats that do not natively use the
+data model provided in this document, but are aligned with a number of concepts
+in this specification. At the time of publication, examples of these digital
+credential formats include pure JSON Web Tokens (JWTs), CBOR Web Tokens (CWTs),
+ISO-18013-5 (mDLs), and Authentic Chained Data Containers (ACDCs).
+        </p>
+
+        <p>
+If conceptually aligned digital credential formats can be transformed to the
+data model according to the rules provided in this section, they are considered
+<em>"compatible with the Verifiable Credentials ecosystem"</em>, and the result
+of the transformation, which is a <a>conforming document</a>, is a
+<a>verifiable credential</a>. Specifications that contain transformations to the
+data model described by this specification:
+        </p>
+
+        <ul>
+          <li>
+MUST identify if the transformation to this data model is uni-directional or
+bi-directional.
+          </li>
+          <li>
+MUST preserve the `@context` values when performing bi-directional
+transformation.
+          </li>
+          <li>
+MUST result in a <a>conforming document</a>.
+          </li>
+          <li>
+MUST specify a media type for the input document, which will be transformed into
+a <a>conforming document</a>.
+          </li>
+          <li>
+SHOULD provide a test suite that demonstrates that the transformation algorithm
+specified results in a <a>conforming document</a>.
+          </li>
+          <li>
+SHOULD ensure that all semantics utilized in the transformed
+<a>conforming document</a> follow best practices for Linked Data. See
+Section <a href="#getting-started"></a>, Section
+<a href="#extensibility"></a>, and Linked Data Best Practices [[?LD-BP]]
+for additional guidance.
+          </li>
+        </ul>
+
+      </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -3651,7 +3651,7 @@ Authentic Chained Data Containers</a> (ACDCs).
         <p>
 If conceptually aligned digital credential formats can be transformed into a
 <a>conforming document</a> according to the rules provided in this section, they
-are considered <em>"compatible with the Verifiable Credentials ecosystem"</em>.
+are considered <em>"compatible with the W3C Verifiable Credentials ecosystem"</em>.
 A <a>conforming document</a> is either a <a>verifiable credential</a> serialized
 as the `application/vc+ld+json` media type or a <a>verifiable presentation</a>
 serialized as the `application/vp+ld+json` media type. Specifications that
@@ -3690,14 +3690,13 @@ for additional guidance.
         </ul>
 
         <p class="note" title="What constitutes a verifiable credential?">
-Readers are advised that a digital credential is only considered a
-<a>verifiable credential</a> or a <a>verifiable presentation</a> if it is a
+Readers are advised that a digital credential is only considered
+compatible with the W3C Verifiable Credentials ecosystem if it is a
 <a>conforming document</a> and it utilizes at least one securing mechanism, as
 described by their respective requirements in this specification. While some communities might call some digital
 credential formats that are not <a>conforming documents</a>
-"verifiable credentials", doing so does NOT make that digital credential a
-<a>verifiable credential</a> or a <a>verifiable presentation</a> as defined by
-this specification.
+"verifiable credentials", doing so does NOT make that digital credential
+compliant to this specification.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -3649,7 +3649,7 @@ Authentic Chained Data Containers</a> (ACDCs).
         </p>
 
         <p>
-If conceptually aligned digital credential formats can be transformed to a
+If conceptually aligned digital credential formats can be transformed into a
 <a>conforming document</a> according to the rules provided in this section, they
 are considered <em>"compatible with the Verifiable Credentials ecosystem"</em>.
 Specifications that are compatible with the Verifiable Credentials ecosystem:
@@ -3690,8 +3690,9 @@ Readers are advised that a digital credential is only considered a
 <a>verifiable credential</a> or a <a>verifiable presentation</a> if it is
 transformed into a <a>conforming document</a>, as described by this
 specification. While some communities might call some digital credential
-formats "verifiable credentials", doing so does not have consensus in this
-community.
+formats that are not <a>conforming documents</a> "verifiable credentials",
+doing so did not achieve consensus with the Working Group that created this
+specification.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -3685,6 +3685,15 @@ for additional guidance.
           </li>
         </ul>
 
+        <p class="note" title="What constitutes a verifiable credential?">
+Readers are advised that a digital credential is only considered a
+<a>verifiable credential</a> or a <a>verifiable presentation</a> if it is
+transformed into a <a>conforming document</a>, as described by this
+specification. While some communities might call some digital credential
+formats "verifiable credentials", doing so does not have consensus in this
+community.
+        </p>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -3633,8 +3633,19 @@ reserved extension points SHOULD be treated as experimental.
 There are a number of digital credential formats that do not natively use the
 data model provided in this document, but are aligned with a number of concepts
 in this specification. At the time of publication, examples of these digital
-credential formats include JSON Web Tokens (JWTs), CBOR Web Tokens (CWTs),
-ISO-18013-5 (mDLs), and Authentic Chained Data Containers (ACDCs).
+credential formats include
+<a href="https://www.rfc-editor.org/rfc/rfc7519.html">
+JSON Web Tokens</a> (JWTs),
+<a href="https://www.rfc-editor.org/rfc/rfc8392.html">
+CBOR Web Tokens</a> (CWTs),
+<a href="https://www.iso.org/standard/69084.html">ISO-18013-5:2021</a>
+(mDLs),
+<a href="https://hyperledger.github.io/anoncreds-spec/">
+AnonCreds</a>,
+<a href="https://www.ietf.org/archive/id/draft-mcnally-envelope-02.html">
+Gordian Envelopes</a>, and
+<a href="https://www.ietf.org/archive/id/draft-ssmith-acdc-02.html">
+Authentic Chained Data Containers</a> (ACDCs).
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3633,7 +3633,7 @@ reserved extension points SHOULD be treated as experimental.
 There are a number of digital credential formats that do not natively use the
 data model provided in this document, but are aligned with a number of concepts
 in this specification. At the time of publication, examples of these digital
-credential formats include pure JSON Web Tokens (JWTs), CBOR Web Tokens (CWTs),
+credential formats include JSON Web Tokens (JWTs), CBOR Web Tokens (CWTs),
 ISO-18013-5 (mDLs), and Authentic Chained Data Containers (ACDCs).
         </p>
 
@@ -3642,17 +3642,17 @@ If conceptually aligned digital credential formats can be transformed to the
 data model according to the rules provided in this section, they are considered
 <em>"compatible with the Verifiable Credentials ecosystem"</em>, and the result
 of the transformation, which is a <a>conforming document</a>, is a
-<a>verifiable credential</a>. Specifications that contain transformations to the
+<a>verifiable credential</a>. Specifications that include transformations to the
 data model described by this specification:
         </p>
 
         <ul>
           <li>
-MUST identify if the transformation to this data model is uni-directional or
-bi-directional.
+MUST identify whether the transformation to this data model is one-way-only or
+round-trippable.
           </li>
           <li>
-MUST preserve the `@context` values when performing bi-directional
+MUST preserve the `@context` values when performing round-trippable
 transformation.
           </li>
           <li>
@@ -3663,8 +3663,8 @@ MUST specify a media type for the input document, which will be transformed into
 a <a>conforming document</a>.
           </li>
           <li>
-SHOULD provide a test suite that demonstrates that the transformation algorithm
-specified results in a <a>conforming document</a>.
+SHOULD provide a test suite that demonstrates that the specified transformation
+algorithm results in a <a>conforming document</a>.
           </li>
           <li>
 SHOULD ensure that all semantics utilized in the transformed

--- a/index.html
+++ b/index.html
@@ -2230,7 +2230,7 @@ each data schema is determined by the specific type definition.
             </p>
             <p>
 If multiple schemas are present, validity is determined according to the
-processing rules outlined by each associated <code>credentialSchema</code> 
+processing rules outlined by each associated <code>credentialSchema</code>
 <code>type</code> property.
             </p>
           </dd>
@@ -3690,12 +3690,16 @@ for additional guidance.
 
         <p class="note" title="What constitutes a verifiable credential?">
 Readers are advised that a digital credential is only considered a
-<a>verifiable credential</a> or a <a>verifiable presentation</a> if it is
-transformed into a <a>conforming document</a>, as described by this
-specification. While some communities might call some digital credential
-formats that are not <a>conforming documents</a> "verifiable credentials",
-doing so did not achieve consensus with the Working Group that created this
-specification.
+<a>verifiable credential</a> or a <a>verifiable presentation</a> if it is a
+<a>conforming document</a> and it utilizes at least one securing mechanism, as
+described by this specification. Additionally, any <a>conforming document</a>,
+using any securing mechanism, where every claim in the <a>conforming
+document</a> is secured, is considered a <a>verifiable credential</a> or a
+<a>verifiable presentation</a>. While some communities might call some digital
+credential formats that are not <a>conforming documents</a>
+"verifiable credentials", doing so does NOT make that digital credential a
+<a>verifiable credential</a> or a <a>verifiable presentation</a> as defined by
+this specification.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -3649,12 +3649,10 @@ Authentic Chained Data Containers</a> (ACDCs).
         </p>
 
         <p>
-If conceptually aligned digital credential formats can be transformed to the
-data model according to the rules provided in this section, they are considered
-<em>"compatible with the Verifiable Credentials ecosystem"</em>, and the result
-of the transformation, which is a <a>conforming document</a>, is a
-<a>verifiable credential</a>. Specifications that include transformations to the
-data model described by this specification:
+If conceptually aligned digital credential formats can be transformed to a
+<a>conforming document</a> according to the rules provided in this section, they
+are considered <em>"compatible with the Verifiable Credentials ecosystem"</em>.
+Specifications that are compatible with the Verifiable Credentials ecosystem:
         </p>
 
         <ul>
@@ -3667,15 +3665,16 @@ MUST preserve the `@context` values when performing round-trippable
 transformation.
           </li>
           <li>
-MUST result in a <a>conforming document</a>.
+MUST result in a <a>conforming document</a> when transforming to the data
+model described by this specification.
           </li>
           <li>
-MUST specify a media type for the input document, which will be transformed into
-a <a>conforming document</a>.
+MUST specify a registered media type for the input document.
           </li>
           <li>
 SHOULD provide a test suite that demonstrates that the specified transformation
-algorithm results in a <a>conforming document</a>.
+algorithm to the data model in this specification results in
+a <a>conforming document</a>.
           </li>
           <li>
 SHOULD ensure that all semantics utilized in the transformed

--- a/index.html
+++ b/index.html
@@ -3652,7 +3652,10 @@ Authentic Chained Data Containers</a> (ACDCs).
 If conceptually aligned digital credential formats can be transformed into a
 <a>conforming document</a> according to the rules provided in this section, they
 are considered <em>"compatible with the Verifiable Credentials ecosystem"</em>.
-Specifications that are compatible with the Verifiable Credentials ecosystem:
+A <a>conforming document</a> is either a <a>verifiable credential</a> serialized
+as the `application/vc+ld+json` media type or a <a>verifiable presentation</a>
+serialized as the `application/vp+ld+json` media type. Specifications that are
+compatible with the Verifiable Credentials ecosystem:
         </p>
 
         <ul>


### PR DESCRIPTION
This PR attempts to address issue #1048 by implementing the [last two](https://github.com/w3c/vc-data-model/issues/1048#issue-1588485377) remaining [resolutions from the Feb 2023 F2F meeting](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-02-16-vcwg#resolution1). Here are the currently unimplemented parts of the resolution that this PR attempts to address:

> Serializations in other media types (defined by the VCWG) MUST be able to be transformed into the base media type. 

This is guidance for the VCWG, and thus does not need to be placed into normative text in the core data model. If a specification produced by the VCWG does not provide this language, it will almost certainly be objected to by a subset of the WG.

> Another media type MUST identify if this transformation is one-directional or bi-directional. 

This is specified in this PR.

> Bi-directional transformation MUST preserve @context.

This is specified in this PR.

> Transformation rules MUST be defined, but not necessarily by this WG.

This is specified in this PR.

In addition to the resolutions above, language has also been included that address concerns raised in #1048 and #947.

This PR is a compromise between PRs #1100 and #1101.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1203.html" title="Last updated on Aug 1, 2023, 2:00 AM UTC (056d2a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1203/892eeac...056d2a1.html" title="Last updated on Aug 1, 2023, 2:00 AM UTC (056d2a1)">Diff</a>