### PR TITLE
Clarify the difference between a "credential" and a "verifiable credential"

### DIFF
--- a/index.html
+++ b/index.html
@@ -641,15 +641,15 @@ specification.
       <p class="note"
         title="Abstract concepts vs. concrete concepts">
 Readers might note that some abstract concepts described in this section
-do not have normative requirements or associated media types defined by this
-specification. For example, the abstract concepts of a <a>credential</a> and a
+do not have normative requirements nor associated media types defined by this
+specification. For example, the abstract concepts of <a>credential</a> and
 <a>presentation</a> do not have normative requirements nor associated media
 types. However, the concrete concepts of a <a>verifiable credential</a> or a
 <a>verifiable presentation</a> are defined as <a>conforming documents</a> and
-do have associated media types. Furthermore, what differentiates the
-abstract concepts of <a>credential</a> and <a>presentation</a> from the
-concrete concepts of a <a>verifiable credential</a> and a
-<a>verifiable presentation</a> is the fact that only the "verifiable" objects
+do have associated media types. Furthermore, the only difference between the
+abstract concepts — of <a>credential</a> and <a>presentation</a> — and the
+concrete concepts — of <a>verifiable credential</a> and
+<a>verifiable presentation</a> — is the fact that the "verifiable" objects
 are secured in a way that is cryptographically verifiable. For more details,
 see Section <a href="#securing-verifiable-credentials"></a>.
       </p>
@@ -1824,7 +1824,7 @@ This specification recognizes two classes of securing mechanisms: those that use
 external proofs and those that use embedded proofs. An
 <dfn class="lint-ignore">external proof</dfn> is one that wraps an expression of
 this data model, such as via a JSON Web Token, which is elaborated on in the
-<em>Securing Verifiable Credentials using JSON Web Tokens</em> [[VC-JWT]]
+<em>Securing Verifiable Credentials using JOSE and COSE</em> [[VC-JOSE-COSE]]
 specification. An <dfn>embedded proof</dfn> is a mechanism where the proof is
 included in the data model, such as a Data Integrity Proof, which is elaborated
 on in <em>Verifiable Credential Data Integrity</em> [[VC-DATA-INTEGRITY]].
@@ -1898,8 +1898,8 @@ proof mechanisms, and this specification does not standardize nor recommend any
 single proof mechanisms for use with <a>verifiable credentials</a> or
 <a>verifiable presentations</a>. For more information about the
 <code>proof</code> mechanisms, see the following specifications: Data Integrity
-[[VC-DATA-INTEGRITY]], Securing Verifiable Credentials using JSON Web Tokens
-[VC-JWT], and the "Proofs" section of the Verifiable Credential Specifications
+[[VC-DATA-INTEGRITY]], Securing Verifiable Credentials using JOSE and COSE
+[VC-JOSE-COSE], and the "Proofs" section of the Verifiable Credential Specifications
 Directory [[VC-SPECS]].
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1812,7 +1812,7 @@ T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))
 
         <p>
 At least one securing mechanism, and the details necessary to evaluate it, MUST
-be expressed for a <a>verifiable credential</a> or a
+be expressed to construct a <a>verifiable credential</a> or a
 <a>verifiable presentation</a>.
         </p>
         <p>
@@ -1845,7 +1845,7 @@ presentations</a> that use an external proof MAY use the <code>proof</code>
 One or more cryptographic proofs that can be used to detect tampering and verify
 the authorship of a <a>verifiable credential</a> or <a>verifiable
 presentation</a>. The specific method used for an <a>embedded proof</a> MUST be
-included using the <code>type</code> <a>property</a>.
+identified using the <code>type</code> <a>property</a>.
           </dd>
         </dl>
 
@@ -1891,9 +1891,9 @@ the signing date. The example below uses Ed25519 digital signatures.
         <p class="note">
 As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
-single proof mechanism for use with <a>verifiable credentials</a> or
+single proof mechanisms for use with <a>verifiable credentials</a> or
 <a>verifiable presentations</a>. For more information about the
-<code>proof</code> mechanism, see the following specifications: Data Integrity
+<code>proof</code> mechanisms, see the following specifications: Data Integrity
 [[VC-DATA-INTEGRITY]], Securing Verifiable Credentials using JSON Web Tokens
 [VC-JWT], and the "Proofs" section of the Verifiable Credential Specifications
 Directory [[VC-SPECS]].

--- a/index.html
+++ b/index.html
@@ -1799,39 +1799,40 @@ T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))
 
         <p>
 At least one securing mechanism, and the details necessary to evaluate it, MUST
-be expressed for a <a>credential</a> or <a>presentation</a> to be a
-<a>verifiable credential</a> or <a>verifiable presentation</a>; that is, to be
-<a>verifiable</a>.
+be expressed for a <a>verifiable credential</a> or a
+<a>verifiable presentation</a>.
         </p>
         <p>
 This specification recognizes two classes of securing mechanisms: those that use
 external proofs and those that use embedded proofs. An
 <dfn class="lint-ignore">external proof</dfn> is one that wraps an expression of
 this data model, such as via a JSON Web Token, which is elaborated on in the
-<em>Securing Verifiable Credentials using JSON Web Tokens</em> [[VC-JWT]] specification.
-An <dfn>embedded proof</dfn> is a mechanism where the proof is included in the
-data model, such as a Data Integrity Proof, which is elaborated on in <em>Verifiable
-Credential Data Integrity</em> [[VC-DATA-INTEGRITY]].
+<em>Securing Verifiable Credentials using JSON Web Tokens</em> [[VC-JWT]]
+specification. An <dfn>embedded proof</dfn> is a mechanism where the proof is
+included in the data model, such as a Data Integrity Proof, which is elaborated
+on in <em>Verifiable Credential Data Integrity</em> [[VC-DATA-INTEGRITY]].
         </p>
         <p>
 It should be noted that these two classes of securing mechanisms are not
 mutually exclusive.
         </p>
         <p>
-Methods of securing <a>credentials</a> or <a>presentations</a> that embed a
-proof in the data model MUST use the <code>proof</code> <a>property</a>.
+Methods of securing <a>verifiable credentials</a> or
+<a>verifiable presentations</a> that embed a proof in the data model MUST use
+the <code>proof</code> <a>property</a>.
         </p>
         <p>
-Methods of securing <a>credentials</a> or <a>presentations</a> that use an
-external proof MAY use the <code>proof</code> <a>property</a>.
+Methods of securing <a>verifiable credentials</a> or <a>verifiable
+presentations</a> that use an external proof MAY use the <code>proof</code>
+<a>property</a>.
         </p>
         <dl>
           <dt><var>proof</var></dt>
           <dd>
-One or more cryptographic proofs that can be used to detect tampering and
-verify the authorship of a <a>credential</a> or <a>presentation</a>. The
-specific method used for an <a>embedded proof</a> MUST be included using the
-<code>type</code> <a>property</a>.
+One or more cryptographic proofs that can be used to detect tampering and verify
+the authorship of a <a>verifiable credential</a> or <a>verifiable
+presentation</a>. The specific method used for an <a>embedded proof</a> MUST be
+included using the <code>type</code> <a>property</a>.
           </dd>
         </dl>
 
@@ -1877,11 +1878,12 @@ the signing date. The example below uses Ed25519 digital signatures.
         <p class="note">
 As discussed in Section <a href="#conformance"></a>, there are multiple viable
 proof mechanisms, and this specification does not standardize nor recommend any
-single proof mechanism for use with <a>verifiable credentials</a>. For more
-information about the <code>proof</code> mechanism, see the following
-specifications: Data Integrity [[VC-DATA-INTEGRITY]], Securing Verifiable
-Credentials using JSON Web Tokens [VC-JWT], and the "Proofs" section of
-the Verifiable Credential Specifications Directory [[VC-SPECS]].
+single proof mechanism for use with <a>verifiable credentials</a> or
+<a>verifiable presentations</a>. For more information about the
+<code>proof</code> mechanism, see the following specifications: Data Integrity
+[[VC-DATA-INTEGRITY]], Securing Verifiable Credentials using JSON Web Tokens
+[VC-JWT], and the "Proofs" section of the Verifiable Credential Specifications
+Directory [[VC-SPECS]].
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -639,15 +639,19 @@ specification.
       </p>
 
       <p class="note"
-        title="Not every abstract concept is realized in implementations">
-Implementers might note that while there are a number of abstract concepts
-described in this section, such as <a>credential</a> and <a>presentation</a>,
-those concepts are not always concretely realized in implementations. These
-abstract concepts are provided as a mechanism to document a helpful mental model
-to readers. Normative language in this specification is focused on
-<a>verifiable credentials</a> and <a>verifiable presentations</a> and thus not
-every abstract concept described in this section is expected to be realized in
-an implementation.
+        title="Abstract concepts vs. concrete concepts">
+Readers might note that some abstract concepts described in this section
+do not have normative requirements or associated media types defined by this
+specification. For example, the abstract concepts of a <a>credential</a> and a
+<a>presentation</a> do not have normative requirements nor associated media
+types. However, the concrete concepts of a <a>verifiable credential</a> or a
+<a>verifiable presentation</a> are defined as <a>conforming documents</a> and
+do have associated media types. Furthermore, what differentiates the
+abstract concepts of <a>credential</a> and <a>presentation</a> from the
+concrete concepts of a <a>verifiable credential</a> and a
+<a>verifiable presentation</a> is the fact that only the "verifiable" objects
+are secured in a way that is cryptographically verifiable. For more details,
+see Section <a href="#securing-verifiable-credentials"></a>.
       </p>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -639,19 +639,17 @@ specification.
       </p>
 
       <p class="note"
-        title="Abstract concepts vs. concrete concepts">
-Readers might note that some abstract concepts described in this section
-do not have normative requirements nor associated media types defined by this
-specification. For example, the abstract concepts of <a>credential</a> and
-<a>presentation</a> do not have normative requirements nor associated media
-types. However, the concrete concepts of a <a>verifiable credential</a> or a
-<a>verifiable presentation</a> are defined as <a>conforming documents</a> and
-do have associated media types. Furthermore, the only difference between the
-abstract concepts — of <a>credential</a> and <a>presentation</a> — and the
-concrete concepts — of <a>verifiable credential</a> and
-<a>verifiable presentation</a> — is the fact that the "verifiable" objects
-are secured in a way that is cryptographically verifiable. For more details,
-see Section <a href="#securing-verifiable-credentials"></a>.
+        title="The difference between a credential and a verifiable credential">
+Readers might note that some concepts described in this section, such as
+<a>credential</a> and <a>presentation</a>, do not have media types defined by
+this specification. However, the concepts of a <a>verifiable credential</a> or a
+<a>verifiable presentation</a> are defined as <a>conforming documents</a> and do
+have associated media types. The concrete difference between the
+concepts &mdash; of <a>credential</a> and <a>presentation</a> &mdash; and the
+concepts &mdash; of <a>verifiable credential</a> and <a>verifiable
+presentation</a> &mdash; is the fact that the "verifiable" objects are secured
+in a way that is cryptographically verifiable. For more details, see Section
+<a href="#securing-verifiable-credentials"></a>.
       </p>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -645,10 +645,10 @@ Readers might note that some concepts described in this section, such as
 this specification. However, the concepts of a <a>verifiable credential</a> or a
 <a>verifiable presentation</a> are defined as <a>conforming documents</a> and do
 have associated media types. The concrete difference between these concepts
-&mdash; between <a>credential</a> and <a>presentation</a> Vs. <a>verifiable
+&mdash; between <a>credential</a> and <a>presentation</a> vs. <a>verifiable
 credential</a> and <a>verifiable presentation</a> &mdash; is simply the fact
 that the "verifiable" objects are secured in a way that is cryptographically
-verifiable, which the others are not. For more details, see Section
+verifiable, and the others are not. For more details, see Section
 <a href="#securing-verifiable-credentials"></a>.
       </p>
 
@@ -1813,9 +1813,9 @@ T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))
         <h3>Securing Verifiable Credentials</h3>
 
         <p>
-At least one securing mechanism, and the details necessary to evaluate it, MUST
-be expressed to construct a <a>verifiable credential</a> or a
-<a>verifiable presentation</a>.
+A securing mechanism MUST express the details necessary to evaluate whether a
+<a>verifiable credential</a> or <a>verifiable presentation</a> has been secured
+using it.
         </p>
         <p>
 This specification recognizes two classes of securing mechanisms: those that use

--- a/index.html
+++ b/index.html
@@ -633,8 +633,21 @@ information as a valid document.
 
       <p>
 The following sections outline core data model concepts, such as <a>claims</a>,
-<a>credentials</a>, and <a>presentations</a>, which form the foundation of this
+<a>credentials</a>, <a>presentations</a>, <a>verifiable credentials</a>, and
+<a>verifiable presentations</a>, which form the foundation of this
 specification.
+      </p>
+
+      <p class="note"
+        title="Not every abstract concept is realized in implementations">
+Implementers might note that while there are a number of abstract concepts
+described in this section, such as <a>credential</a> and <a>presentation</a>,
+those concepts are not always concretely realized in implementations. These
+abstract concepts are provided as a mechanism to document a helpful mental model
+to readers. Normative language in this specification is focused on
+<a>verifiable credentials</a> and <a>verifiable presentations</a> and thus not
+every abstract concept described in this section is expected to be realized in
+an implementation.
       </p>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -644,11 +644,11 @@ Readers might note that some concepts described in this section, such as
 <a>credential</a> and <a>presentation</a>, do not have media types defined by
 this specification. However, the concepts of a <a>verifiable credential</a> or a
 <a>verifiable presentation</a> are defined as <a>conforming documents</a> and do
-have associated media types. The concrete difference between the
-concepts &mdash; of <a>credential</a> and <a>presentation</a> &mdash; and the
-concepts &mdash; of <a>verifiable credential</a> and <a>verifiable
-presentation</a> &mdash; is the fact that the "verifiable" objects are secured
-in a way that is cryptographically verifiable. For more details, see Section
+have associated media types. The concrete difference between these concepts
+&mdash; between <a>credential</a> and <a>presentation</a> Vs. <a>verifiable
+credential</a> and <a>verifiable presentation</a> &mdash; is simply the fact
+that the "verifiable" objects are secured in a way that is cryptographically
+verifiable, which the others are not. For more details, see Section
 <a href="#securing-verifiable-credentials"></a>.
       </p>
 


### PR DESCRIPTION
This PR is an attempt to address #1009 and #1126 by clarifying the difference between a "credential" (an abstract concept) and a "verifiable credential" (a concrete concept). Adjustments are made to normative statements to not talk about "credentials" or "presentations", but rather only "verifiable credentials" and "verifiable presentations" (which MUST be secured).

I expect other adjustments need to be made throughout the spec, and if this PR goes through, we can make those adjustments more easily given consensus around this text being the basis for removing mentions of "credential" or "presentation", when what we meant was "verifiable credential" or "verifiable presentation". Namely, no normative statement in the specification should talk about "credential" or "presentation" if this PR goes through.

What this PR is trying to say is: "If the thing you're talking about isn't secured, it isn't a verifiable credential. A credential is an abstract concept. A verifiable credential is a concrete concept. This specification normatively defines verifiable credential, and that thing MUST be secured."


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1211.html" title="Last updated on Aug 15, 2023, 8:57 PM UTC (01060d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1211/59a9ca0...01060d7.html" title="Last updated on Aug 15, 2023, 8:57 PM UTC (01060d7)">Diff</a>