### PR TITLE
Refer to VC-SPECS-DIR for proof types.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2020,12 +2020,8 @@ to not pertain to the <a>validation</a> of the <a>verifiable presentation</a>.
           <dd>
 The <a>verifiable presentation</a> MAY include a <code>proof</code>
 <a>property</a>. If present, the value SHOULD be used to express a securing
-mechanism, such as [[?VC-DATA-INTEGRITY]], that is listed in the
-<a href="https://w3c.github.io/vc-specs-dir/#proof">Proof section</a> of the
-Verifiable Credentials Specifications Directory [[?VC-SPECS]]. A
-<a>verifiable presentation</a> MAY be secured using an <a>external proof</a> such as
-[[?VC-JWT]]. For details related to the use of this property, see Section
-<a href="#securing-verifiable-credentials"></a>.
+mechanism, such as those listed in the
+Verifiable Credentials Specifications Directory [[?VC-SPECS]].
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2020,9 +2020,12 @@ to not pertain to the <a>validation</a> of the <a>verifiable presentation</a>.
           <dd>
 The <a>verifiable presentation</a> MAY include a <code>proof</code>
 <a>property</a>. If present, the value SHOULD be used to express a securing
-mechanism such as [[?VC-DATA-INTEGRITY]]. A <a>verifiable presentation</a> MAY
-be secured using an external proof such as [[?VC-JWT]]. For details related to
-the use of this property, see Section <a href="#securing-verifiable-credentials"></a>.
+mechanism, such as [[?VC-DATA-INTEGRITY]], that is listed in the
+<a href="https://w3c.github.io/vc-specs-dir/#proof">Proof section</a> of the
+Verifiable Credentials Specifications Directory [[?VC-SPECS]]. A
+<a>verifiable presentation</a> MAY be secured using an external proof such as
+[[?VC-JWT]]. For details related to the use of this property, see Section
+<a href="#securing-verifiable-credentials"></a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2023,7 +2023,7 @@ The <a>verifiable presentation</a> MAY include a <code>proof</code>
 mechanism, such as [[?VC-DATA-INTEGRITY]], that is listed in the
 <a href="https://w3c.github.io/vc-specs-dir/#proof">Proof section</a> of the
 Verifiable Credentials Specifications Directory [[?VC-SPECS]]. A
-<a>verifiable presentation</a> MAY be secured using an external proof such as
+<a>verifiable presentation</a> MAY be secured using an <a>external proof</a> such as
 [[?VC-JWT]]. For details related to the use of this property, see Section
 <a href="#securing-verifiable-credentials"></a>.
           </dd>


### PR DESCRIPTION
This PR attempts to address issue #1105 by explicitly stating that `proof` types SHOULD come from the VC-SPECS-DIR. The PR avoids saying "MUST" because VC-SPECS-DIR is not meant to be the authoritative registry of everything VCs, but rather a directory of things that individuals wanted to have listed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1212.html" title="Last updated on Aug 20, 2023, 5:19 PM UTC (3bcf15a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1212/d84cf2e...3bcf15a.html" title="Last updated on Aug 20, 2023, 5:19 PM UTC (3bcf15a)">Diff</a>