### PR TITLE
Editorial update index.html: use JsonSchema and not JsonSchema2023

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -41,7 +41,7 @@
         "credentialStatus": {
           "@id": "https://www.w3.org/2018/credentials#credentialStatus",
           "@type": "@id"
-        },
+        },  
         "credentialSubject": {
           "@id": "https://www.w3.org/2018/credentials#credentialSubject",
           "@type": "@id"
@@ -79,6 +79,10 @@
         },
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
+          "@type": "@id"
+        },
+        "confidenceMethod": {
+          "@id": "https://www.w3.org/2018/credentials#confidenceMethod",
           "@type": "@id"
         }
       }

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -41,7 +41,7 @@
         "credentialStatus": {
           "@id": "https://www.w3.org/2018/credentials#credentialStatus",
           "@type": "@id"
-        },  
+        },
         "credentialSubject": {
           "@id": "https://www.w3.org/2018/credentials#credentialSubject",
           "@type": "@id"

--- a/index.html
+++ b/index.html
@@ -3568,7 +3568,7 @@ in the specification if at least one specification with two independent
 implementations are demonstrated by the end of the Candidate Recommendation
 Phase. If that does not occur, this reservation will remain, but the existing
 section in the specification will be removed.
-See <a href="https://w3c-ccg.github.io/vc-confidence-method/">Verifiable Credential Confidence Methods</a>.
+See <a href="https://w3c-ccg.github.io/confidence-method-spec/">Verifiable Credential Confidence Methods</a>.
                 </p>
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -3556,6 +3556,23 @@ have at least a draft specification that is being incubated in a community group
 
           <tbody>
             <tr>
+              <td>`confidenceMethod`</td>
+              <td>
+A property used for specifying one or more methods that a verifier 
+might rely on in order to authenticate the holder of a presentation. 
+The associated vocabulary URL MUST be
+`https://www.w3.org/2018/credentials#confidenceMethod`.
+                <p class="issue" title="(AT RISK) Reservation depends on implementations">
+This property reservation might be deleted in favor of an existing section
+in the specification if at least one specification with two independent
+implementations are demonstrated by the end of the Candidate Recommendation
+Phase. If that does not occur, this reservation will remain, but the existing
+section in the specification will be removed.
+See <a href="https://w3c-ccg.github.io/vc-confidence-method/">Verifiable Credential Confidence Methods</a>.
+                </p>
+              </td>
+            </tr>
+            <tr>
               <td>`evidence`</td>
               <td>
 A property used for specifying the evidence that was presented in order to
@@ -3588,13 +3605,14 @@ section in the specification will be removed.
             <tr>
               <td>`renderMethod`</td>
               <td>
-A property used for specifying how to render a credential into a visual,
+A property used for specifying one or more methods to render a credential into a visual,
 auditory, or haptic format. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#renderMethod`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
 This reserved property is at risk and will be removed from the
 specification if at least one specification with two independent implementations
 are not demonstrated by the end of the Candidate Recommendation Phase.
+See <a href="https://w3c-ccg.github.io/vc-render-method/">Verifiable Credential Rendering Methods</a>.
                 </p>
               </td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -2230,7 +2230,7 @@ each data schema is determined by the specific type definition.
             </p>
             <p>
 If multiple schemas are present, validity is determined according to the
-processing rules outlined by each associated <code>credentialSchema</code> 
+processing rules outlined by each associated <code>credentialSchema</code>
 <code>type</code> property.
             </p>
           </dd>
@@ -3625,6 +3625,82 @@ reserved extension points SHOULD be treated as experimental.
         </p>
 
       </section>
+
+      <section class="normative">
+        <h3>Ecosystem Compatibility</h3>
+
+        <p>
+There are a number of digital credential formats that do not natively use the
+data model provided in this document, but are aligned with a number of concepts
+in this specification. At the time of publication, examples of these digital
+credential formats include
+<a href="https://www.rfc-editor.org/rfc/rfc7519.html">
+JSON Web Tokens</a> (JWTs),
+<a href="https://www.rfc-editor.org/rfc/rfc8392.html">
+CBOR Web Tokens</a> (CWTs),
+<a href="https://www.iso.org/standard/69084.html">ISO-18013-5:2021</a>
+(mDLs),
+<a href="https://hyperledger.github.io/anoncreds-spec/">
+AnonCreds</a>,
+<a href="https://www.ietf.org/archive/id/draft-mcnally-envelope-02.html">
+Gordian Envelopes</a>, and
+<a href="https://www.ietf.org/archive/id/draft-ssmith-acdc-02.html">
+Authentic Chained Data Containers</a> (ACDCs).
+        </p>
+
+        <p>
+If conceptually aligned digital credential formats can be transformed into a
+<a>conforming document</a> according to the rules provided in this section, they
+are considered <em>"compatible with the W3C Verifiable Credentials ecosystem"</em>.
+A <a>conforming document</a> is either a <a>verifiable credential</a> serialized
+as the `application/vc+ld+json` media type or a <a>verifiable presentation</a>
+serialized as the `application/vp+ld+json` media type. Specifications that
+describe how to perform transformations that enable compatibility with
+the Verifiable Credentials ecosystem:
+        </p>
+
+        <ul>
+          <li>
+MUST identify whether the transformation to this data model is one-way-only or
+round-trippable.
+          </li>
+          <li>
+MUST preserve the `@context` values when performing round-trippable
+transformation.
+          </li>
+          <li>
+MUST result in a <a>conforming document</a> when transforming to the data
+model described by this specification.
+          </li>
+          <li>
+MUST specify a registered media type for the input document.
+          </li>
+          <li>
+SHOULD provide a test suite that demonstrates that the specified transformation
+algorithm to the data model in this specification results in
+a <a>conforming document</a>.
+          </li>
+          <li>
+SHOULD ensure that all semantics utilized in the transformed
+<a>conforming document</a> follow best practices for Linked Data. See
+Section <a href="#getting-started"></a>, Section
+<a href="#extensibility"></a>, and Linked Data Best Practices [[?LD-BP]]
+for additional guidance.
+          </li>
+        </ul>
+
+        <p class="note" title="What constitutes a verifiable credential?">
+Readers are advised that a digital credential is only considered
+compatible with the W3C Verifiable Credentials ecosystem if it is a
+<a>conforming document</a> and it utilizes at least one securing mechanism, as
+described by their respective requirements in this specification. While some communities might call some digital
+credential formats that are not <a>conforming documents</a>
+"verifiable credentials", doing so does NOT make that digital credential
+compliant to this specification.
+        </p>
+
+      </section>
+
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -3559,7 +3559,10 @@ have at least a draft specification that is being incubated in a community group
               <td>`confidenceMethod`</td>
               <td>
 A property used for specifying one or more methods that a verifier 
-might rely on in order to authenticate the holder of a presentation. 
+might use to increase their confidence that the value of an attribute in or of
+a verifiable credential or verifiable presentation is accurate, including but not
+limited to attributes such `initialRecipient` (a/k/a `issuee`), `presenter`,
+`authorizedPresenter`, `holder`, etc.
 The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#confidenceMethod`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">

--- a/index.html
+++ b/index.html
@@ -939,7 +939,7 @@ discount from a university. In the example below, Pat receives an alumni
     <span class='comment'>// the name of the cryptographic signature suite</span>
     "cryptosuite": "eddsa-2022",
     <span class='comment'>// the date the signature was created</span>
-    "created": "-06-18T21:19:10Z",
+    "created": "2023-06-18T21:19:10Z",
     <span class='comment'>// purpose of this proof</span>
     "proofPurpose": "assertionMethod",
     <span class='comment'>// the identifier of the public key that can verify the signature</span>
@@ -990,7 +990,7 @@ the <a>verifier</a> and <a>verified</a>.
     "proof": {
       "type": "DataIntegrityProof",
       "cryptosuite": "eddsa-2022",
-      "created": "-06-18T21:19:10Z",
+      "created": "2023-06-18T21:19:10Z",
       "proofPurpose": "assertionMethod",
       "verificationMethod": "https://university.example/issuers/565049#key-1",
       "proofValue": "zQeVbY4oey5q2M3XKaxup3tmzN4DRFTLVqpLMweBrSxMY2xHX5XTYV8nQA
@@ -1731,7 +1731,7 @@ millisecond offset from the epoch. However, note that for most applications the
 only moment in time that is affected is the one second period of the leap second
 itself. That is, the moment after the most recent leap second can always be
 represented as the first moment of the next day (for example,
-`-01-01T00:00:00Z`), regardless of whether the system in question
+`2023-01-01T00:00:00Z`), regardless of whether the system in question
 understands leap seconds.
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -939,7 +939,7 @@ discount from a university. In the example below, Pat receives an alumni
     <span class='comment'>// the name of the cryptographic signature suite</span>
     "cryptosuite": "eddsa-2022",
     <span class='comment'>// the date the signature was created</span>
-    "created": "2023-06-18T21:19:10Z",
+    "created": "-06-18T21:19:10Z",
     <span class='comment'>// purpose of this proof</span>
     "proofPurpose": "assertionMethod",
     <span class='comment'>// the identifier of the public key that can verify the signature</span>
@@ -990,7 +990,7 @@ the <a>verifier</a> and <a>verified</a>.
     "proof": {
       "type": "DataIntegrityProof",
       "cryptosuite": "eddsa-2022",
-      "created": "2023-06-18T21:19:10Z",
+      "created": "-06-18T21:19:10Z",
       "proofPurpose": "assertionMethod",
       "verificationMethod": "https://university.example/issuers/565049#key-1",
       "proofValue": "zQeVbY4oey5q2M3XKaxup3tmzN4DRFTLVqpLMweBrSxMY2xHX5XTYV8nQA
@@ -1731,7 +1731,7 @@ millisecond offset from the epoch. However, note that for most applications the
 only moment in time that is affected is the one second period of the leap second
 itself. That is, the moment after the most recent leap second can always be
 represented as the first moment of the next day (for example,
-`2023-01-01T00:00:00Z`), regardless of whether the system in question
+`-01-01T00:00:00Z`), regardless of whether the system in question
 understands leap seconds.
           </li>
         </ul>
@@ -2224,7 +2224,7 @@ The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
 more data schemas that provide <a>verifiers</a> with enough information to
 determine if the provided data conforms to the provided schema(s). Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code>JsonSchema2023</code>), and an <code>id</code> <a>property</a>
+<code>JsonSchema</code>), and an <code>id</code> <a>property</a>
 that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
             </p>
@@ -2270,11 +2270,11 @@ integrity protection mechanism. The <code>credentialSchema</code>
   },
   <span class="highlight">"credentialSchema": [{
     "id": "https://example.org/examples/degree.json",
-    "type": "JsonSchema2023"
+    "type": "JsonSchema"
   },
   {
     "id": "https://example.org/examples/alumni.json",
-    "type": "JsonSchema2023"
+    "type": "JsonSchema"
   }]</span>
 }
         </pre>

--- a/index.html
+++ b/index.html
@@ -3561,7 +3561,7 @@ have at least a draft specification that is being incubated in a community group
 A property used for specifying one or more methods that a verifier 
 might use to increase their confidence that the value of an attribute in or of
 a verifiable credential or verifiable presentation is accurate, including but not
-limited to attributes such `initialRecipient` (a/k/a `issuee`), `presenter`,
+limited to attributes such as `initialRecipient` (a/k/a `issuee`), `presenter`,
 `authorizedPresenter`, `holder`, etc.
 The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#confidenceMethod`.


### PR DESCRIPTION
This is just a leftover of the naming/versioning change around JSON Schemas.

(Editorial change, only in the examples).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1225.html" title="Last updated on Aug 4, 2023, 4:11 AM UTC (8b2e277)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1225/892eeac...8b2e277.html" title="Last updated on Aug 4, 2023, 4:11 AM UTC (8b2e277)">Diff</a>