### PR TITLE
Added reserved confidenceMethod property to the vocabulary — bis

### DIFF
--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -32,7 +32,7 @@ class:
   - id: ConfidenceMethod
     label: Confidence method
     defined_by: https://w3c-ccg.github.io/confidence-method-spec/
-    comment: A Confidence Method provides enough information for a verifier to determine whether the holder can generate a verifiable presentation to increase the verifier's confidence that they are the same entity referenced by the confidence method. This class serves as a supertype for specific status types.
+    comment: A Confidence Method provides enough information for a verifier to determine whether the holder can generate a verifiable presentation to increase the verifier's confidence that they are the same entity referenced by the confidence method. This class serves as a supertype for specific confidence method types.
     status: reserved
 
   - id: JsonSchema2023

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -29,6 +29,12 @@ class:
     label: Credential status
     comment: A Credential Status provides enough information to determine the current status of the credential (for example, suspended or revoked). This class serves as a supertype for specific status types.
 
+  - id: ConfidenceMethod
+    label: Confidence method
+    defined_by: https://w3c-ccg.github.io/confidence-method-spec/
+    comment: A Confidence Method provides enough information for a verifier to determine whether the holder can generate a verifiable presentation to increase the verifier's confidence that they are the same entity referenced by the confidence method. This class serves as a supertype for specific status types.
+    status: reserved
+
   - id: JsonSchema2023
     label: JSON schema validator 2023
     defined_by: https://www.w3.org/TR/vc-json-schema/#jsonschema2023
@@ -71,6 +77,12 @@ property:
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-credentialStatus
     domain: cred:VerifiableCredential
     range: cred:CredentialStatus
+
+  - id: confidenceMethod
+    label: Confidence method
+    defined_by: https://w3c-ccg.github.io/confidence-method-spec/
+    status: reserved
+    range: cred:ConfidenceMethod
 
   - id: credentialSubject
     label: Credential subject

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -34,9 +34,9 @@ class:
     defined_by: https://w3c-ccg.github.io/confidence-method-spec/
     status: reserved
 
-  - id: JsonSchema2023
-    label: JSON schema validator 2023
-    defined_by: https://www.w3.org/TR/vc-json-schema/#jsonschema2023
+  - id: JsonSchema
+    label: JSON schema validator
+    defined_by: https://www.w3.org/TR/vc-json-schema/#jsonschema
     upper_value: cred:CredentialSchema
 
   - id: JsonSchemaCredential

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -32,7 +32,6 @@ class:
   - id: ConfidenceMethod
     label: Confidence method
     defined_by: https://w3c-ccg.github.io/confidence-method-spec/
-    comment: A Confidence Method provides enough information for a verifier to determine whether the holder can generate a verifiable presentation to increase the verifier's confidence that they are the same entity referenced by the confidence method. This class serves as a supertype for specific confidence method types.
     status: reserved
 
   - id: JsonSchema2023


### PR DESCRIPTION
This is, content-wise, the same PR as #1226, but starting fresh due to the merge problems. See https://github.com/w3c/vc-data-model/pull/1226#issuecomment-1665495765.

No need to re-review from scratch, just taking over #1226