### PR TITLE
Editorial update index.html: use JsonSchema and not JsonSchema2023 — bis

### DIFF
--- a/index.html
+++ b/index.html
@@ -2224,7 +2224,7 @@ The value of the <code>credentialSchema</code> <a>property</a> MUST be one or
 more data schemas that provide <a>verifiers</a> with enough information to
 determine if the provided data conforms to the provided schema(s). Each
 <code>credentialSchema</code> MUST specify its <code>type</code> (for example,
-<code>JsonSchema2023</code>), and an <code>id</code> <a>property</a>
+<code>JsonSchema</code>), and an <code>id</code> <a>property</a>
 that MUST be a <a>URL</a> identifying the schema file. The precise contents of
 each data schema is determined by the specific type definition.
             </p>
@@ -2270,11 +2270,11 @@ integrity protection mechanism. The <code>credentialSchema</code>
   },
   <span class="highlight">"credentialSchema": [{
     "id": "https://example.org/examples/degree.json",
-    "type": "JsonSchema2023"
+    "type": "JsonSchema"
   },
   {
     "id": "https://example.org/examples/alumni.json",
-    "type": "JsonSchema2023"
+    "type": "JsonSchema"
   }]</span>
 }
         </pre>


### PR DESCRIPTION
This is, content-wise, the same PR as #1225, but starting fresh due to the merge problems. See #1226 (comment).

No need to re-review from scratch, just taking over #1225


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1229.html" title="Last updated on Aug 4, 2023, 3:23 PM UTC (ee7d5c8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1229/7e6e996...ee7d5c8.html" title="Last updated on Aug 4, 2023, 3:23 PM UTC (ee7d5c8)">Diff</a>