### PR TITLE
Removing the serviceEndpoint vocabulary item

### DIFF
--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -127,12 +127,6 @@ property:
     status: reserved
     range: cred:RefreshService
 
-  - id: serviceEndpoint
-    label: Service endpoint
-    domain: cred:RefreshService
-    range: IRI
-    comment: The value of this property must be a URL to the service endpoint associated with the subject. <b><em>There is no URL yet in a VCWG document to <em>define</em> this term.</em></b>
-
   - id: termsOfUse
     label: Terms of use
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-termsOfUse


### PR DESCRIPTION
This (under-specified) property has been removed from the VCDM spec, so this PR removes the item from the vocabulary, too.