### PR TITLE
Add sd-jwt registered claim names to v2 context

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -55,6 +55,15 @@
         }
       }
     },
+    "_sd_alg": {
+      "@id": "https://www.iana.org/assignments/jwt#_sd_alg"
+    },
+    "_sd": {
+      "@id": "https://www.iana.org/assignments/jwt#_sd"
+    },
+    "...": {
+      "@id": "https://www.iana.org/assignments/jwt#..."
+    },
 
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",


### PR DESCRIPTION
This PR adds registered claim names for sd-jwt to the v2 context.

Like the other PRs, it assumes IANA registries are navigable.

Unlike the other PRs, these terms are not yet present in the JWT registries... so the OAuth WG should be consulted on the best location for implementers to understand these terms.

[Example SD-JWT that would use these definitions](https://jwt.io/#debugger-io?token=eyJhbGciOiJFUzM4NCJ9.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3czaWQub3JnL3RyYWNlYWJpbGl0eS92MSJdLCJpZCI6Imh0dHA6Ly9zdXBwbHktY2hhaW4uZXhhbXBsZS9jcmVkZW50aWFscy9kZDBjNmY5YS01ZGY2LTQwYTMtYmIzNC04NjNjZDFmZGE2MDYiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiRW50cnlOdW1iZXJDcmVkZW50aWFsIl0sInZhbGlkRnJvbSI6IjIwMjMtMDgtMTVUMTU6NTg6NTUuNzMyWiIsInZhbGlkVW50aWwiOiIyMDIzLTA5LTE1VDE1OjU4OjU1LjczMloiLCJpc3N1ZXIiOnsidHlwZSI6WyJPcmdhbml6YXRpb24iXSwiaWQiOiJkaWQ6d2ViOmlzc3Vlci5leGFtcGxlIiwibmFtZSI6IkFDTUUgQ3VzdG9tcyBCcm9rZXIiLCJfc2QiOlsiX1lqMkM3akhIWGozRHNtV19QQTVHc1NTZFNTX0RHN2s2ZV9hNFpPdUJURSJdfSwiY3JlZGVudGlhbFN1YmplY3QiOnsidHlwZSI6WyJFbnRyeU51bWJlciJdLCJfc2QiOlsiNW1wOG1iejBsQWtfd0txTzcwbWtfZzJLRkh1MFRBQzk2SVpSaXhja3pSUSJdfSwiX3NkX2FsZyI6InNoYS0yNTYiLCJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5leGFtcGxlIiwiaWF0IjoxNjkyMTE1MTM1LCJleHAiOjE2OTQ3OTM1MzUsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTM4NCIsIngiOiJEX2pIbVZ3TVRsNnF3LTQ5U2lYSjU5OVI2bnB0WTN2Yk96ckNEQjhUSFlGZklvVFVJeXZkaXBMR2FNcFRYblBIIiwieSI6ImhwQmx1RHB1VDY4QzE3cnVYMGtkOU5OT0g5V016bFE5V2lHWWQteEhDZ0ZnYjg4d2pQNTlaVkdjYm1mMUdJdWIifX19.l-l0HIRuyxbpxiisQdcS260Fz5j0yJgWdLyk9rgS1UZP6yoq2Y6BVGoROQwfw7t6dxzUrSxqzan7qwCB2_Q56LMaFb-JdkOQAPlVEZZlOT1Zfw9gpzrV38_0n3rZd_7z~WyJmaGhwQ1pvMlR1VmNJekJBNDUxZWNBIiwgImxvY2F0aW9uIiwgeyJ0eXBlIjogWyJQbGFjZSJdLCAiYWRkcmVzcyI6IHsidHlwZSI6IFsiUG9zdGFsQWRkcmVzcyJdLCAic3RyZWV0QWRkcmVzcyI6ICIxMjMgRXhhbXBsZSBTdHJlZXQiLCAiYWRkcmVzc0xvY2FsaXR5IjogIlRvcm9udG8iLCAiYWRkcmVzc1JlZ2lvbiI6ICJPTiIsICJhZGRyZXNzQ291bnRyeSI6ICJDQSIsICJwb3N0YWxDb2RlIjogIk0zQiAxQTIifX1d~WyIzSU9kakNWLWl2Tml6YXVtLUt3YW53IiwgImVudHJ5TnVtYmVyIiwgIjEyMzQ1MTIzNDU2Il0)

Example n-quads produced from the current v2 context:

```
<did:web:issuer.example> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://schema.org/Organization> .
<did:web:issuer.example> <https://schema.org/name> "ACME Customs Broker" .
🔥 <did:web:issuer.example> <https://www.w3.org/ns/credentials/issuer-dependent#_sd> "_Yj2C7jHHXj3DsmW_PA5GsSSdSS_DG7k6e_a4ZOuBTE" .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/traceability#EntryNumberCredential> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://www.w3.org/2018/credentials#VerifiableCredential> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.iana.org/assignments/jose#iss> <did:web:issuer.example> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.iana.org/assignments/jwt#cnf> _:c14n0 .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.iana.org/assignments/jwt#exp> "1694793535"^^<https://www.w3.org/2001/XMLSchema#nonNegativeInteger> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.iana.org/assignments/jwt#iat> "1692115135"^^<https://www.w3.org/2001/XMLSchema#nonNegativeInteger> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.w3.org/2018/credentials#credentialSubject> _:c14n1 .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.w3.org/2018/credentials#issuer> <did:web:issuer.example> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.w3.org/2018/credentials#validFrom> "2023-08-15T15:58:55.732Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
<http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.w3.org/2018/credentials#validUntil> "2023-09-15T15:58:55.732Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
🔥 <http://supply-chain.example/credentials/dd0c6f9a-5df6-40a3-bb34-863cd1fda606> <https://www.w3.org/ns/credentials/issuer-dependent#_sd_alg> "sha-256" .
_:c14n0 <https://www.iana.org/assignments/jwt#jwk> "{\"crv\":\"P-384\",\"kty\":\"EC\",\"x\":\"D_jHmVwMTl6qw-49SiXJ599R6nptY3vbOzrCDB8THYFfIoTUIyvdipLGaMpTXnPH\",\"y\":\"hpBluDpuT68C17ruX0kd9NNOH9WMzlQ9WiGYd-xHCgFgb88wjP59ZVGcbmf1GIub\"}"^^<http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON> .
_:c14n1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://w3id.org/traceability#EntryNumber> .
🔥 _:c14n1 <https://www.w3.org/ns/credentials/issuer-dependent#_sd> "5mp8mbz0lAk_wKqO70mk_g2KFHu0TAC96IZRixckzRQ" .

```