### PR TITLE
Provide actionable guidance related to base context hash value.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5468,9 +5468,18 @@ It is possible to confirm the SHA-384 digest above by running the following
 command from a modern Unix command interface line:
 `curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`
         </p>
+        <p>
 More details regarding this hash encoding method can be found in the <a
 href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a>
 section of [[SRI]].
+        </p>
+        <p class="note" title="See errata if hash value changes are detected">
+It is extremely unlikely that the files that have associated cryptographic hash
+values in this specification will change. However, if critical errata are
+found in the specification and corrections are required to ensure
+ecosystem stability the cryptographic hash values might change. As such, the
+HTTP cache times for the files are not set to infinity and implementers are
+advised to check for errata if a cryptographic hash value change is detected.
         </p>
         <p>
 This section serves as a reminder of the importance of ensuring that, when

--- a/index.html
+++ b/index.html
@@ -5453,8 +5453,8 @@ the referenced files to be modified.
         </p>
         <p>
 Implementations MUST treat the base context value, located at
-<code>https://www.w3.org/ns/credentials/v2</code>, as already resolved where the
-content of the resource matches the following SHA-384 digest of the value
+<code>https://www.w3.org/ns/credentials/v2</code>, as already retrieved;
+the following value is the SHA-384 digest of the resource
 computed and encoded according to the [[SRI]] definition of `digest`:
 <strong><code>vxRgTREj3/ZmDabpiTX+Au4UXY8GDhyCSFNw+UQtdtISDyO/znDUY+FTg8rNsGXJ</code></strong>.
 It is strongly advised that all JSON-LD Context URLs used by an

--- a/index.html
+++ b/index.html
@@ -5452,24 +5452,24 @@ Candidate Recommendation phase based on implementer feedback that requires
 the referenced files to be modified.
         </p>
         <p>
-Implementations MUST ensure that the base context value, located at
-<code>https://www.w3.org/ns/credentials/v2</code>, matches the following
-SHA-384 digest of the value computed and encoded according to the [[SRI]] definition of `digest`:
-<strong><code>lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK</code></strong>.
-The base context value matching the digest previously stated can be used to
-implement a local cached copy. It is possible to confirm the
-SHA-384 digest by running the following command from a modern Unix command
-interface line:
+Implementations MUST treat the base context value, located at
+<code>https://www.w3.org/ns/credentials/v2</code>, as already resolved where the
+content of the resource matches the following SHA-384 digest of the value
+computed and encoded according to the [[SRI]] definition of `digest`:
+<strong><code>vxRgTREj3/ZmDabpiTX+Au4UXY8GDhyCSFNw+UQtdtISDyO/znDUY+FTg8rNsGXJ</code></strong>.
+It is strongly advised that all JSON-LD Contexts used in an
+application utilize a similar mechanism to ensure end-to-end security and
+implementations are expected to throw errors if a resource's cryptographic hash
+value does not match the expected hash value.
+        </p>
+        <p>
+It is possible to confirm the SHA-384 digest above by running the following
+command from a modern Unix command interface line:
 `curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`.
         </p>
-        <p class="issue" data-number="1177">
-The Working Group is currently discussing what a processor should do if a hash
-value differs from one that is listed in the specification.
-        </p>
-More details regarding this hash encoding method may be found in the <a
+More details regarding this hash encoding method can be found in the <a
 href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a>
-section of [[SRI]]. It is strongly advised that all JSON-LD Contexts used in an
-application utilize a similar mechanism to ensure end-to-end security.
+section of [[SRI]].
         </p>
         <p>
 This section serves as a reminder of the importance of ensuring that, when
@@ -5495,9 +5495,9 @@ Verifiers are warned that other data that is referenced from within a
 credential, such as resources that are linked to via URLs, are not
 cryptographically protected by default. It is considered a best practice to
 ensure that the same sorts of protections are provided for any URL that is
-critical to the security of the credential through the use of permanently cached
-files and/or cryptographic hashes. See the <a
-data-cite="vc-imp-guide/#content-integrity">Content Integrity</a>
+critical to the security of the <a>verifiable credential</a> through the use of
+permanently cached files and/or cryptographic hashes. See the
+<a data-cite="vc-imp-guide/#content-integrity">Content Integrity</a>
 section of the Verifiable Credential Implementation Guide for further
 information. Ultimately, knowing the cryptographic digest of any linked external
 content enables a <a>verifier</a> to confirm that the content is the same

--- a/index.html
+++ b/index.html
@@ -5457,15 +5457,16 @@ Implementations MUST treat the base context value, located at
 content of the resource matches the following SHA-384 digest of the value
 computed and encoded according to the [[SRI]] definition of `digest`:
 <strong><code>vxRgTREj3/ZmDabpiTX+Au4UXY8GDhyCSFNw+UQtdtISDyO/znDUY+FTg8rNsGXJ</code></strong>.
-It is strongly advised that all JSON-LD Contexts used in an
-application utilize a similar mechanism to ensure end-to-end security and
-implementations are expected to throw errors if a resource's cryptographic hash
-value does not match the expected hash value.
+It is strongly advised that all JSON-LD Context URLs used by an
+application utilize the same mechanism, or a functionally equivalent mechanism,
+to ensure end-to-end security. Implementations are expected to throw errors
+if a cryptographic hash value for a resource does not match the expected hash
+value.
         </p>
         <p>
 It is possible to confirm the SHA-384 digest above by running the following
 command from a modern Unix command interface line:
-`curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`.
+`curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`
         </p>
 More details regarding this hash encoding method can be found in the <a
 href="https://www.w3.org/TR/SRI/#integrity-metadata">integrity metadata</a>
@@ -5486,7 +5487,7 @@ mechanisms such as [[VC-JOSE-COSE]] and [[VC-DATA-INTEGRITY]].
           </li>
           <li>
 The content in a credential whose meaning depends on a link to an external URL,
-such as a JSON-LD Context, which can be secured by using a local static copy,
+such as a JSON-LD Context, which can be secured by using a local static copy
 or a cryptographic digest of the file.
           </li>
         </ol>


### PR DESCRIPTION
This PR attempts to address issue #1177 by providing actionable guidance related to base context hash value. The text applies a suggestion by @jyasskin to treat the context URLs as "already resolved" with specific hash values. It also notes that implementations are expected to throw errors when hash values differ from the expected value w/o saying that they MUST throw errors (in cases where hash values change all the time, like schema.org).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1249.html" title="Last updated on Aug 27, 2023, 11:01 PM UTC (aec155a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1249/43ac552...aec155a.html" title="Last updated on Aug 27, 2023, 11:01 PM UTC (aec155a)">Diff</a>