### PR TITLE
Apply range requirements to validFrom/validUntil.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1669,6 +1669,14 @@ the <code>validUntil</code> <a>property</a> for expressing the date and time
 when a <a>credential</a> ceases to be valid.
         </p>
 
+        <p>
+When comparing dates and times, the calculation is done "temporally", which
+means that the string value is converted to a "temporal value" which exists
+as a point on a timeline. Temporal comparisons are then performed by checking
+to see where the date and time being compared is in relation to
+a particular point on the timeline.
+        </p>
+
         <dl>
           <dt><var id="defn-validFrom">validFrom</var></dt>
           <dd>
@@ -1679,7 +1687,7 @@ an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
 Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>
 <a>property</a> becomes valid. If a `validUntil` value also exists, the
-`validFrom` value MUST express a datetime that is temporally the same or 
+`validFrom` value MUST express a datetime that is temporally the same or
 earlier than the datetime expressed by the `validUntil` value.
           </dd>
           <dt><var id="defn-validUntil">validUntil</var></dt>

--- a/index.html
+++ b/index.html
@@ -1679,8 +1679,8 @@ an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
 Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>
 <a>property</a> becomes valid. If a `validUntil` value also exists, the
-`validFrom` value MUST be temporally the same or earlier than the `validUntil`
-value.
+`validFrom` value MUST express a datetime that is temporally the same or 
+earlier than the datetime expressed by the `validUntil` value.
           </dd>
           <dt><var id="defn-validUntil">validUntil</var></dt>
           <dd>
@@ -1690,8 +1690,9 @@ If present, the value of the <code>validUntil</code> <a>property</a> MUST be an
 <a>credential</a> ceases to be valid, which could be a date and time in the
 past. Note that this value represents the latest point in time at which the
 information associated with the <code>credentialSubject</code> <a>property</a>
-is valid. If a `validFrom` value also exists, the `validUntil` value MUST be
-temporally the same or later than the `validFrom` value.
+is valid. If a `validFrom` value also exists, the `validUntil` value MUST
+express a datetime that is temporally the same or later than the datetime
+expressed by the `validFrom` value.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -1678,7 +1678,9 @@ an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
 <a>credential</a> becomes valid, which could be a date and time in the future.
 Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>
-<a>property</a> becomes valid.
+<a>property</a> becomes valid. If a `validUntil` value also exists, the
+`validFrom` value MUST be temporally the same or earlier than the `validUntil`
+value.
           </dd>
           <dt><var id="defn-validUntil">validUntil</var></dt>
           <dd>
@@ -1688,8 +1690,8 @@ If present, the value of the <code>validUntil</code> <a>property</a> MUST be an
 <a>credential</a> ceases to be valid, which could be a date and time in the
 past. Note that this value represents the latest point in time at which the
 information associated with the <code>credentialSubject</code> <a>property</a>
-is valid. If a `validFrom` value exists, the `validUntil` value MUST be
-temporally greater than the `validFrom` value.
+is valid. If a `validFrom` value also exists, the `validUntil` value MUST be
+temporally the same or later than the `validFrom` value.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -1675,7 +1675,7 @@ when a <a>credential</a> ceases to be valid.
 If present, the value of the <code>validFrom</code> <a>property</a> MUST be
 an [<a data-cite="XMLSCHEMA11-2#dateTime">XMLSCHEMA11-2</a>]
 <code>dateTimeStamp</code> string value representing the date and time the
-<a>credential</a> becomes valid, which could be a date and time in the future.
+<a>credential</a> becomes valid, which could be a date and time in the future or in the past.
 Note that this value represents the earliest point in time
 at which the information associated with the <code>credentialSubject</code>
 <a>property</a> becomes valid. If a `validUntil` value also exists, the
@@ -1688,7 +1688,7 @@ If present, the value of the <code>validUntil</code> <a>property</a> MUST be an
 [<a data-cite="XMLSCHEMA11-2#dateTimeStamp">XMLSCHEMA11-2</a>]
 <code>dateTimeStamp</code> string value representing the date and time the
 <a>credential</a> ceases to be valid, which could be a date and time in the
-past. Note that this value represents the latest point in time at which the
+past or in the future. Note that this value represents the latest point in time at which the
 information associated with the <code>credentialSubject</code> <a>property</a>
 is valid. If a `validFrom` value also exists, the `validUntil` value MUST
 express a datetime that is temporally the same or later than the datetime


### PR DESCRIPTION
This PR is an attempt to address issue #1231 by applying value range requirements to `validFrom` and `validUntil` as requested by @David-Chadwick, @TallTed, and @dlongley.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1250.html" title="Last updated on Aug 27, 2023, 11:13 PM UTC (d0c9d3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1250/f4a8ea1...d0c9d3d.html" title="Last updated on Aug 27, 2023, 11:13 PM UTC (d0c9d3d)">Diff</a>