### PR TITLE
Outline plan to mitigate normative context risk when transitioning to Proposed Recommendation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5451,6 +5451,17 @@ franchise. Policy information expressed by the <a>issuer</a> in the
 This section lists cryptographic hash values that might change during the
 Candidate Recommendation phase based on implementer feedback that requires
 the referenced files to be modified.
+<br><br>
+The Working Group is expecting all of the terms and URLs supplied in the
+JSON-LD Context to be either stabilized, or removed, before the publication of
+this specification as a Proposed Recommendation. While that means that this
+specification could be delayed if dependencies such as [[?VC-DATA-INTEGRITY]],
+[[?VC-JOSE-COSE]], SD-JWT, [[?VC-JSON-SCHEMA-2023]], or status list
+do not enter the Proposed Recommendation phase around the same time frame, the
+Working Group is prepared to remove the dependencies if an undue burden is
+placed on transitioning to the Recommendation phase. This is a calculated
+risk that the Working Group is taking and has a mitigation strategy in place
+to ensure the timely transition of this specification to a Recommendation.
         </p>
         <p>
 Implementations MUST ensure that the base context value, located at


### PR DESCRIPTION
This PR attempts to address issue #1175 by outlining the mitigation strategy for ensuring that the contents in the base context don't impact the various specifications being worked on by this WG from transitioning to Recommendation status in a timely way.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1251.html" title="Last updated on Aug 20, 2023, 9:33 PM UTC (13e8004)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1251/03b0d90...13e8004.html" title="Last updated on Aug 20, 2023, 9:33 PM UTC (13e8004)">Diff</a>