### PR TITLE
Add section about Names and Descriptions of credentials.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -85,7 +85,12 @@
           "@id": "https://www.w3.org/2018/credentials#credentialSubject",
           "@type": "@id"
         },
-        "description": "https://schema.org/description",
+        "description": {
+          "@id": "https://schema.org/description",
+          "@context": {
+            "value": "@value", "lang": "@language", "dir": "@direction"
+          }
+        },
         "evidence": {
           "@id": "https://www.w3.org/2018/credentials#evidence",
           "@type": "@id"
@@ -107,11 +112,26 @@
             "id": "@id",
             "type": "@type",
 
-            "description": "https://schema.org/description",
-            "name": "https://schema.org/name"
+            "description": {
+              "@id": "https://schema.org/description",
+              "@context": {
+                "value": "@value", "lang": "@language", "dir": "@direction"
+              }
+            },
+            "name": {
+              "@id": "https://schema.org/name",
+              "@context": {
+                "value": "@value", "lang": "@language", "dir": "@direction"
+              }
+            }
           }
         },
-        "name": "https://schema.org/name",
+        "name": {
+          "@id": "https://schema.org/name",
+          "@context": {
+            "value": "@value", "lang": "@language", "dir": "@direction"
+          }
+        },
         "proof": {
           "@id": "https://w3id.org/security#proof",
           "@type": "@id",

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -85,9 +85,7 @@
           "@id": "https://www.w3.org/2018/credentials#credentialSubject",
           "@type": "@id"
         },
-        "description": {
-          "@id": "https://schema.org/description"
-        },
+        "description": "https://schema.org/description",
         "evidence": {
           "@id": "https://www.w3.org/2018/credentials#evidence",
           "@type": "@id"
@@ -102,11 +100,18 @@
         },
         "issuer": {
           "@id": "https://www.w3.org/2018/credentials#issuer",
-          "@type": "@id"
+          "@type": "@id",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "description": "https://schema.org/description",
+            "name": "https://schema.org/name"
+          }
         },
-        "name": {
-          "@id": "https://schema.org/name"
-        },
+        "name": "https://schema.org/name",
         "proof": {
           "@id": "https://w3id.org/security#proof",
           "@type": "@id",

--- a/index.html
+++ b/index.html
@@ -1514,11 +1514,11 @@ An OPTIONAL property that expresses the name of the <a>credential</a>. If
 present, the value of the <code>name</code> <a>property</a> MUST be a string or
 an object. If the value is an object, the object MUST contain a `value` property
 whose value is a string, and SHOULD contain a `lang` property whose value is a
-`langtag` defined in [[BCP47]], and MAY contain a `dir` property whose value is
-a text direction code defined by the `dir` attribute in [[HTML5]]. Ideally, the
-name of a <a>credential</a> is concise, human-readable, and could be used to
-enable an individual to quickly differentiate the <a>credential</a> from other
-<a>credentials</a> that they might hold.
+`langtag` string defined in [[BCP47]], and MAY contain a `dir` property whose
+value is a text direction string defined by the `dir` attribute in [[HTML5]].
+Ideally, the name of a <a>credential</a> is concise, human-readable, and could
+be used to enable an individual to quickly differentiate the <a>credential</a>
+from other <a>credentials</a> that they might hold.
           </dd>
           <dt><dfn class="lint-ignore">description</dfn></dt>
           <dd>
@@ -1526,10 +1526,10 @@ An OPTIONAL property that conveys specific details about a <a>credential</a>. If
 present, the value of the <code>description</code> <a>property</a> MUST be a
 string or an object. If the value is an object, the object MUST contain a
 `value` property whose value is a string, and SHOULD contain a `lang` property
-whose value is a `langtag` defined in [[BCP47]], and MAY contain a `dir`
-property whose value is a text direction code defined by the `dir` attribute in
-[[HTML5]]. Ideally, the description of a <a>credential</a> is no longer than a
-few sentences in length and conveys enough information about the
+whose value is a `langtag` string defined in [[BCP47]], and MAY contain a `dir`
+property whose value is a text direction string defined by the `dir` attribute
+in [[HTML5]]. Ideally, the description of a <a>credential</a> is no longer than
+a few sentences in length and conveys enough information about the
 <a>credential</a> to remind an individual as to its contents without having to
 look through the entirety of the <a>claims</a>.
           </dd>

--- a/index.html
+++ b/index.html
@@ -1520,8 +1520,8 @@ be used to enable an individual to quickly differentiate the
           <dd>
 An OPTIONAL property that conveys specific details about a <a>credential</a>.
 If present, the value of the <code>description</code> <a>property</a> MUST be a
-string. Ideally, the description of a <a>credential</a> is a few sentences
-in length and conveys enough information about the
+string. Ideally, the description of a <a>credential</a> is no longer than a
+few sentences in length and conveys enough information about the
 <a>credential</a> to remind an individual as to its contents without having
 to look through the entirety of the <a>claims</a>.
           </dd>

--- a/index.html
+++ b/index.html
@@ -1511,19 +1511,27 @@ are provided for these purposes.
           <dt><dfn class="lint-ignore">name</dfn></dt>
           <dd>
 An OPTIONAL property that expresses the name of the <a>credential</a>. If
-present, the value of the <code>name</code> <a>property</a> MUST be a string.
-Ideally, the name of a <a>credential</a> is concise, human-readable, and could
-be used to enable an individual to quickly differentiate the
-<a>credential</a> from other <a>credentials</a> that they might hold.
+present, the value of the <code>name</code> <a>property</a> MUST be a string or
+an object. If the value is an object, the object MUST contain a `value` property
+whose value is a string, and SHOULD contain a `lang` property whose value is a
+`langtag` defined in [[BCP47]], and MAY contain a `dir` property whose value is
+a text direction code defined by the `dir` attribute in [[HTML5]]. Ideally, the
+name of a <a>credential</a> is concise, human-readable, and could be used to
+enable an individual to quickly differentiate the <a>credential</a> from other
+<a>credentials</a> that they might hold.
           </dd>
           <dt><dfn class="lint-ignore">description</dfn></dt>
           <dd>
-An OPTIONAL property that conveys specific details about a <a>credential</a>.
-If present, the value of the <code>description</code> <a>property</a> MUST be a
-string. Ideally, the description of a <a>credential</a> is no longer than a
+An OPTIONAL property that conveys specific details about a <a>credential</a>. If
+present, the value of the <code>description</code> <a>property</a> MUST be a
+string or an object. If the value is an object, the object MUST contain a
+`value` property whose value is a string, and SHOULD contain a `lang` property
+whose value is a `langtag` defined in [[BCP47]], and MAY contain a `dir`
+property whose value is a text direction code defined by the `dir` attribute in
+[[HTML5]]. Ideally, the description of a <a>credential</a> is no longer than a
 few sentences in length and conveys enough information about the
-<a>credential</a> to remind an individual as to its contents without having
-to look through the entirety of the <a>claims</a>.
+<a>credential</a> to remind an individual as to its contents without having to
+look through the entirety of the <a>claims</a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -1501,10 +1501,10 @@ Implementation Guidelines [[?VC-IMP-GUIDE]].
 
         <p>
 When displaying a <a>credential</a>, it can be useful to have
-text provided by the <a>issuer</a> that provides the
-<a>credential</a> with a name as well as a short description of the
-purpose of the <a>credential</a>. The `name` and `description` <a>properties</a>
-are provided for these purposes.
+text provided by the <a>issuer</a> that furnishes the
+<a>credential</a> with a name as well as a short description of its
+purpose. The `name` and `description` <a>properties</a>
+are meant to serve these purposes.
         </p>
 
         <dl>
@@ -1514,11 +1514,12 @@ An OPTIONAL property that expresses the name of the <a>credential</a>. If
 present, the value of the <code>name</code> <a>property</a> MUST be a string or
 an object. If the value is an object, the object MUST contain a `value` property
 whose value is a string, and SHOULD contain a `lang` property whose value is a
-`langtag` string defined in [[BCP47]], and MAY contain a `dir` property whose
+string containing a well-formed `Language-Tag` as defined by [[BCP47]],
+and MAY contain a `dir` property whose
 value is a text direction string defined by the `dir` attribute in [[JSON-LD]].
 Ideally, the name of a <a>credential</a> is concise, human-readable, and could
-be used to enable an individual to quickly differentiate the <a>credential</a>
-from other <a>credentials</a> that they might hold.
+enable an individual to quickly differentiate one <a>credential</a>
+from any other <a>credentials</a> that they might hold.
           </dd>
           <dt><dfn class="lint-ignore">description</dfn></dt>
           <dd>
@@ -1526,11 +1527,12 @@ An OPTIONAL property that conveys specific details about a <a>credential</a>. If
 present, the value of the <code>description</code> <a>property</a> MUST be a
 string or an object. If the value is an object, the object MUST contain a
 `value` property whose value is a string, and SHOULD contain a `lang` property
-whose value is a `langtag` string defined in [[BCP47]], and MAY contain a `dir`
+whose value is a string containing a well-formed language tag as defined
+by [[BCP47]], and MAY contain a `dir`
 property whose value is a text direction string defined by the `dir` attribute
-in [[JSON-LD]]. Ideally, the description of a <a>credential</a> is no longer than
+in [[JSON-LD]]. Ideally, the description of a <a>credential</a> is no more than
 a few sentences in length and conveys enough information about the
-<a>credential</a> to remind an individual as to its contents without having to
+<a>credential</a> to remind an individual of its contents without their having to
 look through the entirety of the <a>claims</a>.
           </dd>
         </dl>
@@ -1567,7 +1569,7 @@ look through the entirety of the <a>claims</a>.
 Names and descriptions also support expressing content in different languages.
 To express a string with language and text direction information, one can use
 an object that contains the `value`, `lang`, and `dir` properties to express
-the text value, language code, and text direction, respectively.
+the text value, language tag, and text direction, respectively.
 See <a href="#language-and-base-direction"></a> for further information.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1515,7 +1515,7 @@ present, the value of the <code>name</code> <a>property</a> MUST be a string or
 an object. If the value is an object, the object MUST contain a `value` property
 whose value is a string, and SHOULD contain a `lang` property whose value is a
 `langtag` string defined in [[BCP47]], and MAY contain a `dir` property whose
-value is a text direction string defined by the `dir` attribute in [[HTML5]].
+value is a text direction string defined by the `dir` attribute in [[JSON-LD]].
 Ideally, the name of a <a>credential</a> is concise, human-readable, and could
 be used to enable an individual to quickly differentiate the <a>credential</a>
 from other <a>credentials</a> that they might hold.
@@ -1528,7 +1528,7 @@ string or an object. If the value is an object, the object MUST contain a
 `value` property whose value is a string, and SHOULD contain a `lang` property
 whose value is a `langtag` string defined in [[BCP47]], and MAY contain a `dir`
 property whose value is a text direction string defined by the `dir` attribute
-in [[HTML5]]. Ideally, the description of a <a>credential</a> is no longer than
+in [[JSON-LD]]. Ideally, the description of a <a>credential</a> is no longer than
 a few sentences in length and conveys enough information about the
 <a>credential</a> to remind an individual as to its contents without having to
 look through the entirety of the <a>claims</a>.

--- a/index.html
+++ b/index.html
@@ -1497,6 +1497,62 @@ Implementation Guidelines [[?VC-IMP-GUIDE]].
       </section>
 
       <section>
+        <h3>Names and Descriptions</h3>
+
+        <p>
+When displaying a <a>credential</a>, it can be useful to have
+text provided by the <a>issuer</a> that provides the
+<a>credential</a> with a name as well as a short description of the
+purpose of the <a>credential</a>. The `name` and `description` <a>properties</a>
+are provided for these purposes.
+        </p>
+
+        <dl>
+          <dt><dfn class="lint-ignore">name</dfn></dt>
+          <dd>
+An OPTIONAL property that expresses the name of the <a>credential</a>. If
+present, the value of the <code>name</code> <a>property</a> MUST be a string.
+Ideally, the name of a <a>credential</a> is concise, human-readable, and could
+be used to enable an individual to quickly differentiate the
+<a>credential</a> from other <a>credentials</a> that they might hold.
+          </dd>
+          <dt><dfn class="lint-ignore">description</dfn></dt>
+          <dd>
+An OPTIONAL property that conveys specific details about a <a>credential</a>.
+If present, the value of the <code>description</code> <a>property</a> MUST be a
+string. Ideally, the description of a <a>credential</a> is a few sentences
+in length and conveys enough information about the
+<a>credential</a> to remind an individual as to its contents without having
+to look through the entirety of the <a>claims</a>.
+          </dd>
+        </dl>
+
+        <pre class="example nohighlight vc"
+          title="Usage of the name and description property"
+          data-vc-vm="https://university.example/issuers/565049#key-1">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  <span class="highlight">"type": ["VerifiableCredential", "ExampleDegreeCredential"]</span>,
+  "issuer": "https://university.example/issuers/565049",
+  "validFrom": "2015-05-10T12:30:00Z",
+  "name": "Example University Degree",
+  "description": "2015 Bachelor of Science and Arts Degree from Example University."
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": "Bachelor of Science and Arts"
+    }
+  }
+}
+        </pre>
+      </section>
+
+      <section>
         <h3>Credential Subject</h3>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -1537,7 +1537,11 @@ to look through the entirety of the <a>claims</a>.
   ],
   "id": "http://university.example/credentials/3732",
   <span class="highlight">"type": ["VerifiableCredential", "ExampleDegreeCredential"]</span>,
-  "issuer": "https://university.example/issuers/565049",
+  "issuer": {
+    "id": "https://university.example/issuers/565049",
+    "name": "Example University",
+    "description": "A public university focusing on teaching examples."
+  },
   "validFrom": "2015-05-10T12:30:00Z",
   "name": "Example University Degree",
   "description": "2015 Bachelor of Science and Arts Degree"
@@ -1546,6 +1550,80 @@ to look through the entirety of the <a>claims</a>.
     "degree": {
       "type": "ExampleBachelorDegree",
       "name": "Bachelor of Science and Arts"
+    }
+  }
+}
+        </pre>
+
+        <p>
+Names and descriptions also support expressing content in different languages.
+To express a string with language and text direction information, one can use
+an object that contains the `value`, `lang`, and `dir` properties to express
+the text value, language code, and text direction, respectively.
+See <a href="#language-and-base-direction"></a> for further information.
+        </p>
+
+        <pre class="example nohighlight"
+          title="Usage of the name and description property">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "id": "http://university.example/credentials/3732",
+  "issuer": {
+    "id": "https://university.example/issuers/565049",
+    "name": [{
+      "value": "Example University",
+      "lang": "en"
+    }, {
+      "value": "Université de Exemple",
+      "lang": "fr"
+    }, {
+      "value": "جامعة المثال",
+      "lang": "ar",
+      "dir": "rtl"
+    }],
+    "description": [{
+      "value": "A public university focusing on teaching examples.",
+      "lang": "en"
+    }, {
+      "value": "Une université publique axée sur l'enseignement des exemples.",
+      "lang": "fr"
+    }, {
+      "value": "جامعة عامة تركز على أمثلة التدريس.",
+      "lang": "ar",
+      "dir": "rtl"
+    }]
+  },
+  "validFrom": "2015-05-10T12:30:00Z",
+  "name": "Example University Degree",
+  "description": [{
+    "value": "2015 Bachelor of Science and Arts Degree",
+    "lang": "en"
+  }, {
+    "value": "2015 Baccalauréat Scientifique et Arts",
+    "lang": "fr"
+  }, {
+    "value": "2015 بكالوريوس العلوم والآداب",
+    "lang": "ar",
+    "dir": "rtl"
+  }],
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "degree": {
+      "type": "ExampleBachelorDegree",
+      "name": [{
+        "value": "Bachelor of Science and Arts",
+        "lang": "en"
+      }, {
+        "value": "Baccalauréat en sciences et arts",
+        "lang": "fr"
+      }, {
+        "value": "بكالوريوس العلوم والآداب",
+        "lang": "ar",
+        "dir": "rtl"
+      }]
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -1540,7 +1540,7 @@ to look through the entirety of the <a>claims</a>.
   "issuer": "https://university.example/issuers/565049",
   "validFrom": "2015-05-10T12:30:00Z",
   "name": "Example University Degree",
-  "description": "2015 Bachelor of Science and Arts Degree from Example University."
+  "description": "2015 Bachelor of Science and Arts Degree"
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {

--- a/index.html
+++ b/index.html
@@ -1544,7 +1544,7 @@ look through the entirety of the <a>claims</a>.
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "id": "http://university.example/credentials/3732",
-  <span class="highlight">"type": ["VerifiableCredential", "ExampleDegreeCredential"]</span>,
+  "type": ["VerifiableCredential", "ExampleDegreeCredential"],
   "issuer": {
     "id": "https://university.example/issuers/565049",
     "name": "Example University",
@@ -1552,12 +1552,12 @@ look through the entirety of the <a>claims</a>.
   },
   "validFrom": "2015-05-10T12:30:00Z",
   "name": "Example University Degree",
-  "description": "2015 Bachelor of Science and Arts Degree"
+  "description": "2015 Bachelor of Science and Arts Degree",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
       "type": "ExampleBachelorDegree",
-      "name": "Bachelor of Science and Arts"
+      "subtype": "Bachelor of Science and Arts"
     }
   }
 }
@@ -1579,6 +1579,7 @@ See <a href="#language-and-base-direction"></a> for further information.
     "https://www.w3.org/ns/credentials/examples/v2"
   ],
   "id": "http://university.example/credentials/3732",
+  "type": ["VerifiableCredential", "ExampleDegreeCredential"],
   "issuer": {
     "id": "https://university.example/issuers/565049",
     "name": [{
@@ -1605,7 +1606,17 @@ See <a href="#language-and-base-direction"></a> for further information.
     }]
   },
   "validFrom": "2015-05-10T12:30:00Z",
-  "name": "Example University Degree",
+  "name": [{
+    "value": "Example University Degree",
+    "lang": "en"
+  }, {
+    "value": "Exemple de Diplôme Universitaire",
+    "lang": "fr"
+  }, {
+    "value": "مثال الشهادة الجامعية",
+    "lang": "ar",
+    "dir": "rtl"
+  }],
   "description": [{
     "value": "2015 Bachelor of Science and Arts Degree",
     "lang": "en"
@@ -1621,17 +1632,7 @@ See <a href="#language-and-base-direction"></a> for further information.
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
       "type": "ExampleBachelorDegree",
-      "name": [{
-        "value": "Bachelor of Science and Arts",
-        "lang": "en"
-      }, {
-        "value": "Baccalauréat en sciences et arts",
-        "lang": "fr"
-      }, {
-        "value": "بكالوريوس العلوم والآداب",
-        "lang": "ar",
-        "dir": "rtl"
-      }]
+      "subtype": "Bachelor of Science and Arts"
     }
   }
 }


### PR DESCRIPTION
This PR is an attempt to address issue #1214 by adding a section that defines the `name` and `description` properties.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1252.html" title="Last updated on Aug 29, 2023, 8:09 PM UTC (1974cd2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1252/dbd67ab...1974cd2.html" title="Last updated on Aug 29, 2023, 8:09 PM UTC (1974cd2)">Diff</a>