### PR TITLE
Vocabulary fixes — replacement of #1241

### DIFF
--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -269,6 +269,8 @@
             <text x="723" y="651" font-family="Helvetica" font-size="12" text-anchor="middle">validFrom</text>
         </switch>
     </a>
+    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 469h80.76"/>
+    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 469-8 4 2-4-2-4Z"/>
     <a xlink:href="https://w3.org/2018/credentials/#renderMethod">
         <rect width="160" height="30" x="643" y="454" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" rx="4.5" ry="4.5"/>
         <switch transform="translate(-.5 -.5)">
@@ -486,7 +488,7 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#CredentialEvidence">
-        <ellipse cx="987" cy="352" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
+        <ellipse cx="987" cy="352" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:352px;margin-left:893px">
@@ -505,7 +507,7 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#RefreshService">
-        <ellipse cx="987" cy="410" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
+        <ellipse cx="987" cy="410" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:410px;margin-left:893px">
@@ -524,7 +526,7 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#TermsOfUse">
-        <ellipse cx="987" cy="587" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
+        <ellipse cx="987" cy="587" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:587px;margin-left:893px">
@@ -633,6 +635,25 @@
         </foreignObject>
         <text x="273" y="154" font-family="Helvetica" font-size="11" text-anchor="middle">contains</text>
     </switch>
+    <a xlink:href="https://w3.org/2018/credentials/#ConfidenceMethod">
+        <ellipse cx="987" cy="469" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:469px;margin-left:893px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                            <font style="font-size:14px">
+                                <i>
+                                    RenderMethod
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text x="987" y="473" font-family="Helvetica" font-size="12" text-anchor="middle">RenderMethod</text>
+        </switch>
+    </a>
     <switch>
         <a xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank" transform="translate(0 -5)">
             <text x="50%" y="100%" font-size="10" text-anchor="middle">Text is not SVG - cannot display</text>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -19,15 +19,16 @@ ontology:
 class:
   - id: CredentialEvidence
     label: Credential Evidence
-    comment: A Credential Evidence provides evidence schemes that are used by the <a href="#evidence">evidence</a> property. This class serves as a supertype for specific evidence types.
+    comment: A credential evidence provides evidence schemes that are used by the <a href="#evidence">evidence</a> property. This class serves as a supertype for specific evidence types.
+    status: reserved
 
   - id: CredentialSchema
     label: Credential schema
-    comment: A Credential Schema provides verifiers with enough information to determine if the provided data conforms to the provided schema. This class serves as a supertype for specific schemas (e.g., <a href="#JsonSchema">JsonSchema</a>).
+    comment: A credential schema provides verifiers with enough information to determine if the provided data conforms to the provided schema. This class serves as a supertype for specific schemas (e.g., <a href="#JsonSchema">JsonSchema</a>).
 
   - id: CredentialStatus
     label: Credential status
-    comment: A Credential Status provides enough information to determine the current status of the credential (for example, suspended or revoked). This class serves as a supertype for specific status types.
+    comment: A credential status provides enough information to determine the current status of the credential (for example, suspended or revoked). This class serves as a supertype for specific status types.
 
   - id: ConfidenceMethod
     label: Confidence method
@@ -46,11 +47,18 @@ class:
 
   - id: RefreshService
     label: Refresh service
-    comment: A Refresh Service is a mechanism that can be utilized by software agents to retrieve an updated copy of a Verifiable Credential. This class serves as a supertype for specific refresh service types.
+    comment: A refresh service is a mechanism that can be utilized by software agents to retrieve an updated copy of a Verifiable Credential. This class serves as a supertype for specific refresh service types.
+    status: reserved
+
+  - id: RenderMethod
+    label: Render method
+    comment: A specific render method specifies how a software expresses the verifiable credential using a visual, auditory, or haptic mechanism. This class serves as a supertype for specific render method types.
+    status: reserved
 
   - id: TermsOfUse
     label: Terms of use
     comment: Policy under which the creator issued the credential or presentation. This class serves as a supertype for specific types for terms of use.
+    status: reserved
 
   # - id: StatusList2021Entry
   #   label: Status List 2021 Entry
@@ -140,7 +148,7 @@ property:
     domain: cred:VerifiableCredential
     defined_by: https://w3c-ccg.github.io/vc-render-method/#the-rendermethod-property
     status: reserved
-    range: cred:RefreshService
+    range: cred:RenderMethod
 
   - id: termsOfUse
     label: Terms of use

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -171,7 +171,7 @@ property:
 
   - id: verifiableCredential
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-verifiableCredential
-    label: Verifiable credential
+    label: Verifiable credential graph
     domain: cred:VerifiablePresentation
     range: cred:VerifiableCredentialGraph
     comment: The value of this property identifies a <a href="#VerifiableCredentialGraph">Verifiable credential graph</a>. (Informally, it indirectly identifies a <a href="#VerifiableCredential">Verifiable credential</a> contained in a separate graph.)


### PR DESCRIPTION
This is actually a replacement of #1241 : it includes all the changes in there, plus the missing pieces in https://github.com/w3c/vc-data-model/pull/1241#issuecomment-1685780129.

Making PR on top of #1241 would have led to problems because, in the meantime, the main branch has changed too much (e.g., the diagrams have been added), so it was simpler to create a PR on top of `main` rather than `fix/vocab-issues`