### PR TITLE
VCDM Media Types and HTTP

### DIFF
--- a/index.html
+++ b/index.html
@@ -3977,7 +3977,7 @@ system.
           <p>
 It is expected that HTTP endpoints will use the media types associated with
 <a>verifiable credentials</a> in accept headers. They are also expected to be
-used when indicated content types.
+used when indicating content types.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -3976,8 +3976,8 @@ system.
           <h2>HTTP</h2>
           <p>
 It is expected that HTTP endpoints will use the media types associated with
-<a>verifiable credentials</a> in accept headers. They are also expected to be
-used when indicating content types.
+<a>verifiable credentials</a> in accept headers and
+when indicating content types.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -3972,6 +3972,14 @@ ensure that payloads conform with the requirements for their use in a given
 system.
           </p>
         </section>
+        <section class="informative">
+          <h2>HTTP</h2>
+          <p>
+It is expected that HTTP endpoints will use the media types associated with
+<a>verifiable credentials</a> in accept headers. They are also expected to be
+used when indicated content types.
+          </p>
+        </section>
 
         <section class="informative">
           <h2>JSON Processing</h2>

--- a/index.html
+++ b/index.html
@@ -3976,13 +3976,13 @@ system.
           <h2>HTTP</h2>
           <p>
 It is expected that HTTP endpoints will use the media types associated with
-<a>verifiable credentials</a> and <a>verifiable presentations</a> in accept headers and
-when indicating content types.
+<a>verifiable credentials</a> and <a>verifiable presentations</a> in accept
+headers and when indicating content types.
           </p>
           <p>
-Nonetheless, HTTP servers might ignore the accept header and return another content
-type, or return an error code such as <a data-cite="RFC7231#section-6.5.13"><code>415
-Unsupported Media Type</code></a>.
+Nonetheless, HTTP servers might ignore the accept header and return another
+content type, or return an error code such as
+<a data-cite="RFC7231#section-6.5.13"><code>415 Unsupported Media Type</code></a>.
           </p>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -3976,8 +3976,13 @@ system.
           <h2>HTTP</h2>
           <p>
 It is expected that HTTP endpoints will use the media types associated with
-<a>verifiable credentials</a> in accept headers and
+<a>verifiable credentials</a> and <a>verifiable presentations</a> in accept headers and
 when indicating content types.
+          </p>
+          <p>
+Nonetheless, HTTP servers might ignore the accept header and return another content
+type, or return an error code such as <a data-cite="RFC7231#section-6.5.13"><code>415
+Unsupported Media Type</code></a>.
           </p>
         </section>
 


### PR DESCRIPTION
This PR fixes #1118 

This PR adds language to the media types section about accept headers and content types.

It is most certainly not entirely correct or sufficient, but hopefully can serve as a starting point to bring in the ideas discussed in #1118.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/brentzundel/vc-data-model/pull/1257.html" title="Last updated on Aug 28, 2023, 5:19 PM UTC (95058ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1257/3b0e073...brentzundel:95058ef.html" title="Last updated on Aug 28, 2023, 5:19 PM UTC (95058ef)">Diff</a>