### PR TITLE
Sync and fix bugs in v2 context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -44,20 +44,17 @@
     },
     "cnf": {
       "@id": "https://www.iana.org/assignments/jwt#cnf",
-      "@context": [
-        null,
-        {
-          "@protected": true,
-          "kid": {
-            "@id": "https://www.iana.org/assignments/jwt#kid",
-            "@type": "@id"
-          },
-          "jwk": {
-            "@id": "https://www.iana.org/assignments/jwt#jwk",
-            "@type": "@json"
-          }
+      "@context": {
+        "@protected": true,
+        "kid": {
+          "@id": "https://www.iana.org/assignments/jwt#kid",
+          "@type": "@id"
+        },
+        "jwk": {
+          "@id": "https://www.iana.org/assignments/jwt#jwk",
+          "@type": "@json"
         }
-      ]
+      }
     },
     "_sd_alg": {
       "@id": "https://www.iana.org/assignments/jwt#_sd_alg"

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -5,6 +5,7 @@
 
     "id": "@id",
     "type": "@type",
+
     "kid": {
       "@id": "https://www.iana.org/assignments/jose#kid",
       "@type": "@id"
@@ -43,17 +44,20 @@
     },
     "cnf": {
       "@id": "https://www.iana.org/assignments/jwt#cnf",
-      "@context": {
-        "@protected": true,
-        "kid": {
-          "@id": "https://www.iana.org/assignments/jwt#kid",
-          "@type": "@id"
-        },
-        "jwk": {
-          "@id": "https://www.iana.org/assignments/jwt#jwk",
-          "@type": "@json"
+      "@context": [
+        null,
+        {
+          "@protected": true,
+          "kid": {
+            "@id": "https://www.iana.org/assignments/jwt#kid",
+            "@type": "@id"
+          },
+          "jwk": {
+            "@id": "https://www.iana.org/assignments/jwt#jwk",
+            "@type": "@json"
+          }
         }
-      }
+      ]
     },
     "_sd_alg": {
       "@id": "https://www.iana.org/assignments/jwt#_sd_alg"
@@ -146,7 +150,8 @@
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
           "@type": "@id",
-          "@container": "@graph"
+          "@container": "@graph",
+          "@context": null
         },
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
@@ -273,7 +278,10 @@
             }
           }
         },
-        "cryptosuite": "https://w3id.org/security#cryptosuite",
+        "cryptosuite": {
+          "@id": "https://w3id.org/security#cryptosuite",
+          "@type": "https://w3id.org/security#cryptosuiteString"
+        },
         "proofValue": {
           "@id": "https://w3id.org/security#proofValue",
           "@type": "https://w3id.org/security#multibase"


### PR DESCRIPTION
This PR is an attempt to address issue #1150 by ensuring that redefinition doesn't fail in `verifiableCredential` when holding a VC v1.x compliant VC. It also fixes two bugs in the v2 context: 1) ensures that redefinition doesn't fail for `cnf`, and 2) synchronizes the DataIntegrity scoped context terms to now include `cryptosuiteString`.