### PR TITLE
Adding the jsonSchema property to the vocabulary

### DIFF
--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -252,7 +252,8 @@
         <p>
           The diagram uses boxes, ellipses, and connecting lines with different "styles" (border color, end
           marker, line type) to differentiate their semantic meaning; these styles identify 
-          Property, Class, or Datatype, used for shapes used for graph nodes, and Superclass, Domain Of, Range, and Graph Containment for connector lines. 
+          Property, Class, or Datatype, via the shapes used for the graph nodes, and Superclass, Domain Of,
+          Range, or Contains, via the styles of the connecting lines. 
           These style names are used in the explanation text in what follows. 
         </p>
         <p>  
@@ -264,36 +265,39 @@
           On the left side of this column, there are four labeled ellipses, styled as Class. 
           These are, from top to bottom, "VerifiableCredential", "JsonSchemaCredential",
           "VerifiableCredentialGraph", and "VerifiablePresentation". 
-          There is also a small, unlabelled circle, as a crossing point for connector lines.
+          There is also a small, unlabeled circle, which serves as an intersection point for connector
+          lines, with two pointing in, and three pointing out.
         </p>
         <p>
-          The "VerifiableCredential" ellipse is connected through a connecting line
-          styled as Domain Of to the "credentialSchema", "credentialStatus", "credentialSubject",
-          "issuer", "evidence", "refreshService", "renderMethod", and "confidenceMethod" boxes. 
-          It is also related to the separate crossing point circle with a similar connecting line. 
+          The "VerifiableCredential" ellipse is connected to the "credentialSchema", "credentialStatus",
+          "credentialSubject", "issuer", "evidence", "refreshService", "renderMethod", and "confidenceMethod"
+          boxes, through connecting lines styled as Domain Of. 
+          It is also connected to the crossing point circle with a similar connecting line,
+          styled as Domain Of.
           The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" 
-          and "verifiableCredential" boxes with a similar connecting line styled as Domain Of. 
-          The OR box is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a connecting line styled as Domain. 
+          and "verifiableCredential" boxes, with a similar connecting line, styled as Domain Of. 
+          The crossing point circle is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a connecting line styled as Domain Of.
           The "verifiableCredential" box is connected to the "VerifiableCredentialGraph" ellipse with a connecting
           line styled as Range. 
-          The ellipse "JsonSchemaCredential" is connected to the ellipse labelled "VerifiableCredential" with a 
+          The "JsonSchemaCredential" ellipse is connected to the "VerifiableCredential" ellipse with a 
           connecting line styled as Superclass. 
-          Finally, the "VerifiableCredentialGraph" ellipse is connected with a Graph Containment connector line 
-          to the "VerifiableCredential" ellipse.
+          Finally, the "VerifiableCredentialGraph" ellipse is connected to the "VerifiableCredential"
+          ellipse with a connector line styled as Contains.
         </p>
         <p>
-          On the right hand side of the column there is an extra column of ellipses styled as "Class", and labeled as "CredentialSchema",
+          On the right side of the column, there is another column of ellipses, styled as "Class", and labeled as "CredentialSchema",
           "CredentialStatus", "CredentialEvidence", "RefreshService", "RenderMethod", "ConfidenceMethod", and "TermsOfUse".
           The Property boxes labeled as "credentialSchema", "credentialStatus", "credentialEvidence,
-          "refreshService", "renderMethod", "confidenceMethod", and "termsOfUse" are all connected by connecting lines styled as Range to these
-          ellipses, respectively. 
+          "refreshService", "renderMethod", "confidenceMethod", and "termsOfUse" are respectively
+          connected to those Class ellipses, with connecting lines styled as Range. 
         </p>
         <p>
-          Finally, on the far right hand side of the diagram there is one more ellipse styled as Class and labeled as
-          "JsonSchema", connected from the the ellipse labeled as "CredentialSchema" via a connecting line
-          styled as Superclass. This ellipse is also connected through a connector line styled as DomainOf to
-          a Property box labelled as "jsonSchema". Finally, this box is connected, via a Range connector line,
-          to a Datatype Shape labeled as "rdf:JSON". 
+          Finally, the "CredentialSchema" ellipse is connected to one more ellipse, on the far right
+          side of the diagram, styled as Class and labeled as "JsonSchema", with a connecting line
+          styled as Superclass. This "JsonSchema" ellipse is also connected to a Property box
+          labeled as "jsonSchema", through a connector line styled as Domain Of. This "jsonSchema"
+          box is connected to a Datatype shape labeled as "rdf:JSON", with a connecting line
+          styled as Range. 
         </p>
       </details>
     </section>

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -252,7 +252,7 @@
         <p>
           The diagram uses boxes, ellipses, and connecting lines with different "styles" (border color, end
           marker, line type) to differentiate their semantic meaning; these styles identify 
-          Property and Class used for shapes used for graph nodes, and Subclass, Domain, and Range for connector lines. 
+          Property, Class, or Datatype, used for shapes used for graph nodes, and Superclass, Domain Of, Range, and Graph Containment for connector lines. 
           These style names are used in the explanation text in what follows. 
         </p>
         <p>  
@@ -264,33 +264,36 @@
           On the left side of this column, there are four labeled ellipses, styled as Class. 
           These are, from top to bottom, "VerifiableCredential", "JsonSchemaCredential",
           "VerifiableCredentialGraph", and "VerifiablePresentation". 
-          There is also a single circle, not styled as Property or Class, labeled as "OR", and another box 
-          styled as a Property labeled as "verifiableCredential". 
+          There is also a small, unlabelled circle, as a crossing point for connector lines.
         </p>
         <p>
           The "VerifiableCredential" ellipse is connected through a connecting line
-          styled as Domain to the "credentialSchema", "credentialStatus", "credentialSubject",
+          styled as Domain Of to the "credentialSchema", "credentialStatus", "credentialSubject",
           "issuer", "evidence", "refreshService", "renderMethod", and "confidenceMethod" boxes. 
-          It is also related to the separate "OR" circle with a similar connecting line. 
-          The "VerifiablePresentation" ellipse is connected to the "OR" box, as well as the "holder" 
-          and "verifiableCredential" boxes with a similar connecting line styled as Domain. 
+          It is also related to the separate crossing point circle with a similar connecting line. 
+          The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" 
+          and "verifiableCredential" boxes with a similar connecting line styled as Domain Of. 
           The OR box is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a connecting line styled as Domain. 
           The "verifiableCredential" box is connected to the "VerifiableCredentialGraph" ellipse with a connecting
           line styled as Range. 
           The ellipse "JsonSchemaCredential" is connected to the ellipse labelled "VerifiableCredential" with a 
-          connecting line styled as Subclass. 
-          Finally, the "VerifiableCredentialGraph" ellipse is connected, through a uniquely styled connector and with a text "contains" <em>on</em> the connector 
-          line, to the "VerifiableCredential" ellipse.
+          connecting line styled as Superclass. 
+          Finally, the "VerifiableCredentialGraph" ellipse is connected with a Graph Containment connector line 
+          to the "VerifiableCredential" ellipse.
         </p>
         <p>
           On the right hand side of the column there is an extra column of ellipses styled as "Class", and labeled as "CredentialSchema",
-          "CredentialStatus", "CredentialEvidence", "RefreshService", "ConfidenceMethod", and "TermsOfUse".
+          "CredentialStatus", "CredentialEvidence", "RefreshService", "RenderMethod", "ConfidenceMethod", and "TermsOfUse".
           The Property boxes labeled as "credentialSchema", "credentialStatus", "credentialEvidence,
-          "refreshService", "confidenceMethod", and "termsOfUse" are all connected by connecting lines styled as Range to these
+          "refreshService", "renderMethod", "confidenceMethod", and "termsOfUse" are all connected by connecting lines styled as Range to these
           ellipses, respectively. 
-          On the right hand side of the diagram there is one more ellipse styled as Class and labeled as
-          "JsonSchema", connected to the the ellipse labeled as "CredentialSchema" via a connecting line
-          styled as Subclass. 
+        </p>
+        <p>
+          Finally, on the far right hand side of the diagram there is one more ellipse styled as Class and labeled as
+          "JsonSchema", connected from the the ellipse labeled as "CredentialSchema" via a connecting line
+          styled as Superclass. This ellipse is also connected through a connector line styled as DomainOf to
+          a Property box labelled as "jsonSchema". Finally, this box is connected, via a Range connector line,
+          to a Datatype Shape labeled as "rdf:JSON". 
         </p>
       </details>
     </section>

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -1,9 +1,576 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1427 933">
-    <rect width="1350" height="45" x="53.5" y="866.5" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="none"/>
-    <ellipse cx="169.75" cy="889.32" fill="none" stroke="#82b366" stroke-width="4" pointer-events="none" rx="50" ry="11.315"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1662 923">
+    <a xlink:href="https://w3.org/2018/credentials/#verifiableCredential">
+        <rect width="171" height="27.21" x="167" y="525.19" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:539px;margin-left:168px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    verifiableCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="253" y="544" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredential">
+        <ellipse cx="446" cy="40.61" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:41px;margin-left:338px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    VerifiableCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="446" y="45" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredential</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#JsonSchemaCredential">
+        <ellipse cx="166" cy="160.65" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:161px;margin-left:58px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    JsonSchemaCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="166" y="165" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchemaCredential</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#VerifiablePresentation">
+        <ellipse cx="442" cy="778.89" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:779px;margin-left:334px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    VerifiablePresentation
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="442" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiablePresentation</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M166 141.05q41-64.03 161.62-97.82" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m334.85 41.21-8.28 7.51 1.05-5.49-3.75-4.14Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M252.5 525.19V366.07" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m252.5 358.57 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-80.19-216.75" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.57 554.64 5.32 9.84-5.08-2.34-4.92 2.65Z" pointer-events="all"/>
+    <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredentialGraph">
+        <ellipse cx="252.5" cy="336.72" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:337px;margin-left:145px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    VerifiableCredentialGraph
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="253" y="342" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredentialGraph</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 317.11 363.81 63.17" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m366.82 56.3-.96 10.5-2.05-3.63-4.05.95Z" pointer-events="all"/>
+    <a xlink:href="https://w3.org/2018/credentials/#credentialSchema">
+        <rect width="171" height="27.21" x="737" y="85.02" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:99px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    credentialSchema
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSchema</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#credentialStatus">
+        <rect width="171" height="27.21" x="737" y="141.05" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:155px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    credentialStatus
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="159" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#credentialSubject">
+        <rect width="171" height="27.21" x="737" y="197.07" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:211px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    credentialSubject
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="215" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#issuer">
+        <rect width="171" height="27.21" x="737" y="253.09" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:267px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    issuer
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="271" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#evidence">
+        <rect width="171" height="27.21" x="737" y="309.11" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:323px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    evidence
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="328" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#refreshService">
+        <rect width="171" height="27.21" x="737" y="365.13" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:379px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    refreshService
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#renderMethod">
+        <rect width="171" height="27.21" x="737" y="421.15" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:435px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    renderMethod
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="440" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#confidenceMethod">
+        <rect width="171" height="27.21" x="737" y="477.18" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:491px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    confidenceMethod
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="496" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#termsOfUse">
+        <rect width="171" height="27.21" x="737" y="533.2" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:547px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    termsOfUse
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="552" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#validFrom">
+        <rect width="171" height="27.21" x="737" y="589.22" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:603px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    validFrom
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="608" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#validUntil">
+        <rect width="171" height="27.21" x="737" y="645.24" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:659px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    validUntil
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="664" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#holder">
+        <rect width="171" height="27.21" x="737" y="765.29" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:779px;margin-left:738px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    holder
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">holder</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 778.89H551" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 778.89-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 98.66Q628 99 567.5 100.02 507 101.03 446 60.22" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 98.64-9.98 5.03 2.48-5.01-2.51-4.99Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 154.77Q471 157.85 446 60.22" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 154.68-9.93 5.12 2.43-5.03-2.56-4.97Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 144.85 281.27 150.23" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 210.62-10.11 4.77 2.62-4.94-2.39-5.06Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q41 168.86 281.37 205.03" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 266.36-10.63 3.46 3.21-4.57-1.73-5.32Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q21 192.87 281.57 260.07" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.83 322.16-10.93 2.34 3.67-4.21-1.17-5.47Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q11 224.88 281.77 315.43" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.88 378.03-11.07 1.57 3.96-3.95-.79-5.53Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-9 256.89 281.94 370.99" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.92 433.94-11.14 1.01 4.16-3.74-.51-5.57Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-29 256.89 282.44 425.92" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.03 489.71-11.17-.37 4.58-3.2.19-5.59Z" pointer-events="all"/>
+    <circle cx="552" cy="603" r="5" fill="#c00" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M442 759.28Q478 650 543.53 612.81" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m550.06 609.1-6.23 9.29-.3-5.58-4.64-3.12Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22Q408 350 547.11 589.58" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m550.88 596.07-9.35-6.14 5.58-.35 3.07-4.67Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m557 603 170.26-.17" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 602.83-9.99 5.01 2.49-5.01-2.5-4.99Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 603q91-43 170.37-54.77" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 547.13-9.16 6.41 1.74-5.31-3.21-4.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 603q81 47 170.3 54.98" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.77 658.65-10.4 4.09 2.93-4.76-2.04-5.2Z" pointer-events="all"/>
+    <a xlink:href="https://w3.org/2018/credentials/#RenderMethod">
+        <ellipse cx="1136" cy="434.76" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:435px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    RenderMethod
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="440" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#CredentialEvidence">
+        <ellipse cx="1136" cy="322.72" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:323px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    CredentialEvidence
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="328" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#RefreshService">
+        <ellipse cx="1136" cy="378.74" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:379px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    RefreshService
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#ConfidenceMethod">
+        <ellipse cx="1136" cy="490.78" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:491px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    ConfidenceMethod
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="496" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#TermsOfUse">
+        <ellipse cx="1136" cy="546.8" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:547px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    TermsOfUse
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="552" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#CredentialSchema">
+        <ellipse cx="1136" cy="98.63" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:99px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    CredentialSchema
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialSchema</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3.org/2018/credentials/#CredentialStatus">
+        <ellipse cx="1136" cy="154.65" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:155px;margin-left:1028px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    CredentialStatus
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="159" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialStatus</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 98.63h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 98.63-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 154.65h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 154.65-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 322.72h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 322.72-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 378.74h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 378.74-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 434.76h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 434.76-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 490.78h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 490.78-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 546.8h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 546.8-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <a xlink:href="https://w3.org/2018/credentials/#JsonSchema">
+        <ellipse cx="1496" cy="177.46" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:177px;margin-left:1388px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    JsonSchema
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1496" y="182" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchema</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1496 157.85q-89-64.82-241.27-59.56" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1247.23 98.55 9.83-5.34-2.33 5.08 2.67 4.91Z" pointer-events="all"/>
+    <rect width="1621" height="54.5" x="20" y="848" fill="none"/>
+    <rect width="1595" height="54.5" x="20" y="848" fill="none" stroke="#000" stroke-dasharray="3 3"/>
+    <rect width="1614" height="49.5" x="27" y="850.5" fill="none"/>
+    <rect width="163.4" height="40" x="745" y="855.25" fill="none"/>
+    <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M840 866.75h48.4l20 8.5-20 8.5H840l-20-8.5Z"/>
+    <rect width="90" height="40" x="758" y="855.25" fill="none"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:889px;margin-left:85px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:862px;margin-left:760px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
+                            Datatype
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="760" y="878" font-family="Helvetica" font-size="16">Datatype</text>
+    </switch>
+    <rect width="190" height="40" x="1451" y="855.25" fill="none"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1535 881.75 63.26.19"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1605.76 881.96-10.01 4.97 2.51-4.99-2.48-5.01Z"/>
+    <rect width="70" height="40" x="1451" y="855.25" fill="none"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:862px;margin-left:1452px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
+                            Graph containment
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1486" y="878" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
+    </switch>
+    <rect width="160" height="37.13" x="27" y="856.69" fill="none"/>
+    <ellipse cx="137" cy="875.64" fill="#d5e8d4" stroke="#82b366" stroke-width="2" rx="50" ry="14.002"/>
+    <rect width="50" height="30" x="27" y="856.69" fill="none"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:52px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
                         Class
@@ -11,12 +578,14 @@
                 </div>
             </div>
         </foreignObject>
-        <text x="85" y="893" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
     </switch>
-    <rect width="80" height="19.14" x="340.75" y="878" fill="none" stroke="#300" stroke-width="3" pointer-events="none" rx="2.87" ry="2.87"/>
+    <rect width="170" height="37.13" x="202" y="856.69" fill="none"/>
+    <rect width="80" height="23.69" x="285" y="861.64" fill="#fff2cc" stroke="#300" stroke-width="2" rx="3.55" ry="3.55"/>
+    <rect width="70" height="30" x="202" y="856.69" fill="none"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:889px;margin-left:286px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:237px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
                         Property
@@ -24,56 +593,49 @@
                 </div>
             </div>
         </foreignObject>
-        <text x="286" y="893" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="237" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
     </switch>
-    <rect width="80" height="19.14" x="733.75" y="878.43" fill="#fff2cc" pointer-events="none" rx="2.87" ry="2.87"/>
+    <rect width="170" height="37.13" x="921" y="856.69" fill="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1008 874.63 71.76.56"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1085.76 875.23-8.03 3.94 2.03-3.98-1.96-4.02Z"/>
+    <rect width="80" height="30" x="916" y="856.69" fill="none"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:889px;margin-left:679px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:956px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
-                        Reserved
-                        <br/>
-                        property
+                        Superclass
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text x="679" y="893" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="956" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m929.75 888.5 71.76.45" pointer-events="none"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1007.51 888.99-8.02 3.95 2.02-3.99-1.97-4.01Z" pointer-events="none"/>
+    <rect width="136" height="37.13" x="1118" y="856.69" fill="none"/>
+    <path fill="none" stroke="#f33" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1192 875.25 56 .05 15.76-.03"/>
+    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1269.76 875.25-7.99 4.02 1.99-4-2-4Z"/>
+    <rect width="60" height="40" x="1118" y="851.69" fill="none"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:889px;margin-left:875px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
-                        Subclass
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text x="875" y="893" font-family="Helvetica" font-size="12" text-anchor="middle">Subclass</text>
-    </switch>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1142.16 889h70.59" pointer-events="none"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1134.16 889 4-4 4 4-4 4Z" pointer-events="none"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:889px;margin-left:1083px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1148px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
                         Domain
+                        <br/>
+                        of
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text x="1083" y="893" font-family="Helvetica" font-size="12" text-anchor="middle">Domain</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="1148" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Domain...</text>
     </switch>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1317.25 889h71.76" pointer-events="none"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1395.01 889-8 4 2-4-2-4Z" pointer-events="none"/>
+    <rect width="160" height="37.13" x="1286" y="856.69" fill="none"/>
+    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1353 875.25h71.76"/>
+    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1430.76 875.25-8 4 2-4-2-4Z"/>
+    <rect width="60" height="30" x="1286" y="856.69" fill="none"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:889px;margin-left:1267px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1316px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
                         Range
@@ -81,12 +643,14 @@
                 </div>
             </div>
         </foreignObject>
-        <text x="1267" y="893" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="1316" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
     </switch>
-    <ellipse cx="562.75" cy="888.32" fill="none" stroke="#82b366" stroke-dasharray="4 8" stroke-width="4" pointer-events="none" rx="50" ry="11.315"/>
+    <rect width="160" height="43.31" x="387" y="853.59" fill="none"/>
+    <ellipse cx="502" cy="872.55" fill="#d5e8d4" stroke="#82b366" stroke-dasharray="2 4" stroke-width="2" rx="50" ry="14.002"/>
+    <rect width="70" height="40" x="377" y="855.41" fill="none"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:888px;margin-left:478px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:875px;margin-left:412px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
                         Reserved
@@ -96,567 +660,65 @@
                 </div>
             </div>
         </foreignObject>
-        <text x="478" y="892" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="412" y="879" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
     </switch>
-    <a xlink:href="https://w3.org/2018/credentials/#credentialSchema">
-        <rect width="160" height="30" x="643" y="101" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:116px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    credentialSchema
-                                </i>
-                            </font>
-                        </div>
+    <rect width="176" height="49.5" x="559" y="850.5" fill="none"/>
+    <rect width="70" height="40" x="559" y="857.5" fill="none"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:878px;margin-left:594px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                        Reserved
+                        <br/>
+                        property
                     </div>
                 </div>
-            </foreignObject>
-            <text x="723" y="120" font-family="Helvetica" font-size="12" text-anchor="middle">credentialSchema</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#credentialStatus">
-        <rect width="160" height="30" x="643" y="160" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:175px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    credentialStatus
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="179" font-family="Helvetica" font-size="12" text-anchor="middle">credentialStatus</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#holder">
-        <rect width="160" height="30" x="643" y="785" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:800px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    holder
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="804" font-family="Helvetica" font-size="12" text-anchor="middle">holder</text>
-        </switch>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="594" y="881" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
+    </switch>
+    <a xlink:href="https://w3.org/2018/credentials/#evidence">
+        <rect width="91.25" height="24.75" x="640.75" y="864.73" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#credentialSubject">
-        <rect width="160" height="30" x="643" y="219" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
+        <rect width="171" height="27.21" x="1410.5" y="270" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:234px;margin-left:644px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:284px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    credentialSubject
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="238" font-family="Helvetica" font-size="12" text-anchor="middle">credentialSubject</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#issuer">
-        <rect width="160" height="30" x="643" y="278" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:293px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    issuer
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="297" font-family="Helvetica" font-size="12" text-anchor="middle">issuer</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#validUntil">
-        <rect width="160" height="30" x="643" y="690" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:705px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    validUntil
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="709" font-family="Helvetica" font-size="12" text-anchor="middle">validUntil</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#evidence">
-        <rect width="160" height="30" x="643" y="337" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:352px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    evidence
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="356" font-family="Helvetica" font-size="12" text-anchor="middle">evidence</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#refreshService">
-        <rect width="160" height="30" x="643" y="395" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:410px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    refreshService
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="414" font-family="Helvetica" font-size="12" text-anchor="middle">refreshService</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#validFrom">
-        <rect width="160" height="30" x="643" y="632" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:647px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    validFrom
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="651" font-family="Helvetica" font-size="12" text-anchor="middle">validFrom</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 469h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 469-8 4 2-4-2-4Z"/>
-    <a xlink:href="https://w3.org/2018/credentials/#renderMethod">
-        <rect width="160" height="30" x="643" y="454" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:469px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    renderMethod
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="473" font-family="Helvetica" font-size="12" text-anchor="middle">renderMethod</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#termsOfUse">
-        <rect width="160" height="30" x="643" y="572" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:587px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    termsOfUse
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="591" font-family="Helvetica" font-size="12" text-anchor="middle">termsOfUse</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#verifiableCredential">
-        <rect width="160" height="30" x="126" y="506.5" fill="none" stroke="#300" stroke-width="3" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:522px;margin-left:127px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    verifiableCredential
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="206" y="525" font-family="Helvetica" font-size="12" text-anchor="middle">verifiableCredential</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredential">
-        <ellipse cx="413" cy="42.5" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:43px;margin-left:319px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    VerifiableCredential
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="413" y="46" font-family="Helvetica" font-size="12" text-anchor="middle">VerifiableCredential</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 116 643 116"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 175 643 175"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 234 643 234"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 293 643 293"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 352 643 352"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 410 643 410"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 469 643 469"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <circle cx="413" cy="648" r="17.5" fill="none" stroke="#000" stroke-width="3"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:33px;height:1px;padding-top:648px;margin-left:397px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                        OR
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text x="413" y="652" font-family="Helvetica" font-size="12" text-anchor="middle">OR</text>
-    </switch>
-    <path fill="none" stroke="#f33" stroke-dasharray="3 3" stroke-miterlimit="10" d="M413 71.71V630.5"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" d="m413 64.71 3.5 3.5-3.5 3.5-3.5-3.5Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M439.91 648h96.89v-1H643"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m431.91 648 4-4 4 4-4 4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M439.91 648q96.89 0 96.89-30.5T643 587"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m431.91 648 4-4 4 4-4 4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M439.91 648q96.89 0 96.89 28.5T643 705"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m431.91 648 4-4 4 4-4 4Z"/>
-    <a xlink:href="https://w3.org/2018/credentials/#VerifiablePresentation">
-        <ellipse cx="413" cy="800" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:800px;margin-left:319px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    VerifiablePresentation
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="413" y="804" font-family="Helvetica" font-size="12" text-anchor="middle">VerifiablePresentation</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 769.09V665.5"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 777.09-4-4 4-4 4 4Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M517.41 800H643"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m509.41 800 4-4 4 4-4 4Z"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M116 131q0-88.5 193.76-88.5"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m315.76 42.5-8 4 2-4-2-4Z"/>
-    <a xlink:href="https://w3.org/2018/credentials/#JsonSchemaCredential">
-        <ellipse cx="116" cy="152.5" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:153px;margin-left:22px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    JsonSchemaCredential
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="116" y="156" font-family="Helvetica" font-size="12" text-anchor="middle">JsonSchemaCredential</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredentialGraph">
-        <ellipse cx="206" cy="270.5" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:271px;margin-left:112px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    VerifiableCredentialGraph
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="206" y="274" font-family="Helvetica" font-size="12" text-anchor="middle">VerifiableCredentialGraph</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M206 506.5V300.24"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m206 294.24 4 8-4-2-4 2Z"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M308.59 800Q206 800 206 536.5"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m316.59 800-4 4-4-4 4-4Z"/>
-    <a xlink:href="https://w3.org/2018/credentials/#CredentialSchema">
-        <ellipse cx="987" cy="116" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:116px;margin-left:893px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    CredentialSchema
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="987" y="120" font-family="Helvetica" font-size="12" text-anchor="middle">CredentialSchema</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#CredentialStatus">
-        <ellipse cx="987" cy="175" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:175px;margin-left:893px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    CredentialStatus
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="987" y="179" font-family="Helvetica" font-size="12" text-anchor="middle">CredentialStatus</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#CredentialEvidence">
-        <ellipse cx="987" cy="352" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:352px;margin-left:893px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    CredentialEvidence
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="987" y="356" font-family="Helvetica" font-size="12" text-anchor="middle">CredentialEvidence</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#RefreshService">
-        <ellipse cx="987" cy="410" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:410px;margin-left:893px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    RefreshService
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="987" y="414" font-family="Helvetica" font-size="12" text-anchor="middle">RefreshService</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#TermsOfUse">
-        <ellipse cx="987" cy="587" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:587px;margin-left:893px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    TermsOfUse
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="987" y="591" font-family="Helvetica" font-size="12" text-anchor="middle">TermsOfUse</text>
-        </switch>
-    </a>
-    <a xlink:href="https://w3.org/2018/credentials/#JsonSchema">
-        <ellipse cx="1253" cy="216" fill="none" stroke="#82b366" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:216px;margin-left:1159px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    JsonSchema
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="1253" y="220" font-family="Helvetica" font-size="12" text-anchor="middle">JsonSchema</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1253 194.5q0-78.5-162.76-78.5"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1084.24 116 8-4-2 4 2 4Z"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 116h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 116-8 4 2-4-2-4Z"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 175h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 175-8 4 2-4-2-4Z"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 352h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 352-8 4 2-4-2-4Z"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 410h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 410-8 4 2-4-2-4Z"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 587h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 587-8 4 2-4-2-4Z"/>
-    <a xlink:href="https://w3.org/2018/credentials/#confidenceMethod">
-        <rect width="160" height="30" x="643" y="513" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" rx="4.5" ry="4.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:528px;margin-left:644px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    confidenceMethod
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="723" y="532" font-family="Helvetica" font-size="12" text-anchor="middle">confidenceMethod</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#f33" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M413 73.41Q413 528 643 528"/>
-    <path fill="none" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m413 65.41 4 4-4 4-4-4Z"/>
-    <a xlink:href="https://w3.org/2018/credentials/#ConfidenceMethod">
-        <ellipse cx="987" cy="528" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:528px;margin-left:893px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    ConfidenceMethod
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text x="987" y="532" font-family="Helvetica" font-size="12" text-anchor="middle">ConfidenceMethod</text>
-        </switch>
-    </a>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M803 528h80.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m889.76 528-8 4 2-4-2-4Z"/>
-    <path fill="none" stroke="#000" stroke-dasharray="2 4" stroke-miterlimit="10" stroke-width="2" d="M202.01 242.98 338.79 65.63"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m343.67 59.29-2.77 7.97-4.22-3.26Z"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:150px;margin-left:273px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:11px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;background-color:#fff;white-space:nowrap">
-                        <font size="1">
-                            <i style="font-size:13px">
-                                contains
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#bd0000">
+                                    jsonSchema
+                                </font>
                             </i>
-                        </font>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </foreignObject>
-        <text x="273" y="154" font-family="Helvetica" font-size="11" text-anchor="middle">contains</text>
-    </switch>
-    <a xlink:href="https://w3.org/2018/credentials/#ConfidenceMethod">
-        <ellipse cx="987" cy="469" fill="none" stroke="#82b366" stroke-dasharray="3 6" stroke-width="3" rx="95" ry="21.5"/>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1496" y="288" font-family="Helvetica" font-size="16" text-anchor="middle">jsonSchema</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1498 200-1.72 60.27"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1496.06 267.76-4.71-10.14 4.93 2.65 5.07-2.36Z"/>
+    <a xlink:href="https://w3id.org/security/#cryptosuiteString">
+        <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 365h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:469px;margin-left:893px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:379px;margin-left:1423px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font style="font-size:14px">
-                                <i>
-                                    RenderMethod
-                                </i>
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                            <font color="#bd0000">
+                                rdf:JSON
                             </font>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text x="987" y="473" font-family="Helvetica" font-size="12" text-anchor="middle">RenderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1497" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
         </switch>
     </a>
-    <switch>
-        <a xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank" transform="translate(0 -5)">
-            <text x="50%" y="100%" font-size="10" text-anchor="middle">Text is not SVG - cannot display</text>
-        </a>
-    </switch>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z"/>
 </svg>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -122,6 +122,12 @@ property:
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-holder
     range : IRI
 
+  - id: jsonSchema
+    label: Referring to a Json Schema
+    domain: cred:JsonSchema
+    range: rdf:JSON
+    defined_by: https://www.w3.org/TR/vc-json-schema/#jsonschema-0
+
   - id: issuanceDate
     label: Issuance date
     defined_by: https://www.w3.org/TR/2022/REC-vc-data-model-20220303/#issuance-date


### PR DESCRIPTION
This is the counterpart, in the VCDM vocabulary, of https://github.com/w3c/vc-json-schema/pull/211. The diagram, and its alt-text description, has also been adapted.

See the [preview of the generated vocab](https://w3c.github.io/yml2vocab/previews/vcdm/vocabulary.html)