### PR TITLE
Warn authors that usage of global JSON-LD keywords might harm interoperability

### DIFF
--- a/index.html
+++ b/index.html
@@ -3989,7 +3989,7 @@ base media type, `application/vc+ld+json`.
 
         <p>
 As elaborated upon in Section <a href="#json-processing"></a>, some software
-applications might not perform full JSON-LD processing.
+applications might not perform dynamic JSON-LD processing.
 Authors of <a>conforming documents</a> are advised that using JSON-LD keywords
 in the `@context` value to globally affect values in documents, such as
 globally setting the keywords `@base` or `@language`, might reduce

--- a/index.html
+++ b/index.html
@@ -3990,9 +3990,9 @@ base media type, `application/vc+ld+json`.
         <p>
 As elaborated upon in Section <a href="#json-processing"></a>, some software
 applications might not perform full JSON-LD processing.
-<a>Conforming document</a> authors are urged to not use JSON-LD keywords that
-affect document processing in the `@context` value, such as globally setting
-`@base` and `@language`, in order to increase interoperability.
+To increase interoperability, authors of <a>conforming document</a> are urged
+to not use JSON-LD keywords in the `@context` value to globally affect values
+in documents, such as globally setting the keywords `@base` or `@language`.
         </p>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -3993,8 +3993,7 @@ applications might not perform full JSON-LD processing.
 Authors of <a>conforming documents</a> are advised that using JSON-LD keywords
 in the `@context` value to globally affect values in documents, such as
 globally setting the keywords `@base` or `@language`, might reduce
-interoperability with certain processors that do not perform full JSON-LD
-processing.
+interoperability.
         </p>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -3988,7 +3988,7 @@ base media type, `application/vc+ld+json`.
         </p>
 
         <p>
-As elaborated upon in Section <a href="#json-processing"></a>, some software
+As elaborated upon in Section <a href="#static-processing"></a>, some software
 applications might not perform dynamic JSON-LD processing.
 Authors of <a>conforming documents</a> are advised that using JSON-LD keywords
 in the `@context` value to globally affect values in documents, such as

--- a/index.html
+++ b/index.html
@@ -3990,10 +3990,13 @@ base media type, `application/vc+ld+json`.
         <p>
 As elaborated upon in Section <a href="#static-processing"></a>, some software
 applications might not perform dynamic JSON-LD processing.
-Authors of <a>conforming documents</a> are advised that using JSON-LD keywords
-in the `@context` value to globally affect values in documents, such as
-globally setting the keywords `@base` or `@language`, might reduce
-interoperability.
+Authors of <a>conforming documents</a> are advised that interoperability
+might be reduced if JSON-LD keywords in the `@context` value are used to
+globally affect values in `@context` or other documents, such as by
+globally setting the keywords `@base` or `@language`. Using these
+keywords with specific focus, as when aligned with one or more values
+of one or more other keywords, may broaden the utility of specific
+`@context` files and/or <a>conforming documents</a>.
         </p>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -3987,6 +3987,14 @@ form</a> MUST be utilized for all representations of the data model in the
 base media type, `application/vc+ld+json`.
         </p>
 
+        <p>
+As elaborated upon in Section <a href="#json-processing"></a>, some software
+applications might not perform full JSON-LD processing.
+<a>Conforming document</a> authors are urged to not use JSON-LD keywords that
+affect document processing in the `@context` value, such as globally setting
+`@base` and `@language`, in order to increase interoperability.
+        </p>
+
         <section>
           <h3>Syntactic Sugar</h3>
 

--- a/index.html
+++ b/index.html
@@ -3990,9 +3990,11 @@ base media type, `application/vc+ld+json`.
         <p>
 As elaborated upon in Section <a href="#json-processing"></a>, some software
 applications might not perform full JSON-LD processing.
-To increase interoperability, authors of <a>conforming document</a> are urged
-to not use JSON-LD keywords in the `@context` value to globally affect values
-in documents, such as globally setting the keywords `@base` or `@language`.
+Authors of <a>conforming documents</a> are advised that using JSON-LD keywords
+in the `@context` value to globally affect values in documents, such as
+globally setting the keywords `@base` or `@language`, might reduce
+interoperability with certain processors that do not perform full JSON-LD
+processing.
         </p>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -3966,7 +3966,8 @@ specification. Instances of the data model are encoded in JSON-LD compact
 form [[!JSON-LD]] and include the <code>@context</code> <a>property</a>. The
 <a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD context</a>
 is described in detail in the [[!JSON-LD]] specification and its use is
-elaborated on in Section <a href="#extensibility"></a>.
+elaborated on in Section <a href="#contexts"></a> and
+Section <a href="#extensibility"></a>.
         </p>
 
         <p>
@@ -3988,15 +3989,17 @@ base media type, `application/vc+ld+json`.
         </p>
 
         <p>
-As elaborated upon in Section <a href="#static-processing"></a>, some software
-applications might not perform dynamic JSON-LD processing.
+As elaborated upon in Section
+<a href="#credential-type-specific-processing"></a>, some software
+applications might not perform generalized JSON-LD processing.
 Authors of <a>conforming documents</a> are advised that interoperability
 might be reduced if JSON-LD keywords in the `@context` value are used to
-globally affect values in `@context` or other documents, such as by
-globally setting the keywords `@base` or `@language`. Using these
-keywords with specific focus, as when aligned with one or more values
-of one or more other keywords, may broaden the utility of specific
-`@context` files and/or <a>conforming documents</a>.
+globally affect values in a <a>verifiable credential</a> or
+<a>verifiable presentation</a>, such as by globally setting the `@base` keyword.
+For example, globally setting these values might trigger a failure in a
+mis-implemented JSON Schema check on the `@context` value in an implementation
+that is performing credential-type-specific processing and not expecting the
+`@base` value to be expressed in the `@context` value.
         </p>
 
         <section>


### PR DESCRIPTION
This PR is an attempt to address issues #1264 and #1266. It provides guidance that document authors shouldn't use JSON-LD keywords that affect document processing inside the `@context` array because it can impact how processors that don't do full JSON-LD processing interpret the document, leading to a degradation in interoperability.

A separate PR will be raised for guidance on how to use the language features to increase interoperability. This PR just says "don't use the `@language` sledgehammer in `@context`".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1271.html" title="Last updated on Nov 14, 2023, 6:45 PM UTC (5c322b1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1271/922dce6...5c322b1.html" title="Last updated on Nov 14, 2023, 6:45 PM UTC (5c322b1)">Diff</a>