### PR TITLE
Add base classes and fragment identifiers for vocabulary.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5965,7 +5965,7 @@ cryptographic hash.
 
         <p>
 The following base classes are defined in this specification for processors
-and other specifications that benefit from the definition of base classes:
+and other specifications that benefit from such definitions:
         </p>
 
         <table class="simple">
@@ -5981,10 +5981,10 @@ and other specifications that benefit from the definition of base classes:
 `CredentialEvidence`
               </td>
               <td>
-Serves as a supercass for specific evidence types that are placed into the
+Serves as a superclass for specific evidence types that are placed into the
 <a href="#evidence">evidence</a> property. <span class="issue atrisk">This
 superclass is at risk and will be removed if at least two independent
-implementations for the super class are not identified by the end of the
+implementations for the superclass are not identified by the end of the
 Candidate Recommendation phase.</span>
               </td>
             </tr>
@@ -5993,7 +5993,7 @@ Candidate Recommendation phase.</span>
 `CredentialSchema`
               </td>
               <td>
-Serves as a supercass for specific schema types that are placed into the
+Serves as a superclass for specific schema types that are placed into the
 <a href="#data-schemas">credentialSchema</a> property.
               </td>
             </tr>
@@ -6002,7 +6002,7 @@ Serves as a supercass for specific schema types that are placed into the
 `CredentialStatus`
               </td>
               <td>
-Serves as a supercass for specific credential status types that are placed into
+Serves as a superclass for specific credential status types that are placed into
 the <a href="#status">credentialStatus</a> property.
               </td>
             </tr>
@@ -6011,10 +6011,10 @@ the <a href="#status">credentialStatus</a> property.
 `ConfidenceMethod`
               </td>
               <td>
-Serves as a supercass for specific confidence method types that are placed into
+Serves as a superclass for specific confidence method types that are placed into
 the `confidenceMethod` property.
 <span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the super class are not identified
+at least two independent implementations for the superclass are not identified
 by the end of the Candidate Recommendation phase.
 </span>
               </td>
@@ -6024,10 +6024,10 @@ by the end of the Candidate Recommendation phase.
 `RefreshService`
               </td>
               <td>
-Serves as a supercass for specific refresh service types that are placed into
+Serves as a superclass for specific refresh service types that are placed into
 the <a href="#refreshing">credentialRefresh</a> property.
 <span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the super class are not identified
+at least two independent implementations for the superclass are not identified
 by the end of the Candidate Recommendation phase.
 </span>
               </td>
@@ -6037,10 +6037,10 @@ by the end of the Candidate Recommendation phase.
 `RenderMethod`
               </td>
               <td>
-Serves as a supercass for specific render method types that are placed into
+Serves as a superclass for specific render method types that are placed into
 the `renderMethod` property.
 <span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the super class are not identified
+at least two independent implementations for the superclass are not identified
 by the end of the Candidate Recommendation phase.
 </span>
               </td>
@@ -6050,10 +6050,10 @@ by the end of the Candidate Recommendation phase.
 `TermsOfUse`
               </td>
               <td>
-Serves as a supercass for specific terms of use types that are placed into
+Serves as a superclass for specific terms of use types that are placed into
 the <a href="#terms-of-use">termsOfUse</a> property.
 <span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the super class are not identified
+at least two independent implementations for the superclass are not identified
 by the end of the Candidate Recommendation phase.
 </span>
               </td>

--- a/index.html
+++ b/index.html
@@ -5963,6 +5963,104 @@ publishing the files in W3C TR space and referring to them by using a
 cryptographic hash.
         </p>
 
+        <p>
+The following base classes are defined in this specification for processors
+and other specifications that benefit from the definition of base classes:
+        </p>
+
+        <table class="simple">
+          <thead>
+            <tr>
+              <th>Base Class</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr id="bc-credential-evidence">
+              <td>
+`CredentialEvidence`
+              </td>
+              <td>
+Serves as a supercass for specific evidence types that are placed into the
+<a href="#evidence">evidence</a> property. <span class="issue atrisk">This
+superclass is at risk and will be removed if at least two independent
+implementations for the super class are not identified by the end of the
+Candidate Recommendation phase.</span>
+              </td>
+            </tr>
+            <tr id="bc-credential-schema">
+              <td>
+`CredentialSchema`
+              </td>
+              <td>
+Serves as a supercass for specific schema types that are placed into the
+<a href="#data-schemas">credentialSchema</a> property.
+              </td>
+            </tr>
+            <tr id="bc-credential-status">
+              <td>
+`CredentialStatus`
+              </td>
+              <td>
+Serves as a supercass for specific credential status types that are placed into
+the <a href="#status">credentialStatus</a> property.
+              </td>
+            </tr>
+            <tr id="bc-confidence-method">
+              <td>
+`ConfidenceMethod`
+              </td>
+              <td>
+Serves as a supercass for specific confidence method types that are placed into
+the `confidenceMethod` property.
+<span class="issue atrisk">This superclass is at risk and will be removed if
+at least two independent implementations for the super class are not identified
+by the end of the Candidate Recommendation phase.
+</span>
+              </td>
+            </tr>
+            <tr id="bc-refresh-service">
+              <td>
+`RefreshService`
+              </td>
+              <td>
+Serves as a supercass for specific refresh service types that are placed into
+the <a href="#refreshing">credentialRefresh</a> property.
+<span class="issue atrisk">This superclass is at risk and will be removed if
+at least two independent implementations for the super class are not identified
+by the end of the Candidate Recommendation phase.
+</span>
+              </td>
+            </tr>
+            <tr id="bc-render-method">
+              <td>
+`RenderMethod`
+              </td>
+              <td>
+Serves as a supercass for specific render method types that are placed into
+the `renderMethod` property.
+<span class="issue atrisk">This superclass is at risk and will be removed if
+at least two independent implementations for the super class are not identified
+by the end of the Candidate Recommendation phase.
+</span>
+              </td>
+            </tr>
+            <tr id="bc-terms-of-use">
+              <td>
+`TermsOfUse`
+              </td>
+              <td>
+Serves as a supercass for specific terms of use types that are placed into
+the <a href="#terms-of-use">termsOfUse</a> property.
+<span class="issue atrisk">This superclass is at risk and will be removed if
+at least two independent implementations for the super class are not identified
+by the end of the Candidate Recommendation phase.
+</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
       </section>
       <section class="informative">
         <h3>Differences between Contexts, Types, and CredentialSchemas</h3>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -19,20 +19,20 @@ ontology:
 class:
   - id: CredentialEvidence
     label: Credential Evidence
-    comment: A credential evidence provides evidence schemes that are used by the <a href="#evidence">evidence</a> property. This class serves as a supertype for specific evidence types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-evidence
     status: reserved
 
   - id: CredentialSchema
     label: Credential schema
-    comment: A credential schema provides verifiers with enough information to determine if the provided data conforms to the provided schema. This class serves as a supertype for specific schemas (e.g., <a href="#JsonSchema">JsonSchema</a>).
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-schema
 
   - id: CredentialStatus
     label: Credential status
-    comment: A credential status provides enough information to determine the current status of the credential (for example, suspended or revoked). This class serves as a supertype for specific status types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-status
 
   - id: ConfidenceMethod
     label: Confidence method
-    defined_by: https://w3c-ccg.github.io/confidence-method-spec/
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-confidence-method
     status: reserved
 
   - id: JsonSchema
@@ -47,22 +47,18 @@ class:
 
   - id: RefreshService
     label: Refresh service
-    comment: A refresh service is a mechanism that can be utilized by software agents to retrieve an updated copy of a Verifiable Credential. This class serves as a supertype for specific refresh service types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-refresh-service
     status: reserved
 
   - id: RenderMethod
     label: Render method
-    comment: A specific render method specifies how a software expresses the verifiable credential using a visual, auditory, or haptic mechanism. This class serves as a supertype for specific render method types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-render-method
     status: reserved
 
   - id: TermsOfUse
     label: Terms of use
-    comment: Policy under which the creator issued the credential or presentation. This class serves as a supertype for specific types for terms of use.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-terms-of-use
     status: reserved
-
-  # - id: StatusList2021Entry
-  #   label: Status List 2021 Entry
-  #   comment: A Status List 2021 Entry provides issuers with a mechanism to provide status information for verifiable credentials.
 
   - id: VerifiableCredential
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#credentials


### PR DESCRIPTION
This PR attempts to address part of issue #1263 by defining base classes (and their anchors) in the VCDM specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Sep 26, 2023, 8:39 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fvc-data-model%2Ff5b8ac9e937acf27a8e63bcef30bfb8d0cc1f434%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/teRudZ/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-09-26
ReSpec version: 34.1.8
File a bug: https://github.com/w3c/respec/
Error: undefined

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/vc-data-model%231272.)._
</details>
