### PR TITLE
Provide guidance to use compact terms/types instead of full URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4001,6 +4001,11 @@ Not using JSON-LD keywords in the `@context` value that modify document
 processing, such as globally setting `@base` and `@language`, in order to
 increase interoperability.
           </li>
+          <li>
+Always using the compact form for JSON-LD terms and types and always ensuring
+that those terms and types are defined in application-specific JSON-LD context
+files.
+          </li>
        </ul>
 
         </p>

--- a/index.html
+++ b/index.html
@@ -3989,10 +3989,20 @@ base media type, `application/vc+ld+json`.
 
         <p>
 As elaborated upon in Section <a href="#json-processing"></a>, some software
-applications might not perform full JSON-LD processing.
-<a>Conforming document</a> authors are urged to not use JSON-LD keywords that
-affect document processing in the `@context` value, such as globally setting
-`@base` and `@language`, in order to increase interoperability.
+applications might not perform full JSON-LD processing. In order to increase
+interoperability, <a>conforming document</a> authors are urged to not use
+JSON-LD features that are not easily detected when not performing full
+JSON-LD processing. This guidance includes:
+        </p>
+
+        <ul>
+          <li>
+Not using JSON-LD keywords in the `@context` value that modify document
+processing, such as globally setting `@base` and `@language`, in order to
+increase interoperability.
+          </li>
+       </ul>
+
         </p>
 
         <section>


### PR DESCRIPTION
This PR attempts to address issue #1206 by advising that document authors do not use full URLs, such as `https://schema.org/Person` for terms/types, and instead use the compact form (`Person`), in order to increase compatibility with processors that don't do full JSON-LD processing.