### PR TITLE
Base classes are defined now in the spec

### DIFF
--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -19,20 +19,20 @@ ontology:
 class:
   - id: CredentialEvidence
     label: Credential Evidence
-    comment: A credential evidence provides evidence schemes that are used by the <a href="#evidence">evidence</a> property. This class serves as a supertype for specific evidence types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-evidence
     status: reserved
 
   - id: CredentialSchema
     label: Credential schema
-    comment: A credential schema provides verifiers with enough information to determine if the provided data conforms to the provided schema. This class serves as a supertype for specific schemas (e.g., <a href="#JsonSchema">JsonSchema</a>).
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-schema
 
   - id: CredentialStatus
     label: Credential status
-    comment: A credential status provides enough information to determine the current status of the credential (for example, suspended or revoked). This class serves as a supertype for specific status types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-status
 
   - id: ConfidenceMethod
     label: Confidence method
-    defined_by: https://w3c-ccg.github.io/confidence-method-spec/
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-confidence-method
     status: reserved
 
   - id: JsonSchema
@@ -47,22 +47,18 @@ class:
 
   - id: RefreshService
     label: Refresh service
-    comment: A refresh service is a mechanism that can be utilized by software agents to retrieve an updated copy of a Verifiable Credential. This class serves as a supertype for specific refresh service types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-refresh-service
     status: reserved
 
   - id: RenderMethod
     label: Render method
-    comment: A specific render method specifies how a software expresses the verifiable credential using a visual, auditory, or haptic mechanism. This class serves as a supertype for specific render method types.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-render-method
     status: reserved
 
   - id: TermsOfUse
     label: Terms of use
-    comment: Policy under which the creator issued the credential or presentation. This class serves as a supertype for specific types for terms of use.
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-terms-of-use
     status: reserved
-
-  # - id: StatusList2021Entry
-  #   label: Status List 2021 Entry
-  #   comment: A Status List 2021 Entry provides issuers with a mechanism to provide status information for verifiable credentials.
 
   - id: VerifiableCredential
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#credentials


### PR DESCRIPTION
***This is a PR against #1272***

The vocabulary definitions for the base classes have been changed to rely on the table in the VCDM specification.