### PR TITLE
Add links to static copies of vocabulary files and hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5849,14 +5849,16 @@ as what the <a>issuer</a> or <a>holder</a> intended.
 
         <p class="issue" title="(AT RISK) URL values might change during Candidate Recommendation">
 This section lists URL values that might change during the Candidate
-Recommendation phase based on migration of documents to the W3C Technical
-Reports namespace and implementer feedback that requires the referenced URLs to
-be modified.
+Recommendation phase based on migration of documents to time-stamped locations,
+migration of documents to the W3C Technical Reports namespace, and/or
+implementer feedback that requires the referenced URLs to be modified.
         </p>
 
         <p>
 Implementations MUST ensure that the following vocabulary URLs used in the base
-context ultimately resolve to the following files, which are normative:
+context ultimately resolve to the following files, which are normative.
+Cryptographic hashes are provided for all content to ensure that developers
+can verify that the contents of each file are correct.
         </p>
 
         <table class="simple">
@@ -5873,32 +5875,13 @@ context ultimately resolve to the following files, which are normative:
 https://www.w3.org/2018/credentials#
               </td>
               <td>
-text/html
-              </td>
-              <td>
-https://www.w3.org/2018/credentials/index.html
-              </td>
-            </tr>
-            <tr>
-              <td>
-https://www.w3.org/2018/credentials#
-              </td>
-              <td>
 application/ld+json
               </td>
               <td>
-https://www.w3.org/2018/credentials/index.jsonld
-              </td>
-            </tr>
-            <tr>
-              <td>
-https://schema.org/
-              </td>
-              <td>
-text/html
-              </td>
-              <td>
-https://schema.org/
+https://www.w3.org/2018/credentials/index.jsonld<br><br>
+sha256: z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=<br><br>
+sha3-512: m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
+h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==
               </td>
             </tr>
             <tr>
@@ -5909,18 +5892,10 @@ https://schema.org/
 application/ld+json
               </td>
               <td>
-https://schema.org/version/latest/schemaorg-current-https.jsonld
-              </td>
-            </tr>
-            <tr>
-              <td>
-https://w3id.org/security#
-              </td>
-              <td>
-text/html
-              </td>
-              <td>
-https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.html
+https://schema.org/version/22.0/schemaorg-all-https.jsonld<br><br>
+sha256: KToiFier2I43VBuzvTkHG1dnBZEnpwoThC5AozLhnzA=<br><br>
+sha3-512: uao4ahYBx+0pl5os+tg1CaljyXxVN4CpHtC19tESQF<wbr>
+QYx7Rd5nQww/F8/ERpnsay1gDECReEyZzmffwhWV3omQ==
               </td>
             </tr>
             <tr>
@@ -5931,25 +5906,18 @@ https://w3id.org/security#
 application/ld+json
               </td>
               <td>
-https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld
+https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
+sha256: LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=<br><br>
+sha3-512: f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==
               </td>
             </tr>
           </tbody>
         </table>
 
-        <p class="issue" title="w3c.github.io links expected to change">
-The URLs listed above that start with
-`https://w3c.github.io/vc-data-integrity/vocab/security/` are expected to change
-to `https://www.w3.org/ns/security/` or an equally normative and archived
-location under W3C control.
-        </p>
-
-        <p class="issue" title="How to normatively refer to vocabulary files">
-The Working Group is currently discussing how it might want to normatively
-refer to the vocabulary files that are under the control of the Working Group.
-Current options are: inclusion of the files directly into the specification or
-publishing the files in W3C TR space and referring to them by using a
-cryptographic hash.
+        <p>
+It is possible to confirm the cryptographic digests listed above by running the
+following command from a modern Unix command interface line:
+`curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -5904,6 +5904,17 @@ following command from a modern Unix command interface line:
 `curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
         </p>
 
+        <p class="note"
+            title="schema.org changes regularly, but considered stable">
+Implementers and document authors might note that cryptographic digests for
+`schema.org` are not provided. This is due to the `schema.org` vocabulary
+undergoing regular changes; any digest provided would be out of date within
+weeks of publication. The Working Group discussed this concern and concluded
+that the vocabulary terms that are used from `schema.org`, by this
+specification, have been stable for years and are highly unlikely to change in
+their semantic meaning.
+        </p>
+
         <p>
 The following base classes are defined in this specification for processors
 and other specifications that benefit from such definitions:

--- a/index.html
+++ b/index.html
@@ -5855,26 +5855,25 @@ implementer feedback that requires the referenced URLs to be modified.
         </p>
 
         <p>
-Implementations MUST ensure that the following vocabulary URLs used in the base
-context ultimately resolve to the following files, which are normative.
-Cryptographic hashes are provided for all content to ensure that developers
-can verify that the contents of each file are correct.
+Implementations that depend on RDF vocabulary processing MUST ensure that the
+following vocabulary URLs used in the base context ultimately resolve to the
+following files, which are normative. Other semantically equivalent
+serializations of the vocabulary files MAY be utilized by implementations.
+Cryptographic hashes are provided for all content to ensure that developers can
+verify that the contents of each file are correct.
         </p>
 
         <table class="simple">
           <thead>
             <tr>
-              <th>URL</th>
-              <th>Media Type</th>
-              <th>Content</th>
+              <th>URL and Media Type</th>
+              <th>Content and Hashes</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td>
-https://www.w3.org/2018/credentials#
-              </td>
-              <td>
+https://www.w3.org/2018/credentials#<br>
 application/ld+json
               </td>
               <td>
@@ -5886,9 +5885,7 @@ h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==
             </tr>
             <tr>
               <td>
-https://schema.org/
-              </td>
-              <td>
+https://schema.org/<br>
 application/ld+json
               </td>
               <td>
@@ -5900,15 +5897,14 @@ QYx7Rd5nQww/F8/ERpnsay1gDECReEyZzmffwhWV3omQ==
             </tr>
             <tr>
               <td>
-https://w3id.org/security#
-              </td>
-              <td>
+https://w3id.org/security#<br>
 application/ld+json
               </td>
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
 sha256: LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=<br><br>
-sha3-512: f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==
+sha3-512: f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
+e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -5858,7 +5858,7 @@ implementer feedback that requires the referenced URLs to be modified.
 Implementations that depend on RDF vocabulary processing MUST ensure that the
 following vocabulary URLs used in the base context ultimately resolve to the
 following files, which are normative. Other semantically equivalent
-serializations of the vocabulary files MAY be utilized by implementations.
+serializations of the vocabulary files MAY be used by implementations.
 Cryptographic hashes are provided for all content to ensure that developers can
 verify that the contents of each file are correct.
         </p>
@@ -5874,37 +5874,37 @@ verify that the contents of each file are correct.
             <tr>
               <td>
 https://www.w3.org/2018/credentials#<br>
-application/ld+json
+`application/ld+json`
               </td>
               <td>
 https://www.w3.org/2018/credentials/index.jsonld<br><br>
-sha256: z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=<br><br>
-sha3-512: m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
-h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==
+sha256: `z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=`<br><br>
+sha3-512: `m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
+h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==`
               </td>
             </tr>
             <tr>
               <td>
 https://schema.org/<br>
-application/ld+json
+`application/ld+json`
               </td>
               <td>
 https://schema.org/version/22.0/schemaorg-all-https.jsonld<br><br>
-sha256: KToiFier2I43VBuzvTkHG1dnBZEnpwoThC5AozLhnzA=<br><br>
-sha3-512: uao4ahYBx+0pl5os+tg1CaljyXxVN4CpHtC19tESQF<wbr>
-QYx7Rd5nQww/F8/ERpnsay1gDECReEyZzmffwhWV3omQ==
+sha256: `KToiFier2I43VBuzvTkHG1dnBZEnpwoThC5AozLhnzA=`<br><br>
+sha3-512: `uao4ahYBx+0pl5os+tg1CaljyXxVN4CpHtC19tESQF<wbr>
+QYx7Rd5nQww/F8/ERpnsay1gDECReEyZzmffwhWV3omQ==`
               </td>
             </tr>
             <tr>
               <td>
 https://w3id.org/security#<br>
-application/ld+json
+`application/ld+json`
               </td>
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
-sha256: LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=<br><br>
-sha3-512: f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
-e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==
+sha256: `LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=`<br><br>
+sha3-512: `f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
+e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==`
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -5879,20 +5879,8 @@ https://www.w3.org/2018/credentials#<br>
               <td>
 https://www.w3.org/2018/credentials/index.jsonld<br><br>
 sha256: `z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=`<br><br>
-sha3-512: `m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
-h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==`
-              </td>
-            </tr>
-            <tr>
-              <td>
-https://schema.org/<br>
-`application/ld+json`
-              </td>
-              <td>
-https://schema.org/version/22.0/schemaorg-all-https.jsonld<br><br>
-sha256: `KToiFier2I43VBuzvTkHG1dnBZEnpwoThC5AozLhnzA=`<br><br>
-sha3-512: `uao4ahYBx+0pl5os+tg1CaljyXxVN4CpHtC19tESQF<wbr>
-QYx7Rd5nQww/F8/ERpnsay1gDECReEyZzmffwhWV3omQ==`
+sha3-512: <code>m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
+h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==</code>
               </td>
             </tr>
             <tr>
@@ -5903,8 +5891,8 @@ https://w3id.org/security#<br>
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
 sha256: `LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=`<br><br>
-sha3-512: `f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
-e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==`
+sha3-512: <code>f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
+e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -5905,12 +5905,12 @@ following command from a modern Unix command interface line:
         </p>
 
         <p class="note"
-            title="schema.org changes regularly, but considered stable">
+            title="schema.org changes regularly, but is considered stable">
 Implementers and document authors might note that cryptographic digests for
-`schema.org` are not provided. This is due to the `schema.org` vocabulary
-undergoing regular changes; any digest provided would be out of date within
+`schema.org` are not provided. This is because the `schema.org` vocabulary
+undergoes regular changes; any digest provided would be out of date within
 weeks of publication. The Working Group discussed this concern and concluded
-that the vocabulary terms that are used from `schema.org`, by this
+that the vocabulary terms from `schema.org`, that are used by this
 specification, have been stable for years and are highly unlikely to change in
 their semantic meaning.
         </p>


### PR DESCRIPTION
This PR is an attempt at addressing issue #1261, which requested that cryptographic hashes be added to the vocabulary files. This PR utilizes both frozen static files and hash values to achieve the end result, which are stable vocabulary definitions for systems that perform RDF vocabulary processing (which is a completely optional, non-mandatory thing).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1279.html" title="Last updated on Oct 21, 2023, 6:54 PM UTC (1a88c3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1279/87a4db3...1a88c3c.html" title="Last updated on Oct 21, 2023, 6:54 PM UTC (1a88c3c)">Diff</a>