### PR TITLE
Add normative requirements related to context processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -5804,6 +5804,17 @@ if a cryptographic hash value for a resource does not match the expected hash
 value.
         </p>
         <p>
+Implementations that apply the base context above, as well as other contexts
+and values in any `@context` property, during operations such as
+<a href="https://www.w3.org/TR/json-ld11-api/#expansion-algorithm">
+JSON-LD Expansion</a> or
+<a href="https://www.w3.org/TR/json-ld11/#serializing-deserializing-rdf">
+transformation to RDF</a> are expected to do so without experiencing any
+errors. If these operations are performed, and the result is an error, the
+<a>verifiable credential</a> or <a>verifiable presentation</a> MUST result in
+a verification failure.
+        </p>
+        <p>
 It is possible to confirm the SHA-384 digest above by running the following
 command from a modern Unix command interface line:
 `curl -s https://www.w3.org/ns/credentials/v2 | openssl dgst -sha384 -binary | openssl base64 -A`

--- a/index.html
+++ b/index.html
@@ -5810,9 +5810,9 @@ and values in any `@context` property, during operations such as
 JSON-LD Expansion</a> or
 <a href="https://www.w3.org/TR/json-ld11/#serializing-deserializing-rdf">
 transformation to RDF</a> are expected to do so without experiencing any
-errors. If these operations are performed, and the result is an error, the
-<a>verifiable credential</a> or <a>verifiable presentation</a> MUST result in
-a verification failure.
+errors. If operations of this type are performed, and the result is an error,
+the <a>verifiable credential</a> or <a>verifiable presentation</a> MUST result
+in a verification failure.
         </p>
         <p>
 It is possible to confirm the SHA-384 digest above by running the following

--- a/index.html
+++ b/index.html
@@ -5809,8 +5809,8 @@ and values in any `@context` property, during operations such as
 <a href="https://www.w3.org/TR/json-ld11-api/#expansion-algorithm">
 JSON-LD Expansion</a> or
 <a href="https://www.w3.org/TR/json-ld11/#serializing-deserializing-rdf">
-transformation to RDF</a> are expected to do so without experiencing any
-errors. If operations of this type are performed, and the result is an error,
+transformation to RDF</a>, are expected to do so without experiencing any
+errors. If such operations are performed and result in an error,
 the <a>verifiable credential</a> or <a>verifiable presentation</a> MUST result
 in a verification failure.
         </p>


### PR DESCRIPTION
This PR is an attempt at addressing #1185 by noting how the normative context is used and to make sure that if that optional processing is performed, if an error occurs, verification MUST fail.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1281.html" title="Last updated on Sep 26, 2023, 9:26 PM UTC (6247ecf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1281/d300869...6247ecf.html" title="Last updated on Sep 26, 2023, 9:26 PM UTC (6247ecf)">Diff</a>