### PR TITLE
Add `relatedResource` and `digestSRI` to the vocabulary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .vscode
 .idea
 .gitignore
+vocab/credentials/v2/.$vocabulary.drawio.bkp
 
 **/node_modules
 **/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .vscode
 .idea
 .gitignore
-vocab/credentials/v2/.$vocabulary.drawio.bkp
+*.bkp
 
 **/node_modules
 **/.DS_Store

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -68,12 +68,11 @@
 
     "digestSRI": {
       "@id": "https://www.w3.org/2018/credentials#digestSRI",
-      "@type": "https://www.w3.org/2018/credentials#sristring"
+      "@type": "https://www.w3.org/2018/credentials#sriString"
     },
     "mediaType": {
       "@id": "https://schema.org/encodingFormat"
     },
-
 
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -66,6 +66,15 @@
       "@id": "https://www.iana.org/assignments/jwt#..."
     },
 
+    "digestSRI": {
+      "@id": "https://www.w3.org/2018/credentials#digestSRI",
+      "@type": "https://www.w3.org/2018/credentials#sristring"
+    },
+    "mediaType": {
+      "@id": "https://schema.org/encodingFormat"
+    },
+
+
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
       "@context": {
@@ -148,6 +157,10 @@
         },
         "confidenceMethod": {
           "@id": "https://www.w3.org/2018/credentials#confidenceMethod",
+          "@type": "@id"
+        },
+        "relatedResource": {
+          "@id": "https://www.w3.org/2018/credentials#relatedResource",
           "@type": "@id"
         }
       }

--- a/index.html
+++ b/index.html
@@ -6181,20 +6181,20 @@ by the end of the Candidate Recommendation phase.
         </p>
 
         <section>
-            <h4>The <code>sristring</code> Datatype</h4>
+            <h4>The <code>sriString</code> Datatype</h4>
         
             <p>
               The string provides the integrity information for a resource using the method specified in the [[SRI]] specification.
             </p>
         
             <p>
-              The `sristring` datatype is defined as follows:
+              The `sriString` datatype is defined as follows:
             </p>
         
             <dl>
               <dt>The URL denoting this datatype</dt>
               <dd>
-                `https://w3.org/2018/credentials#sristring`
+                `https://w3.org/2018/credentials#sriString`
               </dd>
               <dt>The lexical space</dt>
               <dd>

--- a/index.html
+++ b/index.html
@@ -6194,7 +6194,7 @@ by the end of the Candidate Recommendation phase.
             <dl>
               <dt>The URL denoting this datatype</dt>
               <dd>
-                `https://w3.org/2018/credentials#sriString`
+                `https://www.w3.org/2018/credentials#sriString`
               </dd>
               <dt>The lexical space</dt>
               <dd>

--- a/index.html
+++ b/index.html
@@ -6203,7 +6203,7 @@ by the end of the Candidate Recommendation phase.
               </dd>
               <dt>The value space</dt>
               <dd>
-                Valid hash expressions whose hash functions are understood by the application.
+                A (possibly empty) list of <i>(alg,val)</i> pairs, where <i>alg</i> identifies a hash function, and <i>val</i> is an integer as a standard mathematical concept.
               </dd>
               <dt>The lexical-to-value mapping</dt>
               <dd>

--- a/index.html
+++ b/index.html
@@ -6213,7 +6213,7 @@ by the end of the Candidate Recommendation phase.
               </dd>
               <dt>The canonical mapping</dt>
               <dd>
-                The canonical mapping consists of using the lexical-to-value mapping.
+                The canonical mapping consists of the lexical-to-value mapping.
               </dd>
             </dl>
         </section>

--- a/index.html
+++ b/index.html
@@ -2968,7 +2968,7 @@ the <a>verifiable credential</a> are the same when used by both the
         <p>
 To validate that a resource referenced by a <a>verifiable credential</a> is the
 same at verification time as it is at issuing time, an implementer MAY include a
-property named <code>relatedResource</code> that stores an array of objects that
+property named <code id="defn-relatedResource">relatedResource</code> that stores an array of objects that
 describe additional integrity metadata about each resource referenced by the
 <a>verifiable credential</a>. If <code>relatedResource</code> is present, there
 MUST be an object in the array for each remote resource for each context used in
@@ -2982,7 +2982,7 @@ the specification.
         <p>
 Each object in the <code>relatedResource</code> array MUST contain the
 following: the [[URL]] to the resource named <code>id</code> and the
-<code>digestSRI</code> information for the resource constructed using the method
+<code id="defn-digestSRI">digestSRI</code> information for the resource constructed using the method
 specified in <a href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource
 Integrity</a>.
         </p>
@@ -6169,6 +6169,54 @@ by the end of the Candidate Recommendation phase.
         </table>
 
       </section>
+
+      <section>
+        <h3>Datatypes</h3>
+        <p>
+          This section defines datatypes that are used by this specification.
+        </p>
+
+        <section>
+            <h4>The <code>sristring</code> Datatype</h4>
+        
+            <p>
+              The string provides the integrity information for a resource using the method specified in the [[SRI]] specification.
+            </p>
+        
+            <p>
+              The `sristring` datatype is defined as follows:
+            </p>
+        
+            <dl>
+              <dt>The URL denoting this datatype</dt>
+              <dd>
+                `https://w3.org/2018/credentials#sristring`
+              </dd>
+              <dt>The lexical space</dt>
+              <dd>
+                See the <a href="https://www.w3.org/TR/SRI/#the-integrity-attribute">ABNF grammar</a>, defining the `integrity` 
+                attribute in the [[SRI]] specification, for the restrictions on the string format.
+              </dd>
+              <dt>The value space</dt>
+              <dd>
+                Valid hash expressions whose hash functions are understood by the application.
+              </dd>
+              <dt>The lexical-to-value mapping</dt>
+              <dd>
+                Any element of the lexical space is mapped to the value space by   
+                following the <a href="https://www.w3.org/TR/SRI/#parse-metadata">parse metadata algorithm</a> based
+                on the <a href="https://www.w3.org/TR/SRI/#the-integrity-attribute">ABNF grammar</a> in the [[SRI]] specification.
+              </dd>
+              <dt>The canonical mapping</dt>
+              <dd>
+                The canonical mapping consists of using the lexical-to-value mapping.
+              </dd>
+            </dl>
+        </section>
+
+
+      </section>
+
       <section class="informative">
         <h3>Differences between Contexts, Types, and CredentialSchemas</h3>
 

--- a/vocab/credentials/v2/README.md
+++ b/vocab/credentials/v2/README.md
@@ -13,5 +13,5 @@ The generation of the final files is done via a github action (see `/.github/wor
   
     The corresponding application can be downloaded and used directly, or added to Google Docs. Note that, due to some bug in the software the exported SVG file must be ran through a [post-processing script](https://github.com/iherman/drawio-svg/), to be downloaded and run separately.
 - `vocabulary.svg`: the SVG file for the vocabulary, generated from `vocabulary.drawio`.
-- `template.json`: an HTML template file used by the script; it is the skeleton of the final HTML format based on [ReSpec](https://respec.org/docs/). If the file is modified, care should be taken not to change the core structure and the various, possibly empty, HTML elements with `@id` values. The script fills those elements with content when generating the `vocabulary.html` file (and removes the sections that remain empty after processing).
+- `template.json`: an HTML template file used by the script; it is the skeleton of the final HTML format based on [ReSpec](https://respec.org/docs/). If the file is modified, care should be taken not to change the core structure and the various, possibly empty, HTML elements with `@id` values. The script fills those elements with content when generating the `vocabulary.html` file (and removes any sections that remain empty after processing).
 

--- a/vocab/credentials/v2/README.md
+++ b/vocab/credentials/v2/README.md
@@ -9,5 +9,9 @@ The generation of the final files is done via a github action (see `/.github/wor
 
 - `Readme.md`: this file.
 - `vocabulary.yml`: the core vocabulary specification. _Any change on the vocabulary must be made by modifying this file;_ see the separate [description](https://github.com/w3c/yml2vocab) of the underlying YAML format.
-- `template.json`: an HTML template file used by the script; it is the skeleton of the final HTML format based on [ReSpec](https://respec.org/docs/). If the file is modified, care should be taken not to change the core structure and the various, possibly empty, HTML elements with `@id` values. The script fills those elements with content when generating the `vocabulary.html` file.
+- `vocabulary.drawio`: the vocabulary diagram in the [draw.io](https://www.drawio.com/) format. _Any change on the vocabulary diagram must be made by modifying this file._ 
+  
+    The corresponding application can be downloaded and used directly, or added to Google Docs. Note that, due to some bug in the software the exported SVG file must be ran through a [post-processing script](https://github.com/iherman/drawio-svg/), to be downloaded and run separately.
+- `vocabulary.svg`: the SVG file for the vocabulary, generated from `vocabulary.drawio`.
+- `template.json`: an HTML template file used by the script; it is the skeleton of the final HTML format based on [ReSpec](https://respec.org/docs/). If the file is modified, care should be taken not to change the core structure and the various, possibly empty, HTML elements with `@id` values. The script fills those elements with content when generating the `vocabulary.html` file (and removes the sections that remain empty after processing).
 

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -14,7 +14,7 @@
         const retval = content
           .replace('<svg', '<svg aria-details="#vocabulary-diagram-alt" ')
           .replace(/xlink:href/g, 'href')
-          .replace(/href="https:\/\/w3.org\/2018\/credentials\/#/g, 'href="#');
+          .replace(/href="https:\/\/www.w3.org\/2018\/credentials#/g, 'href="#');
         return retval;
       }
 

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -282,13 +282,14 @@
         </p>
         <p>
           The "VerifiableCredential" ellipse is connected to the "credentialSchema", "credentialStatus",
-          "credentialSubject", "issuer", "evidence", "refreshService", "renderMethod", and "confidenceMethod"
-          boxes, through connecting lines styled as Domain Of. 
+          "credentialSubject", "issuer", "relatedResource", "evidence", "refreshService", "renderMethod", 
+          and "confidenceMethod" boxes, through connecting lines styled as Domain Of. 
           It is also connected to the crossing point circle with a similar connecting line,
           styled as Domain Of.
           The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" 
           and "verifiableCredential" boxes, with a similar connecting line, styled as Domain Of. 
-          The crossing point circle is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a connecting line styled as Domain Of.
+          The crossing point circle is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a 
+          connecting line styled as Domain Of.
           The "verifiableCredential" box is connected to the "VerifiableCredentialGraph" ellipse with a connecting
           line styled as Range. 
           The "JsonSchemaCredential" ellipse is connected to the "VerifiableCredential" ellipse with a 
@@ -304,12 +305,17 @@
           connected to those Class ellipses, with connecting lines styled as Range. 
         </p>
         <p>
-          Finally, the "CredentialSchema" ellipse is connected to one more ellipse, on the far right
+          The "CredentialSchema" ellipse is connected to one more ellipse, on the far right
           side of the diagram, styled as Class and labeled as "JsonSchema", with a connecting line
           styled as Superclass. This "JsonSchema" ellipse is also connected to a Property box
           labeled as "jsonSchema", through a connector line styled as Domain Of. This "jsonSchema"
           box is connected to a Datatype shape labeled as "rdf:JSON", with a connecting line
           styled as Range. 
+        </p>
+        <p>
+          Finally, on the lower far right side of the diagram, there is a separate Property box labeled as 
+          "digestSRI", connected to a Datatype shape labeled as "sristring", with a connecting line 
+          styled as Range.
         </p>
       </details>
     </section>

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -198,6 +198,10 @@
         <h2>Property definitions</h2>
       </section>
 
+      <section id="datatype_definitions" class="term_definitions">
+        <h2>Datatype definitions</h2>
+      </section>
+
       <section id="individual_definitions" class="term_definitions">
         <h2>Definitions for individuals</h2>
       </section>
@@ -220,6 +224,10 @@
         <h2>Reserved properties</h2>
       </section>
 
+      <section id="reserved_datatype_definitions" class="term_definitions">
+        <h2>Reserved datatype definitions</h2>
+      </section>
+
       <section id="reserved_individual_definitions" class="term_definitions">
         <h2>Reserved individuals</h2>
       </section>
@@ -234,6 +242,10 @@
 
       <section id="deprecated_class_definitions" class="term_definitions">
         <h2>Deprecated classes</h2>
+      </section>
+
+      <section id="deprecated_property_definitions" class="term_definitions">
+        <h2>Deprecated properties</h2>
       </section>
 
       <section id="deprecated_property_definitions" class="term_definitions">

--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -4,22 +4,22 @@
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-1451" y="-384.80545548121466" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1281" y="-889" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1561" y="-768.9536798764797" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1285" y="-150.71513124034982" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -51,7 +51,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1474.5" y="-592.8857436953165" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -61,62 +61,62 @@
             <mxPoint x="-1251" y="-640.9042717447246" as="sourcePoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-824.9752959341225" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-768" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-712" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-655" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-542" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-486" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-429" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-372" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-316" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-259" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-202.75913535769416" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-144.71281523417395" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
@@ -245,37 +245,37 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-433.84791559444164" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-546.8911477097273" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-490.86953165208445" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-377.8262995367988" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-321.80468347915604" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-830.9776119402985" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-774.9559958826557" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -322,7 +322,7 @@
             <mxPoint x="-572" y="-274.7869274318065" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-231" y="-752.1471950591869" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -432,7 +432,7 @@
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-55" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
           <mxGeometry y="7" width="70" height="40" as="geometry" />
         </mxCell>
-        <UserObject label="" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
+        <UserObject label="" link="https://www.w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
             <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
           </mxCell>
@@ -443,7 +443,7 @@
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-49" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="usrDyYZYH79wCYu34c_K-5" vertex="1">
           <mxGeometry y="6.1875" width="50" height="30" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-207.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
@@ -465,7 +465,7 @@
             <mxPoint x="-191" y="-389.8028821410189" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
             <mxGeometry x="-881" y="-599" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
@@ -479,7 +479,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
             <mxGeometry x="-207.5" y="-429.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>

--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -4,22 +4,22 @@
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-1451" y="-384.80545548121466" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1281" y="-889" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1561" y="-768.9536798764797" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1285" y="-150.71513124034982" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -51,7 +51,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1474.5" y="-592.8857436953165" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -61,62 +61,62 @@
             <mxPoint x="-1251" y="-640.9042717447246" as="sourcePoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-824.9752959341225" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-768" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-712" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-655" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-542" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-486" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-429" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-372" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-316" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-259" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-202.75913535769416" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-144.71281523417395" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
@@ -245,37 +245,37 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-433.84791559444164" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-546.8911477097273" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-490.86953165208445" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-377.8262995367988" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-321.80468347915604" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-830.9776119402985" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-774.9559958826557" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -322,7 +322,7 @@
             <mxPoint x="-572" y="-274.7869274318065" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-231" y="-752.1471950591869" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
@@ -432,7 +432,7 @@
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-55" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
           <mxGeometry y="7" width="70" height="40" as="geometry" />
         </mxCell>
-        <UserObject label="" link="https://www.w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
+        <UserObject label="" link="https://www.w3.org/2018/credentials#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
             <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
           </mxCell>
@@ -443,7 +443,7 @@
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-49" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="usrDyYZYH79wCYu34c_K-5" vertex="1">
           <mxGeometry y="6.1875" width="50" height="30" as="geometry" />
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-207.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
@@ -465,7 +465,7 @@
             <mxPoint x="-191" y="-389.8028821410189" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
             <mxGeometry x="-881" y="-599" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
@@ -479,7 +479,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials/#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
             <mxGeometry x="-207.5" y="-429.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>

--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -1,26 +1,26 @@
-<mxfile host="Electron" modified="2023-09-06T12:04:00.902Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.6.8 Chrome/114.0.5735.289 Electron/25.5.0 Safari/537.36" etag="TgjbTUcafH9ymLvzvLQA" version="21.6.8" type="device">
+<mxfile host="Electron" modified="2023-09-30T08:19:13.594Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.0 Chrome/114.0.5735.289 Electron/25.8.3 Safari/537.36" etag="P2DNnCw8gU-rS8J6qqE1" version="22.0.0" type="device">
   <diagram name="Page-1" id="5wcF2D67hh1iBqyEtvuE">
-    <mxGraphModel dx="3512" dy="2118" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+    <mxGraphModel dx="3310" dy="2042" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-1451" y="-384.80545548121466" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1281" y="-889" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1561" y="-768.9536798764797" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1285" y="-150.71513124034982" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
@@ -51,8 +51,8 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-1474.5" y="-592.8857436953165" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
@@ -61,63 +61,63 @@
             <mxPoint x="-1251" y="-640.9042717447246" as="sourcePoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-824.9752959341225" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-768.9536798764797" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-768" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-712.9320638188369" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-712" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-656.9104477611941" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-655" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-600.8888317035512" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-542" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-544.8672156459083" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-486" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-488.8455995882656" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-429" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-432.82398353062274" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-372" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-376.8023674729799" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-316" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-320.78075141533725" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-259" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-264.75913535769416" width="171" height="27.21049922799794" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-202.75913535769416" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-881" y="-144.71281523417395" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
@@ -201,14 +201,14 @@
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fontSize=16;fillColor=#cc0000;strokeColor=none;" parent="1" vertex="1">
-          <mxGeometry x="-1071" y="-312" width="10" height="10" as="geometry" />
+          <mxGeometry x="-1071" y="-253" width="10" height="10" as="geometry" />
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-23" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-7" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-871" y="-123.10447761194041" as="sourcePoint" />
             <mxPoint x="-1053" y="-123.10447761194041" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1140" y="-260" />
+              <mxPoint x="-1130" y="-220" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -232,7 +232,7 @@
             <mxPoint x="-1142" y="-299.1724137931036" as="sourcePoint" />
             <mxPoint x="-901" y="-360.79619145651066" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-970" y="-350" />
+              <mxPoint x="-970" y="-300" />
             </Array>
           </mxGeometry>
         </mxCell>
@@ -241,42 +241,42 @@
             <mxPoint x="-1141" y="-280.76531137416373" as="sourcePoint" />
             <mxPoint x="-921" y="-232.7467833247556" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-980" y="-260" />
+              <mxPoint x="-980" y="-200" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-494.84791559444164" width="218" height="39.215131240349976" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-433.84791559444164" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-606.8911477097273" width="218" height="39.215131240349976" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-546.8911477097273" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-550.8695316520844" width="218" height="39.215131240349976" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-490.86953165208445" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-438.8262995367988" width="218" height="39.215131240349976" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-377.8262995367988" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-382.80468347915604" width="218" height="39.215131240349976" as="geometry" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-321.80468347915604" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-830.9776119402985" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-591" y="-774.9559958826557" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
@@ -294,36 +294,36 @@
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-37" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-5" target="lZdwYr-LXM3OhQDUA7XR-29" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-701" y="-584.8826556870819" as="sourcePoint" />
-            <mxPoint x="-542" y="-630.5002573340196" as="targetPoint" />
+            <mxPoint x="-701" y="-522.8826556870819" as="sourcePoint" />
+            <mxPoint x="-542" y="-568.5002573340196" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-38" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-6" target="lZdwYr-LXM3OhQDUA7XR-30" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-671" y="-672.9166237776634" as="sourcePoint" />
-            <mxPoint x="-552" y="-672.9166237776634" as="targetPoint" />
+            <mxPoint x="-671" y="-610.9166237776634" as="sourcePoint" />
+            <mxPoint x="-552" y="-610.9166237776634" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-39" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-7" target="lZdwYr-LXM3OhQDUA7XR-28" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-561" y="-673.7169325784869" as="sourcePoint" />
-            <mxPoint x="-442" y="-673.7169325784869" as="targetPoint" />
+            <mxPoint x="-561" y="-611.7169325784869" as="sourcePoint" />
+            <mxPoint x="-442" y="-611.7169325784869" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-40" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-8" target="lZdwYr-LXM3OhQDUA7XR-31" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-671" y="-384.80545548121466" as="sourcePoint" />
-            <mxPoint x="-552" y="-384.80545548121466" as="targetPoint" />
+            <mxPoint x="-671" y="-322.80545548121466" as="sourcePoint" />
+            <mxPoint x="-552" y="-322.80545548121466" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-41" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-9" target="lZdwYr-LXM3OhQDUA7XR-32" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-691" y="-336.7869274318065" as="sourcePoint" />
-            <mxPoint x="-572" y="-336.7869274318065" as="targetPoint" />
+            <mxPoint x="-691" y="-274.7869274318065" as="sourcePoint" />
+            <mxPoint x="-572" y="-274.7869274318065" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-231" y="-752.1471950591869" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
@@ -336,24 +336,24 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="usrDyYZYH79wCYu34c_K-6" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="usrDyYZYH79wCYu34c_K-6" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="-1598" y="-62" width="1621" height="54.5" as="geometry" />
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-45" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="usrDyYZYH79wCYu34c_K-6" vertex="1">
           <mxGeometry width="1595" height="54.5" as="geometry" />
         </mxCell>
-        <mxCell id="usrDyYZYH79wCYu34c_K-5" value="" style="group" vertex="1" connectable="0" parent="usrDyYZYH79wCYu34c_K-6">
+        <mxCell id="usrDyYZYH79wCYu34c_K-5" value="" style="group" parent="usrDyYZYH79wCYu34c_K-6" vertex="1" connectable="0">
           <mxGeometry x="7" y="2.5" width="1614" height="49.5" as="geometry" />
         </mxCell>
-        <mxCell id="usrDyYZYH79wCYu34c_K-1" value="" style="group" vertex="1" connectable="0" parent="usrDyYZYH79wCYu34c_K-5">
+        <mxCell id="usrDyYZYH79wCYu34c_K-1" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
           <mxGeometry x="718" y="4.75" width="163.39999999999998" height="40" as="geometry" />
         </mxCell>
         <UserObject label="" id="usrDyYZYH79wCYu34c_K-2">
-          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=#dae8fc;strokeWidth=2;" vertex="1" parent="usrDyYZYH79wCYu34c_K-1">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="usrDyYZYH79wCYu34c_K-1" vertex="1">
             <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="usrDyYZYH79wCYu34c_K-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" vertex="1" parent="usrDyYZYH79wCYu34c_K-1">
+        <mxCell id="usrDyYZYH79wCYu34c_K-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="usrDyYZYH79wCYu34c_K-1" vertex="1">
           <mxGeometry x="13" width="90" height="40" as="geometry" />
         </mxCell>
         <mxCell id="OI71fulDIgHqbVsoXd_f-4" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
@@ -368,19 +368,10 @@
         <mxCell id="OI71fulDIgHqbVsoXd_f-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" parent="OI71fulDIgHqbVsoXd_f-4" vertex="1">
           <mxGeometry width="70" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-47" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry y="6.1875" width="160" height="37.125" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-48" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-47" vertex="1">
-          <mxGeometry x="60" y="4.95" width="100" height="28.004625" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-49" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-47" vertex="1">
-          <mxGeometry width="50" height="30" as="geometry" />
-        </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-50" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
           <mxGeometry x="175" y="6.1875" width="170" height="37.125" as="geometry" />
         </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-51" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFf2cc;strokeColor=#330000;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-51" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
           <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-52" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
@@ -429,7 +420,7 @@
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-65" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
           <mxGeometry x="360" y="3.09375" width="160" height="43.3125" as="geometry" />
         </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-66" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-66" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
           <mxGeometry x="65" y="4.95" width="100" height="28.004625" as="geometry" />
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-67" value="Reserved&lt;br&gt;class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
@@ -442,30 +433,66 @@
           <mxGeometry y="7" width="70" height="40" as="geometry" />
         </mxCell>
         <UserObject label="" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#FFF2CC;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
             <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" vertex="1" parent="1">
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-48" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" parent="usrDyYZYH79wCYu34c_K-5" vertex="1">
+          <mxGeometry x="60" y="11.1375" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-49" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="usrDyYZYH79wCYu34c_K-5" vertex="1">
+          <mxGeometry y="6.1875" width="50" height="30" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-207.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="usrDyYZYH79wCYu34c_K-8" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" target="usrDyYZYH79wCYu34c_K-7">
+        <mxCell id="usrDyYZYH79wCYu34c_K-8" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" target="usrDyYZYH79wCYu34c_K-7" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-120" y="-710" as="sourcePoint" />
             <mxPoint x="-90" y="-310" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <UserObject label="&lt;font color=&quot;#bd0000&quot;&gt;rdf:JSON&lt;/font&gt;" link="https://w3id.org/security/#cryptosuiteString" id="usrDyYZYH79wCYu34c_K-9">
-          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=#dae8fc;strokeWidth=2;" vertex="1" parent="1">
+        <UserObject label="&lt;font color=&quot;#000000&quot;&gt;rdf:JSON&lt;/font&gt;" id="usrDyYZYH79wCYu34c_K-9">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-195.99999999999994" y="-545.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="usrDyYZYH79wCYu34c_K-10" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="usrDyYZYH79wCYu34c_K-7" target="usrDyYZYH79wCYu34c_K-9">
+        <mxCell id="usrDyYZYH79wCYu34c_K-10" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="usrDyYZYH79wCYu34c_K-7" target="usrDyYZYH79wCYu34c_K-9" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-310" y="-389.8028821410189" as="sourcePoint" />
             <mxPoint x="-191" y="-389.8028821410189" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="-881" y="-599" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="NdHKz3nYJsEpI_Vai11b-2" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" edge="1" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="NdHKz3nYJsEpI_Vai11b-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1162" y="-840" as="sourcePoint" />
+            <mxPoint x="-871" y="-631" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1121" y="-670.9197117858981" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="-207.5" y="-429.002063818837" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font color=&quot;#000000&quot;&gt;sriString&lt;/font&gt;" link="https://w3id.org/security/#sriString" id="NdHKz3nYJsEpI_Vai11b-4">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="-195.99999999999994" y="-334.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="NdHKz3nYJsEpI_Vai11b-5" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="NdHKz3nYJsEpI_Vai11b-3" target="NdHKz3nYJsEpI_Vai11b-4">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-310" y="-178.80288214101893" as="sourcePoint" />
+            <mxPoint x="-191" y="-178.80288214101893" as="targetPoint" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -1,0 +1,474 @@
+<mxfile host="Electron" modified="2023-09-06T12:04:00.902Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/21.6.8 Chrome/114.0.5735.289 Electron/25.5.0 Safari/537.36" etag="TgjbTUcafH9ymLvzvLQA" version="21.6.8" type="device">
+  <diagram name="Page-1" id="5wcF2D67hh1iBqyEtvuE">
+    <mxGraphModel dx="3512" dy="2118" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-1451" y="-384.80545548121466" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1281" y="-889" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1561" y="-768.9536798764797" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1285" y="-150.71513124034982" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-9" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-6" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1535" y="-563.2743180648482" as="sourcePoint" />
+            <mxPoint x="-1485" y="-603.2897581060216" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1411" y="-832.9783839423571" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-3" target="1oUjKqBKF74gJ-cnWfdO-15" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1314" y="-492.0468347915595" as="sourcePoint" />
+            <mxPoint x="-1291" y="-552.8703036541431" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-13" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-3" target="1oUjKqBKF74gJ-cnWfdO-3" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-7" target="1oUjKqBKF74gJ-cnWfdO-3" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-987" y="-436.0252187339167" as="sourcePoint" />
+            <mxPoint x="-937" y="-476.04065877509004" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1361" y="-216.74060730828626" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1474.5" y="-592.8857436953165" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="1oUjKqBKF74gJ-cnWfdO-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=classicThin;endFill=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1251" y="-640.9042717447246" as="sourcePoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-824.9752959341225" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-768.9536798764797" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-712.9320638188369" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-656.9104477611941" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-600.8888317035512" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-544.8672156459083" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-488.8455995882656" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-432.82398353062274" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-376.8023674729799" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-320.78075141533725" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-264.75913535769416" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-144.71281523417395" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-13" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-12" target="1oUjKqBKF74gJ-cnWfdO-7" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1039" y="-161.51930005146687" as="sourcePoint" />
+            <mxPoint x="-1105" y="-336.7869274318065" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-14" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-1" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1029" y="-601.6891405043747" as="sourcePoint" />
+            <mxPoint x="-1095" y="-776.9567678847144" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-990" y="-811" />
+              <mxPoint x="-1111" y="-808.9691199176531" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-15" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-2" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-988" y="-754.5481214616573" as="sourcePoint" />
+            <mxPoint x="-1201" y="-792.9629439011837" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1147" y="-752.1471950591869" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-3" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1149" y="-497.6489963973238" as="sourcePoint" />
+            <mxPoint x="-1215" y="-672.9166237776634" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1121" y="-704.9289758106022" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-17" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-4" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1162" y="-841.7817807514153" as="sourcePoint" />
+            <mxPoint x="-942" y="-691.3237261966032" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1131" y="-680.9197117858981" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-5" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1152" y="-833.7786927431806" as="sourcePoint" />
+            <mxPoint x="-961" y="-592.8857436953165" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1151" y="-656.9104477611941" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-19" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-6" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1142" y="-825.775604734946" as="sourcePoint" />
+            <mxPoint x="-922" y="-675.3175501801338" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1161" y="-624.8980957282554" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-20" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-7" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1132" y="-817.7725167267113" as="sourcePoint" />
+            <mxPoint x="-912" y="-667.3144621718991" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1181" y="-592.8857436953165" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-21" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-8" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1122" y="-809.7694287184765" as="sourcePoint" />
+            <mxPoint x="-902" y="-659.3113741636645" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1201" y="-592.8857436953165" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fontSize=16;fillColor=#cc0000;strokeColor=none;" parent="1" vertex="1">
+          <mxGeometry x="-1071" y="-312" width="10" height="10" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-23" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-7" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-871" y="-123.10447761194041" as="sourcePoint" />
+            <mxPoint x="-1053" y="-123.10447761194041" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1140" y="-260" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-24" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-861" y="-115.10138960370568" as="sourcePoint" />
+            <mxPoint x="-1060" y="-307" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1210" y="-560" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-25" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-10" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-929" y="-307.57565620175" as="sourcePoint" />
+            <mxPoint x="-1111" y="-307.57565620175" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-26" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-9" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1142" y="-299.1724137931036" as="sourcePoint" />
+            <mxPoint x="-901" y="-360.79619145651066" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-970" y="-350" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-11" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1141" y="-280.76531137416373" as="sourcePoint" />
+            <mxPoint x="-921" y="-232.7467833247556" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-980" y="-260" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-494.84791559444164" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-606.8911477097273" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-550.8695316520844" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-438.8262995367988" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#D5E8D4;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-382.80468347915604" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-830.9776119402985" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-591" y="-774.9559958826557" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-35" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-1" target="lZdwYr-LXM3OhQDUA7XR-33" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-621" y="-604.0900669068451" as="sourcePoint" />
+            <mxPoint x="-621" y="-712.9320638188369" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-36" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-2" target="lZdwYr-LXM3OhQDUA7XR-34" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-681" y="-736.9413278435409" as="sourcePoint" />
+            <mxPoint x="-601" y="-720.9351518270715" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-37" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-5" target="lZdwYr-LXM3OhQDUA7XR-29" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-701" y="-584.8826556870819" as="sourcePoint" />
+            <mxPoint x="-542" y="-630.5002573340196" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-38" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-6" target="lZdwYr-LXM3OhQDUA7XR-30" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-671" y="-672.9166237776634" as="sourcePoint" />
+            <mxPoint x="-552" y="-672.9166237776634" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-39" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-7" target="lZdwYr-LXM3OhQDUA7XR-28" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-561" y="-673.7169325784869" as="sourcePoint" />
+            <mxPoint x="-442" y="-673.7169325784869" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-40" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-8" target="lZdwYr-LXM3OhQDUA7XR-31" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-671" y="-384.80545548121466" as="sourcePoint" />
+            <mxPoint x="-552" y="-384.80545548121466" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-41" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-9" target="lZdwYr-LXM3OhQDUA7XR-32" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-691" y="-336.7869274318065" as="sourcePoint" />
+            <mxPoint x="-572" y="-336.7869274318065" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=#d5e8d4;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-231" y="-752.1471950591869" width="218" height="39.215131240349976" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-43" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-42" target="lZdwYr-LXM3OhQDUA7XR-33" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-241" y="-484.44390118373656" as="sourcePoint" />
+            <mxPoint x="-70" y="-584.4825012866701" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-211" y="-816.9722079258878" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="usrDyYZYH79wCYu34c_K-6" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1598" y="-62" width="1621" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-45" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="usrDyYZYH79wCYu34c_K-6" vertex="1">
+          <mxGeometry width="1595" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="usrDyYZYH79wCYu34c_K-5" value="" style="group" vertex="1" connectable="0" parent="usrDyYZYH79wCYu34c_K-6">
+          <mxGeometry x="7" y="2.5" width="1614" height="49.5" as="geometry" />
+        </mxCell>
+        <mxCell id="usrDyYZYH79wCYu34c_K-1" value="" style="group" vertex="1" connectable="0" parent="usrDyYZYH79wCYu34c_K-5">
+          <mxGeometry x="718" y="4.75" width="163.39999999999998" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="" id="usrDyYZYH79wCYu34c_K-2">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=#dae8fc;strokeWidth=2;" vertex="1" parent="usrDyYZYH79wCYu34c_K-1">
+            <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="usrDyYZYH79wCYu34c_K-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" vertex="1" parent="usrDyYZYH79wCYu34c_K-1">
+          <mxGeometry x="13" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="OI71fulDIgHqbVsoXd_f-4" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="1424" y="4.75" width="190" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="OI71fulDIgHqbVsoXd_f-1" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" parent="OI71fulDIgHqbVsoXd_f-4" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="84" y="26.5" as="sourcePoint" />
+            <mxPoint x="157" y="26.72" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="OI71fulDIgHqbVsoXd_f-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" parent="OI71fulDIgHqbVsoXd_f-4" vertex="1">
+          <mxGeometry width="70" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-47" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry y="6.1875" width="160" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-48" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#d5e8d4;strokeColor=#82b366;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-47" vertex="1">
+          <mxGeometry x="60" y="4.95" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-49" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-47" vertex="1">
+          <mxGeometry width="50" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-50" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="175" y="6.1875" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-51" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFf2cc;strokeColor=#330000;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
+          <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-52" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
+          <mxGeometry width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-56" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="894" y="6.1875" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-57" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-56" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="87" y="17.94375" as="sourcePoint" />
+            <mxPoint x="167" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-58" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-56" vertex="1">
+          <mxGeometry x="-5" width="80" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-59" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="1091" y="6.1875" width="136" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-60" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=5 2 2 2;" parent="lZdwYr-LXM3OhQDUA7XR-59" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="74" y="18.5625" as="sourcePoint" />
+            <mxPoint x="154" y="18.5625" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="130" y="18.5625" />
+              <mxPoint x="130" y="18.5625" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-61" value="Domain&lt;br&gt;of" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-59" vertex="1">
+          <mxGeometry y="-5" width="60" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-62" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="1259" y="6.1875" width="160" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-63" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-62" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="67" y="18.5625" as="sourcePoint" />
+            <mxPoint x="147" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-64" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-62" vertex="1">
+          <mxGeometry width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-65" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="360" y="3.09375" width="160" height="43.3125" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-66" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#D5E8D4;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
+          <mxGeometry x="65" y="4.95" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-67" value="Reserved&lt;br&gt;class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
+          <mxGeometry x="-10" y="1.8125" width="70" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-71" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
+          <mxGeometry x="532" width="176" height="49.5" as="geometry" />
+        </mxCell>
+        <mxCell id="lZdwYr-LXM3OhQDUA7XR-55" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
+          <mxGeometry y="7" width="70" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="" link="https://w3.org/2018/credentials/#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#FFF2CC;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
+            <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#bd0000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://w3.org/2018/credentials/#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=#fff2cc;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="-207.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="usrDyYZYH79wCYu34c_K-8" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" target="usrDyYZYH79wCYu34c_K-7">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-120" y="-710" as="sourcePoint" />
+            <mxPoint x="-90" y="-310" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;font color=&quot;#bd0000&quot;&gt;rdf:JSON&lt;/font&gt;" link="https://w3id.org/security/#cryptosuiteString" id="usrDyYZYH79wCYu34c_K-9">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=#dae8fc;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="-195.99999999999994" y="-545.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="usrDyYZYH79wCYu34c_K-10" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="usrDyYZYH79wCYu34c_K-7" target="usrDyYZYH79wCYu34c_K-9">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-310" y="-389.8028821410189" as="sourcePoint" />
+            <mxPoint x="-191" y="-389.8028821410189" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1662 923">
-    <a xlink:href="https://www.w3.org/2018/credentials/#verifiableCredential">
+    <a xlink:href="https://www.w3.org/2018/credentials#verifiableCredential">
         <rect width="171" height="27.21" x="167" y="525.19" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -18,7 +18,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="253" y="544" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#VerifiableCredential">
+    <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredential">
         <ellipse cx="446" cy="40.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -37,7 +37,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="446" y="45" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredential</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#JsonSchemaCredential">
+    <a xlink:href="https://www.w3.org/2018/credentials#JsonSchemaCredential">
         <ellipse cx="166" cy="160.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -56,7 +56,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="166" y="165" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchemaCredential</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#VerifiablePresentation">
+    <a xlink:href="https://www.w3.org/2018/credentials#VerifiablePresentation">
         <ellipse cx="442" cy="778.89" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -81,7 +81,7 @@
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m252.5 358.57 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-80.19-216.75" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.57 554.64 5.32 9.84-5.08-2.34-4.92 2.65Z" pointer-events="all"/>
-    <a xlink:href="https://www.w3.org/2018/credentials/#VerifiableCredentialGraph">
+    <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredentialGraph">
         <ellipse cx="252.5" cy="336.72" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -102,7 +102,7 @@
     </a>
     <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 317.11 363.81 63.17" pointer-events="stroke"/>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m366.82 56.3-.96 10.5-2.05-3.63-4.05.95Z" pointer-events="all"/>
-    <a xlink:href="https://www.w3.org/2018/credentials/#credentialSchema">
+    <a xlink:href="https://www.w3.org/2018/credentials#credentialSchema">
         <rect width="171" height="27.21" x="737" y="85.02" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -121,7 +121,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSchema</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#credentialStatus">
+    <a xlink:href="https://www.w3.org/2018/credentials#credentialStatus">
         <rect width="171" height="27.21" x="737" y="142" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -140,7 +140,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#credentialSubject">
+    <a xlink:href="https://www.w3.org/2018/credentials#credentialSubject">
         <rect width="171" height="27.21" x="737" y="198" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -159,7 +159,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="216" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#issuer">
+    <a xlink:href="https://www.w3.org/2018/credentials#issuer">
         <rect width="171" height="27.21" x="737" y="255" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -178,7 +178,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="273" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#evidence">
+    <a xlink:href="https://www.w3.org/2018/credentials#evidence">
         <rect width="171" height="27.21" x="737" y="368" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -197,7 +197,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#refreshService">
+    <a xlink:href="https://www.w3.org/2018/credentials#refreshService">
         <rect width="171" height="27.21" x="737" y="424" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -216,7 +216,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="442" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#renderMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials#renderMethod">
         <rect width="171" height="27.21" x="737" y="481" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -235,7 +235,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#confidenceMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials#confidenceMethod">
         <rect width="171" height="27.21" x="737" y="538" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -254,7 +254,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="556" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#termsOfUse">
+    <a xlink:href="https://www.w3.org/2018/credentials#termsOfUse">
         <rect width="171" height="27.21" x="737" y="594" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -273,7 +273,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="612" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#validFrom">
+    <a xlink:href="https://www.w3.org/2018/credentials#validFrom">
         <rect width="171" height="27.21" x="737" y="651" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -292,7 +292,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="669" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#validUntil">
+    <a xlink:href="https://www.w3.org/2018/credentials#validUntil">
         <rect width="171" height="27.21" x="737" y="707.24" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -311,7 +311,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="726" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#holder">
+    <a xlink:href="https://www.w3.org/2018/credentials#holder">
         <rect width="171" height="27.21" x="737" y="765.29" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -359,7 +359,7 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 607.67-9.86 5.26 2.37-5.06-2.64-4.93Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q81 48 170.32 57.79" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.78 720.6-10.49 3.88 3.03-4.69-1.94-5.25Z" pointer-events="all"/>
-    <a xlink:href="https://www.w3.org/2018/credentials/#RenderMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials#RenderMethod">
         <ellipse cx="1136" cy="495.76" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -378,7 +378,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="501" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#CredentialEvidence">
+    <a xlink:href="https://www.w3.org/2018/credentials#CredentialEvidence">
         <ellipse cx="1136" cy="382.72" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -397,7 +397,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="388" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#RefreshService">
+    <a xlink:href="https://www.w3.org/2018/credentials#RefreshService">
         <ellipse cx="1136" cy="438.74" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -416,7 +416,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="444" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#ConfidenceMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials#ConfidenceMethod">
         <ellipse cx="1136" cy="551.78" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -435,7 +435,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#TermsOfUse">
+    <a xlink:href="https://www.w3.org/2018/credentials#TermsOfUse">
         <ellipse cx="1136" cy="607.8" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -454,7 +454,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#CredentialSchema">
+    <a xlink:href="https://www.w3.org/2018/credentials#CredentialSchema">
         <ellipse cx="1136" cy="98.63" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -473,7 +473,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialSchema</text>
         </switch>
     </a>
-    <a xlink:href="https://www.w3.org/2018/credentials/#CredentialStatus">
+    <a xlink:href="https://www.w3.org/2018/credentials#CredentialStatus">
         <ellipse cx="1136" cy="154.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -506,7 +506,7 @@
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 551.78-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 607.61 109.26.18" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 607.8-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
-    <a xlink:href="https://www.w3.org/2018/credentials/#JsonSchema">
+    <a xlink:href="https://www.w3.org/2018/credentials#JsonSchema">
         <ellipse cx="1496" cy="177.46" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -663,7 +663,7 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="594" y="881" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
     </switch>
-    <a xlink:href="https://www.w3.org/2018/credentials/#evidence">
+    <a xlink:href="https://www.w3.org/2018/credentials#evidence">
         <rect width="91.25" height="24.75" x="640.75" y="864.73" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
     </a>
     <ellipse cx="137" cy="875.64" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
@@ -680,7 +680,7 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="52" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
     </switch>
-    <a xlink:href="https://www.w3.org/2018/credentials/#credentialSubject">
+    <a xlink:href="https://www.w3.org/2018/credentials#credentialSubject">
         <rect width="171" height="27.21" x="1410.5" y="270" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -718,7 +718,7 @@
     </switch>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
-    <a xlink:href="https://www.w3.org/2018/credentials/#relatedResource">
+    <a xlink:href="https://www.w3.org/2018/credentials#relatedResource">
         <rect width="171" height="27.21" x="737" y="311" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -739,7 +739,7 @@
     </a>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 178.86 281.83 261.12" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.89 323.85-11.09 1.36 4.03-3.87-.68-5.55Z" pointer-events="all"/>
-    <a xlink:href="https://www.w3.org/2018/credentials/#digestSRI">
+    <a xlink:href="https://www.w3.org/2018/credentials#digestSRI">
         <rect width="171" height="27.21" x="1410.5" y="481" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1662 923">
-    <a xlink:href="https://w3.org/2018/credentials/#verifiableCredential">
+    <a xlink:href="https://www.w3.org/2018/credentials/#verifiableCredential">
         <rect width="171" height="27.21" x="167" y="525.19" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -18,7 +18,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="253" y="544" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredential">
+    <a xlink:href="https://www.w3.org/2018/credentials/#VerifiableCredential">
         <ellipse cx="446" cy="40.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -37,7 +37,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="446" y="45" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredential</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#JsonSchemaCredential">
+    <a xlink:href="https://www.w3.org/2018/credentials/#JsonSchemaCredential">
         <ellipse cx="166" cy="160.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -56,7 +56,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="166" y="165" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchemaCredential</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#VerifiablePresentation">
+    <a xlink:href="https://www.w3.org/2018/credentials/#VerifiablePresentation">
         <ellipse cx="442" cy="778.89" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -81,7 +81,7 @@
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m252.5 358.57 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-80.19-216.75" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.57 554.64 5.32 9.84-5.08-2.34-4.92 2.65Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredentialGraph">
+    <a xlink:href="https://www.w3.org/2018/credentials/#VerifiableCredentialGraph">
         <ellipse cx="252.5" cy="336.72" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -102,7 +102,7 @@
     </a>
     <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 317.11 363.81 63.17" pointer-events="stroke"/>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m366.82 56.3-.96 10.5-2.05-3.63-4.05.95Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#credentialSchema">
+    <a xlink:href="https://www.w3.org/2018/credentials/#credentialSchema">
         <rect width="171" height="27.21" x="737" y="85.02" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -121,7 +121,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSchema</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#credentialStatus">
+    <a xlink:href="https://www.w3.org/2018/credentials/#credentialStatus">
         <rect width="171" height="27.21" x="737" y="142" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -140,7 +140,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#credentialSubject">
+    <a xlink:href="https://www.w3.org/2018/credentials/#credentialSubject">
         <rect width="171" height="27.21" x="737" y="198" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -159,7 +159,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="216" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#issuer">
+    <a xlink:href="https://www.w3.org/2018/credentials/#issuer">
         <rect width="171" height="27.21" x="737" y="255" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -178,7 +178,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="273" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#evidence">
+    <a xlink:href="https://www.w3.org/2018/credentials/#evidence">
         <rect width="171" height="27.21" x="737" y="368" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -197,7 +197,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#refreshService">
+    <a xlink:href="https://www.w3.org/2018/credentials/#refreshService">
         <rect width="171" height="27.21" x="737" y="424" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -216,7 +216,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="442" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#renderMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials/#renderMethod">
         <rect width="171" height="27.21" x="737" y="481" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -235,7 +235,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#confidenceMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials/#confidenceMethod">
         <rect width="171" height="27.21" x="737" y="538" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -254,7 +254,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="556" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#termsOfUse">
+    <a xlink:href="https://www.w3.org/2018/credentials/#termsOfUse">
         <rect width="171" height="27.21" x="737" y="594" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -273,7 +273,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="612" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#validFrom">
+    <a xlink:href="https://www.w3.org/2018/credentials/#validFrom">
         <rect width="171" height="27.21" x="737" y="651" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -292,7 +292,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="669" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#validUntil">
+    <a xlink:href="https://www.w3.org/2018/credentials/#validUntil">
         <rect width="171" height="27.21" x="737" y="707.24" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -311,7 +311,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="823" y="726" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#holder">
+    <a xlink:href="https://www.w3.org/2018/credentials/#holder">
         <rect width="171" height="27.21" x="737" y="765.29" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -359,7 +359,7 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 607.67-9.86 5.26 2.37-5.06-2.64-4.93Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q81 48 170.32 57.79" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.78 720.6-10.49 3.88 3.03-4.69-1.94-5.25Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#RenderMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials/#RenderMethod">
         <ellipse cx="1136" cy="495.76" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -378,7 +378,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="501" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#CredentialEvidence">
+    <a xlink:href="https://www.w3.org/2018/credentials/#CredentialEvidence">
         <ellipse cx="1136" cy="382.72" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -397,7 +397,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="388" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#RefreshService">
+    <a xlink:href="https://www.w3.org/2018/credentials/#RefreshService">
         <ellipse cx="1136" cy="438.74" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -416,7 +416,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="444" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#ConfidenceMethod">
+    <a xlink:href="https://www.w3.org/2018/credentials/#ConfidenceMethod">
         <ellipse cx="1136" cy="551.78" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -435,7 +435,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#TermsOfUse">
+    <a xlink:href="https://www.w3.org/2018/credentials/#TermsOfUse">
         <ellipse cx="1136" cy="607.8" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -454,7 +454,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#CredentialSchema">
+    <a xlink:href="https://www.w3.org/2018/credentials/#CredentialSchema">
         <ellipse cx="1136" cy="98.63" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -473,7 +473,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1136" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialSchema</text>
         </switch>
     </a>
-    <a xlink:href="https://w3.org/2018/credentials/#CredentialStatus">
+    <a xlink:href="https://www.w3.org/2018/credentials/#CredentialStatus">
         <ellipse cx="1136" cy="154.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -506,7 +506,7 @@
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 551.78-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 607.61 109.26.18" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 607.8-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#JsonSchema">
+    <a xlink:href="https://www.w3.org/2018/credentials/#JsonSchema">
         <ellipse cx="1496" cy="177.46" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -663,7 +663,7 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="594" y="881" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
     </switch>
-    <a xlink:href="https://w3.org/2018/credentials/#evidence">
+    <a xlink:href="https://www.w3.org/2018/credentials/#evidence">
         <rect width="91.25" height="24.75" x="640.75" y="864.73" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
     </a>
     <ellipse cx="137" cy="875.64" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
@@ -680,7 +680,7 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="52" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
     </switch>
-    <a xlink:href="https://w3.org/2018/credentials/#credentialSubject">
+    <a xlink:href="https://www.w3.org/2018/credentials/#credentialSubject">
         <rect width="171" height="27.21" x="1410.5" y="270" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -718,7 +718,7 @@
     </switch>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#relatedResource">
+    <a xlink:href="https://www.w3.org/2018/credentials/#relatedResource">
         <rect width="171" height="27.21" x="737" y="311" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -739,7 +739,7 @@
     </a>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 178.86 281.83 261.12" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.89 323.85-11.09 1.36 4.03-3.87-.68-5.55Z" pointer-events="all"/>
-    <a xlink:href="https://w3.org/2018/credentials/#digestSRI">
+    <a xlink:href="https://www.w3.org/2018/credentials/#digestSRI">
         <rect width="171" height="27.21" x="1410.5" y="481" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -1,13 +1,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1662 923">
     <a xlink:href="https://w3.org/2018/credentials/#verifiableCredential">
-        <rect width="171" height="27.21" x="167" y="525.19" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="167" y="525.19" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:539px;margin-left:168px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     verifiableCredential
                                 </font>
                             </i>
@@ -19,14 +19,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredential">
-        <ellipse cx="446" cy="40.61" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="446" cy="40.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:41px;margin-left:338px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     VerifiableCredential
                                 </font>
                             </i>
@@ -38,14 +38,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#JsonSchemaCredential">
-        <ellipse cx="166" cy="160.65" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="166" cy="160.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:161px;margin-left:58px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     JsonSchemaCredential
                                 </font>
                             </i>
@@ -57,14 +57,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#VerifiablePresentation">
-        <ellipse cx="442" cy="778.89" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="442" cy="778.89" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:779px;margin-left:334px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     VerifiablePresentation
                                 </font>
                             </i>
@@ -82,14 +82,14 @@
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-80.19-216.75" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.57 554.64 5.32 9.84-5.08-2.34-4.92 2.65Z" pointer-events="all"/>
     <a xlink:href="https://w3.org/2018/credentials/#VerifiableCredentialGraph">
-        <ellipse cx="252.5" cy="336.72" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="252.5" cy="336.72" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:337px;margin-left:145px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     VerifiableCredentialGraph
                                 </font>
                             </i>
@@ -103,14 +103,14 @@
     <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 317.11 363.81 63.17" pointer-events="stroke"/>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m366.82 56.3-.96 10.5-2.05-3.63-4.05.95Z" pointer-events="all"/>
     <a xlink:href="https://w3.org/2018/credentials/#credentialSchema">
-        <rect width="171" height="27.21" x="737" y="85.02" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="85.02" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:99px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     credentialSchema
                                 </font>
                             </i>
@@ -122,14 +122,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#credentialStatus">
-        <rect width="171" height="27.21" x="737" y="141.05" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="142" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:155px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:156px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     credentialStatus
                                 </font>
                             </i>
@@ -137,18 +137,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="159" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#credentialSubject">
-        <rect width="171" height="27.21" x="737" y="197.07" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="198" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:211px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:212px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     credentialSubject
                                 </font>
                             </i>
@@ -156,18 +156,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="215" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="216" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#issuer">
-        <rect width="171" height="27.21" x="737" y="253.09" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="255" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:267px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:269px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     issuer
                                 </font>
                             </i>
@@ -175,18 +175,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="271" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="273" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#evidence">
-        <rect width="171" height="27.21" x="737" y="309.11" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="368" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:323px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:382px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     evidence
                                 </font>
                             </i>
@@ -194,18 +194,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="328" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#refreshService">
-        <rect width="171" height="27.21" x="737" y="365.13" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="424" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:379px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:438px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     refreshService
                                 </font>
                             </i>
@@ -213,18 +213,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="442" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#renderMethod">
-        <rect width="171" height="27.21" x="737" y="421.15" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="481" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:435px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:495px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     renderMethod
                                 </font>
                             </i>
@@ -232,18 +232,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="440" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#confidenceMethod">
-        <rect width="171" height="27.21" x="737" y="477.18" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="538" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:491px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:552px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     confidenceMethod
                                 </font>
                             </i>
@@ -251,18 +251,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="496" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="556" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#termsOfUse">
-        <rect width="171" height="27.21" x="737" y="533.2" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="594" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:547px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:608px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     termsOfUse
                                 </font>
                             </i>
@@ -270,18 +270,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="552" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="612" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#validFrom">
-        <rect width="171" height="27.21" x="737" y="589.22" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="651" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:603px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:665px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     validFrom
                                 </font>
                             </i>
@@ -289,18 +289,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="608" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="669" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#validUntil">
-        <rect width="171" height="27.21" x="737" y="645.24" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="707.24" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:659px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:721px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     validUntil
                                 </font>
                             </i>
@@ -308,18 +308,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="664" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="726" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#holder">
-        <rect width="171" height="27.21" x="737" y="765.29" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="765.29" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:779px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     holder
                                 </font>
                             </i>
@@ -334,40 +334,40 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 778.89-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 98.66Q628 99 567.5 100.02 507 101.03 446 60.22" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 98.64-9.98 5.03 2.48-5.01-2.51-4.99Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 154.77Q471 157.85 446 60.22" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 154.68-9.93 5.12 2.43-5.03-2.56-4.97Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 144.85 281.27 150.23" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 210.62-10.11 4.77 2.62-4.94-2.39-5.06Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q41 168.86 281.37 205.03" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 266.36-10.63 3.46 3.21-4.57-1.73-5.32Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q21 192.87 281.57 260.07" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.83 322.16-10.93 2.34 3.67-4.21-1.17-5.47Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q11 224.88 281.77 315.43" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.88 378.03-11.07 1.57 3.96-3.95-.79-5.53Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-9 256.89 281.94 370.99" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.92 433.94-11.14 1.01 4.16-3.74-.51-5.57Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-29 256.89 282.44 425.92" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.03 489.71-11.17-.37 4.58-3.2.19-5.59Z" pointer-events="all"/>
-    <circle cx="552" cy="603" r="5" fill="#c00" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M442 759.28Q478 650 543.53 612.81" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m550.06 609.1-6.23 9.29-.3-5.58-4.64-3.12Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22Q408 350 547.11 589.58" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m550.88 596.07-9.35-6.14 5.58-.35 3.07-4.67Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m557 603 170.26-.17" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 602.83-9.99 5.01 2.49-5.01-2.5-4.99Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 603q91-43 170.37-54.77" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 547.13-9.16 6.41 1.74-5.31-3.21-4.58Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 603q81 47 170.3 54.98" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.77 658.65-10.4 4.09 2.93-4.76-2.04-5.2Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 155.69Q471 157.85 446 60.22" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 155.62-9.95 5.09 2.45-5.02-2.54-4.98Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 144.85 281.27 151.12" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 211.54-10.13 4.73 2.64-4.93-2.37-5.07Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q41 168.86 281.38 206.86" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 268.26-10.66 3.37 3.25-4.55-1.69-5.32Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q21 192.87 282.21 317.2" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.98 380.64-11.18.22 4.41-3.44-.11-5.59Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q11 224.88 282.45 372.73" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.04 436.54-11.18-.4 4.59-3.19.2-5.59Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-9 256.89 282.62 429.43" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.08 493.47-11.16-.79 4.7-3.03.4-5.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-29 256.89 283.15 485.63" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.2 550.28-11.03-1.87 4.98-2.56.94-5.51Z" pointer-events="all"/>
+    <circle cx="552" cy="662" r="5" fill="#c00" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M442 759.28q46-69.28 100.84-88.99" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m549.9 667.76-7.72 8.08.66-5.55-4.05-3.86Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22Q408 350 547.87 648.19" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m551.05 654.98-8.77-6.93 5.59.14 3.46-4.39Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m557 662 170.27 2.46" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 664.57-10.07 4.86 2.58-4.97-2.43-5.03Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q91-52 170.27-54.13" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 607.67-9.86 5.26 2.37-5.06-2.64-4.93Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q81 48 170.32 57.79" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.78 720.6-10.49 3.88 3.03-4.69-1.94-5.25Z" pointer-events="all"/>
     <a xlink:href="https://w3.org/2018/credentials/#RenderMethod">
-        <ellipse cx="1136" cy="434.76" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="495.76" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:435px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:496px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     RenderMethod
                                 </font>
                             </i>
@@ -375,18 +375,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="440" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="501" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#CredentialEvidence">
-        <ellipse cx="1136" cy="322.72" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="382.72" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:323px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:383px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     CredentialEvidence
                                 </font>
                             </i>
@@ -394,18 +394,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="328" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="388" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#RefreshService">
-        <ellipse cx="1136" cy="378.74" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="438.74" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:379px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:439px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     RefreshService
                                 </font>
                             </i>
@@ -413,18 +413,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="444" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#ConfidenceMethod">
-        <ellipse cx="1136" cy="490.78" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="551.78" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:491px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:552px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     ConfidenceMethod
                                 </font>
                             </i>
@@ -432,18 +432,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="496" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#TermsOfUse">
-        <ellipse cx="1136" cy="546.8" fill="#d5e8d4" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="607.8" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:547px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:608px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     TermsOfUse
                                 </font>
                             </i>
@@ -451,18 +451,18 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="552" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#CredentialSchema">
-        <ellipse cx="1136" cy="98.63" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="98.63" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:99px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     CredentialSchema
                                 </font>
                             </i>
@@ -474,14 +474,14 @@
         </switch>
     </a>
     <a xlink:href="https://w3.org/2018/credentials/#CredentialStatus">
-        <ellipse cx="1136" cy="154.65" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="154.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:155px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     CredentialStatus
                                 </font>
                             </i>
@@ -494,27 +494,27 @@
     </a>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 98.63h109.26" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 98.63-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 154.65h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 154.65-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 322.72h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 322.72-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 378.74h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 378.74-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 434.76h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 434.76-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 490.78h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 490.78-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 546.8h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 546.8-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 155.61 109.26-.88" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 154.67-9.96 5.08 2.46-5.02-2.54-4.98Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 381.61 109.26 1.02" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 382.7-10.04 4.9 2.54-4.97-2.45-5.03Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 437.61 109.26 1.04" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 438.72-10.04 4.9 2.54-4.97-2.45-5.03Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 494.61 109.26 1.06" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 495.74-10.04 4.9 2.54-4.97-2.45-5.03Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 551.61 109.26.16" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 551.78-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 607.61 109.26.18" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 607.8-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
     <a xlink:href="https://w3.org/2018/credentials/#JsonSchema">
-        <ellipse cx="1496" cy="177.46" fill="#d5e8d4" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1496" cy="177.46" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:177px;margin-left:1388px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     JsonSchema
                                 </font>
                             </i>
@@ -528,16 +528,16 @@
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1496 157.85q-89-64.82-241.27-59.56" pointer-events="stroke"/>
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1247.23 98.55 9.83-5.34-2.33 5.08 2.67 4.91Z" pointer-events="all"/>
     <rect width="1621" height="54.5" x="20" y="848" fill="none"/>
-    <rect width="1595" height="54.5" x="20" y="848" fill="none" stroke="#000" stroke-dasharray="3 3"/>
+    <rect width="1595" height="54.5" x="20" y="848" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
     <rect width="1614" height="49.5" x="27" y="850.5" fill="none"/>
     <rect width="163.4" height="40" x="745" y="855.25" fill="none"/>
-    <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M840 866.75h48.4l20 8.5-20 8.5H840l-20-8.5Z"/>
-    <rect width="90" height="40" x="758" y="855.25" fill="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M840 866.75h48.4l20 8.5-20 8.5H840l-20-8.5Z" pointer-events="all"/>
+    <rect width="90" height="40" x="758" y="855.25" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:862px;margin-left:760px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
                             Datatype
                         </span>
@@ -548,14 +548,14 @@
         <text xmlns="http://www.w3.org/2000/svg" x="760" y="878" font-family="Helvetica" font-size="16">Datatype</text>
     </switch>
     <rect width="190" height="40" x="1451" y="855.25" fill="none"/>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1535 881.75 63.26.19"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1605.76 881.96-10.01 4.97 2.51-4.99-2.48-5.01Z"/>
-    <rect width="70" height="40" x="1451" y="855.25" fill="none"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1535 881.75 63.26.19" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1605.76 881.96-10.01 4.97 2.51-4.99-2.48-5.01Z" pointer-events="all"/>
+    <rect width="70" height="40" x="1451" y="855.25" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:862px;margin-left:1452px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
                             Graph containment
                         </span>
@@ -565,29 +565,14 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="1486" y="878" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
     </switch>
-    <rect width="160" height="37.13" x="27" y="856.69" fill="none"/>
-    <ellipse cx="137" cy="875.64" fill="#d5e8d4" stroke="#82b366" stroke-width="2" rx="50" ry="14.002"/>
-    <rect width="50" height="30" x="27" y="856.69" fill="none"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:52px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
-                        Class
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="52" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
-    </switch>
     <rect width="170" height="37.13" x="202" y="856.69" fill="none"/>
-    <rect width="80" height="23.69" x="285" y="861.64" fill="#fff2cc" stroke="#300" stroke-width="2" rx="3.55" ry="3.55"/>
-    <rect width="70" height="30" x="202" y="856.69" fill="none"/>
+    <rect width="80" height="23.69" x="285" y="861.64" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
+    <rect width="70" height="30" x="202" y="856.69" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:237px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Property
                     </div>
                 </div>
@@ -596,14 +581,14 @@
         <text xmlns="http://www.w3.org/2000/svg" x="237" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
     </switch>
     <rect width="170" height="37.13" x="921" y="856.69" fill="none"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1008 874.63 71.76.56"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1085.76 875.23-8.03 3.94 2.03-3.98-1.96-4.02Z"/>
-    <rect width="80" height="30" x="916" y="856.69" fill="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1008 874.63 71.76.56" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1085.76 875.23-8.03 3.94 2.03-3.98-1.96-4.02Z" pointer-events="all"/>
+    <rect width="80" height="30" x="916" y="856.69" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:956px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Superclass
                     </div>
                 </div>
@@ -612,14 +597,14 @@
         <text xmlns="http://www.w3.org/2000/svg" x="956" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
     </switch>
     <rect width="136" height="37.13" x="1118" y="856.69" fill="none"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1192 875.25 56 .05 15.76-.03"/>
-    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1269.76 875.25-7.99 4.02 1.99-4-2-4Z"/>
-    <rect width="60" height="40" x="1118" y="851.69" fill="none"/>
+    <path fill="none" stroke="#f33" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1192 875.25 56 .05 15.76-.03" pointer-events="stroke"/>
+    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1269.76 875.25-7.99 4.02 1.99-4-2-4Z" pointer-events="all"/>
+    <rect width="60" height="40" x="1118" y="851.69" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1148px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Domain
                         <br/>
                         of
@@ -630,14 +615,14 @@
         <text xmlns="http://www.w3.org/2000/svg" x="1148" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Domain...</text>
     </switch>
     <rect width="160" height="37.13" x="1286" y="856.69" fill="none"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1353 875.25h71.76"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1430.76 875.25-8 4 2-4-2-4Z"/>
-    <rect width="60" height="30" x="1286" y="856.69" fill="none"/>
+    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1353 875.25h71.76" pointer-events="stroke"/>
+    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1430.76 875.25-8 4 2-4-2-4Z" pointer-events="all"/>
+    <rect width="60" height="30" x="1286" y="856.69" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1316px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Range
                     </div>
                 </div>
@@ -646,13 +631,13 @@
         <text xmlns="http://www.w3.org/2000/svg" x="1316" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
     </switch>
     <rect width="160" height="43.31" x="387" y="853.59" fill="none"/>
-    <ellipse cx="502" cy="872.55" fill="#d5e8d4" stroke="#82b366" stroke-dasharray="2 4" stroke-width="2" rx="50" ry="14.002"/>
-    <rect width="70" height="40" x="377" y="855.41" fill="none"/>
+    <ellipse cx="502" cy="872.55" fill="none" stroke="#82b366" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="70" height="40" x="377" y="855.41" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:875px;margin-left:412px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Reserved
                         <br/>
                         class
@@ -663,12 +648,12 @@
         <text xmlns="http://www.w3.org/2000/svg" x="412" y="879" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
     </switch>
     <rect width="176" height="49.5" x="559" y="850.5" fill="none"/>
-    <rect width="70" height="40" x="559" y="857.5" fill="none"/>
+    <rect width="70" height="40" x="559" y="857.5" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:878px;margin-left:594px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:nowrap">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
                         Reserved
                         <br/>
                         property
@@ -679,17 +664,31 @@
         <text xmlns="http://www.w3.org/2000/svg" x="594" y="881" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
     </switch>
     <a xlink:href="https://w3.org/2018/credentials/#evidence">
-        <rect width="91.25" height="24.75" x="640.75" y="864.73" fill="#fff2cc" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
+        <rect width="91.25" height="24.75" x="640.75" y="864.73" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
     </a>
+    <ellipse cx="137" cy="875.64" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="50" height="30" x="27" y="856.69" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Class
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
+    </switch>
     <a xlink:href="https://w3.org/2018/credentials/#credentialSubject">
-        <rect width="171" height="27.21" x="1410.5" y="270" fill="#fff2cc" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="1410.5" y="270" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:284px;margin-left:1412px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
-                                <font color="#bd0000">
+                                <font color="#000">
                                     jsonSchema
                                 </font>
                             </i>
@@ -700,25 +699,82 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1496" y="288" font-family="Helvetica" font-size="16" text-anchor="middle">jsonSchema</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1498 200-1.72 60.27"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1496.06 267.76-4.71-10.14 4.93 2.65 5.07-2.36Z"/>
-    <a xlink:href="https://w3id.org/security/#cryptosuiteString">
-        <path fill="#dae8fc" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 365h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1498 200-1.72 60.27" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1496.06 267.76-4.71-10.14 4.93 2.65 5.07-2.36Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 365h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:379px;margin-left:1423px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font color="#000">
+                            rdf:JSON
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1497" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
+    </switch>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
+    <a xlink:href="https://w3.org/2018/credentials/#relatedResource">
+        <rect width="171" height="27.21" x="737" y="311" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:379px;margin-left:1423px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:325px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:none;white-space:normal;overflow-wrap:normal">
-                            <font color="#bd0000">
-                                rdf:JSON
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    relatedResource
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="329" font-family="Helvetica" font-size="16" text-anchor="middle">relatedResource</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 178.86 281.83 261.12" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.89 323.85-11.09 1.36 4.03-3.87-.68-5.55Z" pointer-events="all"/>
+    <a xlink:href="https://w3.org/2018/credentials/#digestSRI">
+        <rect width="171" height="27.21" x="1410.5" y="481" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:495px;margin-left:1412px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    digestSRI
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="1496" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">digestSRI</text>
+        </switch>
+    </a>
+    <a xlink:href="https://w3id.org/security/#sriString">
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 576h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:590px;margin-left:1423px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <font color="#000">
+                                sriString
                             </font>
                         </div>
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1497" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1497" y="595" font-family="Helvetica" font-size="16" text-anchor="middle">sriString</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 508.21.59 58.05" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 573.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
 </svg>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -1,6 +1,6 @@
 vocab:
   - id: cred
-    value: https://w3.org/2018/credentials#
+    value: https://www.w3.org/2018/credentials#
 
 # prefix:
 #   - id: odrl

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -99,6 +99,14 @@ property:
     range: IRI
     comment: An entity about which claims are made.
 
+  - id: digestSRI
+    label: Subresource integrity digest
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-digestSRI
+    range: cred:sristring
+    see_also: 
+      - label: Subresource Integrity Metadata
+      - url:  https://www.w3.org/TR/SRI/#integrity-metadata
+    
   - id: evidence
     label: Evidence
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-evidence
@@ -153,6 +161,11 @@ property:
     status: reserved
     range: cred:RenderMethod
 
+  - id: relatedResource
+    label: Related resource
+    domain: cred:VerifiableCredential
+    defined_by: https://w3c-ccg.github.io/vc-render-method/#defn-relatedResource
+
   - id: termsOfUse
     label: Terms of use
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-termsOfUse
@@ -178,3 +191,13 @@ property:
     domain: cred:VerifiablePresentation
     range: cred:VerifiableCredentialGraph
     comment: The value of this property identifies a <a href="#VerifiableCredentialGraph">Verifiable credential graph</a>. (Informally, it indirectly identifies a <a href="#VerifiableCredential">Verifiable credential</a> contained in a separate graph.)
+
+datatype:
+  - id: sristring
+  - label: Datatype for digest SRI values
+  - upper_value: xsd:string
+  - defined_by: https://www.w3.org/TR/vc-data-model-2.0/#the-sristring-datatype
+  - see_also: 
+    - label: Subresource Integrity Metadata
+    - url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
+ 

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -165,7 +165,7 @@ property:
     label: Related resource
     domain: cred:VerifiableCredential
     range: IRI
-    defined_by: https://w3c-ccg.github.io/vc-render-method/#defn-relatedResource
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-relatedResource
 
   - id: termsOfUse
     label: Terms of use

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -102,10 +102,10 @@ property:
   - id: digestSRI
     label: Subresource integrity digest
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-digestSRI
-    range: cred:sristring
+    range: cred:sriString
     see_also: 
       - label: Subresource Integrity Metadata
-      - url:  https://www.w3.org/TR/SRI/#integrity-metadata
+        url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
     
   - id: evidence
     label: Evidence
@@ -164,6 +164,7 @@ property:
   - id: relatedResource
     label: Related resource
     domain: cred:VerifiableCredential
+    range: IRI
     defined_by: https://w3c-ccg.github.io/vc-render-method/#defn-relatedResource
 
   - id: termsOfUse
@@ -193,11 +194,11 @@ property:
     comment: The value of this property identifies a <a href="#VerifiableCredentialGraph">Verifiable credential graph</a>. (Informally, it indirectly identifies a <a href="#VerifiableCredential">Verifiable credential</a> contained in a separate graph.)
 
 datatype:
-  - id: sristring
-  - label: Datatype for digest SRI values
-  - upper_value: xsd:string
-  - defined_by: https://www.w3.org/TR/vc-data-model-2.0/#the-sristring-datatype
-  - see_also: 
-    - label: Subresource Integrity Metadata
-    - url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
+  - id: sriString
+    label: Datatype for digest SRI values
+    upper_value: xsd:string
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#the-sristring-datatype
+    see_also: 
+      - label: Subresource Integrity Metadata
+        url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
  


### PR DESCRIPTION
This is the [action I took at the F2F](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2023-09-14-vcwg#section5-1): adding the resource integrity terms to the VCDM vocabulary. Here is what I did:

- Added anchors to the `digestSRI` and `relatedResource` terms in the specification itself (to be used by the vocabulary)
- Added a section to define the `sriString` datatype
- Added the `digestSRI`, `relatedResource`, `mediaType` to the v2 `@context` file
- Added the `digestSRI` and `relatedResource` properties, as well as the `sriString` datatype, to `vocabulary.yml`
- Added a section on data types in the vocabulary’s `template.html` file for the vocabulary generation
- Expanded the diagram’s alt text to also refer to the new terms

Note that the `mediaType` term has not been added to the vocabulary; instead, it is mapped to https://schema.org/encodingFormat term. Let us avoid the "not invented here" syndrome...

Not strictly related to the underlying issue, but:

- Added the `vocabulary.drawio` file to the repository and expanded the `README.md` file in the corresponding directory (this makes the maintenance of the diagrams easier and puts the raw data into our repo)
- Updated the diagram (there were syntax errors in the links)

The automatic preview below works for the spec text, but not for the vocabulary. For the vocabulary files, see the [separate vocabulary preview](https://w3c.github.io/yml2vocab/previews/vcdm/)

This PR takes care of the issues #1237 and #1265.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1296.html" title="Last updated on Oct 16, 2023, 7:24 AM UTC (b4031ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1296/286c2b2...b4031ef.html" title="Last updated on Oct 16, 2023, 7:24 AM UTC (b4031ef)">Diff</a>