### PR TITLE
Remove CL Signature Example

### DIFF
--- a/common.js
+++ b/common.js
@@ -55,16 +55,6 @@ var vcwg = {
       status: "CG-DRAFT",
       publisher: "Credentials Community Group"
     },
-    "CL-SIGNATURES": {
-      title: "A Signature Scheme with Efficient Protocols",
-      href: "https://www.researchgate.net/publication/220922101_A_Signature_Scheme_with_Efficient_Protocols",
-      authors: [
-        "Jan Camenisch",
-        "Anna Lysyanskaya"
-      ],
-      status: "Peer Reviewed Paper",
-      publisher: "IBM Research"
-    },
     // aliases to known references
     "HTTP-SIGNATURES": {
       aliasOf: "http-signatures"

--- a/index.html
+++ b/index.html
@@ -598,9 +598,6 @@ Securing Verifiable Credentials using JOSE and COSE [[VC-JOSE-COSE]].
           <li>
 Securing Verifiable Credentials using Data Integrity Proofs [[VC-DATA-INTEGRITY]].
           </li>
-          <li>
-Camenisch-Lysyanskaya Zero-Knowledge Proofs [[?CL-SIGNATURES]].
-          </li>
         </ul>
 
         <p>
@@ -3546,68 +3543,11 @@ selective disclosure in mind, then validation is likely to fail.
 The examples below highlight how the data model might be used to issue and
 present <a>verifiable credentials</a> in zero-knowledge.
         </p>
-        <p class="note">
-The provided examples will either be significantly re-written to demonstrate how
-to secure a <a>verifiable credential</a> using a normatively defined method that
-enable zero knowledge proofs, or they will be removed.
+        <p class="issue">
+Examples of leveraging <a href="https://w3c.github.io/vc-di-bbs/">vc-di-bbs</a>,
+will be added here in the future, or this section will be removed.
         </p>
-        <p>
-The following example shows one method of using <a>verifiable credentials</a> in
-zero-knowledge. It makes use of a Camenisch-Lysyanskaya Signature
-[[?CL-SIGNATURES]], which allows the presentation of the <a>verifiable
-credential</a> in a way that supports the privacy of the
-<a>holder</a> and <a>subject</a> through the use of selective disclosure of the
-<a>verifiable credential</a> values. Some other cryptographic systems which rely
-upon zero-knowledge proofs to selectively disclose attributes can be found in the
-Verifiable Credential Specifications Directory [[?VC-SPECS]] as well.
-        </p>
-
-        <pre class="example nohighlight" title="A verifiable credential that supports CL Signatures">
-{
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
-  ],
-  "type": ["VerifiableCredential", "ExampleDegreeCredential"],
-  <span class="highlight">"credentialSchema": {
-    "id": "did:example:cdf:35LB7w9ueWbagPL94T9bMLtyXDj9pX5o",
-    "type": "did:example:schema:22KpkXgecryx9k7N6XN1QoN3gXwBkSU8SfyyYQG"
-  }</span>,
-  "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
-  "credentialSubject": {
-    "givenName": "Jane",
-    "familyName": "Doe",
-    "degree": {
-      "type": "ExampleBachelorDegree",
-      "name": "Bachelor of Science and Arts",
-      "college": "College of Engineering"
-    }
-  },
-  <span class="highlight">"proof": {
-    "type": "CLSignature2019",
-    "issuerData": "5NQ4TgzNfSQxoLzf2d5AV3JNiCdMaTgm...BXiX5UggB381QU7ZCgqWivUmy4D",
-    "attributes": "pPYmqDvwwWBDPNykXVrBtKdsJDeZUGFA...tTERiLqsZ5oxCoCSodPQaggkDJy",
-    "signature": "8eGWSiTiWtEA8WnBwX4T259STpxpRKuk...kpFnikqqSP3GMW7mVxC4chxFhVs",
-    "signatureCorrectnessProof": "SNQbW3u1QV5q89qhxA1xyVqFa6jCrKwv...dsRypyuGGK3RhhBUvH1tPEL8orH"
-  }</span>
-}
-        </pre>
-        <p>
-The example above provides the <a>verifiable credential</a> definition by using
-the <code>credentialSchema</code> <a>property</a> and a specific proof that is
-usable in the Camenisch-Lysyanskaya Zero-Knowledge Proof system.
-        </p>
-
-        <p>
-The next example utilizes the <a>verifiable credential</a> above to generate a
-new derived <a>verifiable credential</a> with a privacy-preserving proof. The
-derived <a>verifiable credential</a> is then placed in a
-<a>verifiable presentation</a>, so that the <a>verifiable credential</a>
-discloses only the <a>claims</a> and additional credential metadata that the
-<a>holder</a> intended. To do this, all of the following requirements are
-expected to be met:
-        </p>
-
+        
         <ul>
           <li>
 Each derived <a>verifiable credential</a> within a <a>verifiable
@@ -3629,41 +3569,6 @@ that the <a>holder</a> did not intend to share.
           </li>
         </ul>
 
-        <pre class="example nohighlight" title="A verifiable presentation that supports CL Signatures">
-{
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
-  ],
-  "type": "VerifiablePresentation",
-  "verifiableCredential": [
-    {
-      "@context": [
-        "https://www.w3.org/ns/credentials/v2",
-        "https://www.w3.org/ns/credentials/examples/v2"
-      ],
-      "type": ["VerifiableCredential", "ExampleDegreeCredential"],
-      <span class="highlight">"credentialSchema": {
-        "id": "did:example:cdf:35LB7w9ueWbagPL94T9bMLtyXDj9pX5o",
-        "type": "did:example:schema:22KpkXgecryx9k7N6XN1QoN3gXwBkSU8SfyyYQG"
-      }</span>,
-      "issuer": "did:example:Wz4eUg7SetGfaUVCn8U9d62oDYrUJLuUtcy619",
-      "credentialSubject": {
-        "degreeType": "ExampleBachelorDegree",
-        "degreeSchool": "College of Engineering"
-      },
-      <span class="highlight">"proof": {
-        "type": "AnonCredDerivedCredentialv1",
-        "primaryProof": "cg7wLNSi48K5qNyAVMwdYqVHSMv1Ur8i...Fg2ZvWF6zGvcSAsym2sgSk737",
-        "nonRevocationProof": "mu6fg24MfJPU1HvSXsf3ybzKARib4WxG...RSce53M6UwQCxYshCuS3d2h"
-      }</span>
-  }],
-  <span class="highlight">"proof": {
-    "type": "AnonCredPresentationProofv1",
-    "proofValue": "DgYdYMUYHURJLD7xdnWRinqWCEY5u5fK...j915Lt3hMzLHoPiPQ9sSVfRrs1D"
-  }</span>
-}
-        </pre>
         <figure>
           <img style="margin: auto; display: block; width: 75%;"
             src="diagrams/zkp-cred-pres.svg" alt="Verifiable
@@ -3699,14 +3604,6 @@ A visual example of the relationship between credentials and derived
 credentials in a ZKP <a>presentation</a>.
           </figcaption>
         </figure>
-
-        <p class="note">
-Important details regarding the format for the <a>credential</a> definition and
-of the proofs are omitted on purpose because they are outside of the scope of
-this document. The purpose of this section is to guide implementers who want to
-extend <a>verifiable credentials</a> and <a>verifiable presentations</a> to
-support zero-knowledge proof systems.
-        </p>
 
       </section>
 


### PR DESCRIPTION
This PR adds a reference to vc-di-bbs, which is expected to be the only zkp credential system commented on by the WG, and is currently stalled, awaiting new leadership. 

See: 

- https://github.com/w3c/vc-di-bbs/pull/91
- https://github.com/w3c/vc-di-bbs/issues/84

I've retained normative statements surrounding the example, but removed the examples.

Ideally, we get some bbs examples in the spec here soon, although I personally think it would be better to drop the bbs work item, and focus on improving the specification and test suites related to the existing security mechansisms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1305.html" title="Last updated on Oct 4, 2023, 10:32 PM UTC (0d7bdca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1305/286c2b2...0d7bdca.html" title="Last updated on Oct 4, 2023, 10:32 PM UTC (0d7bdca)">Diff</a>