### PR TITLE
Remove "proof" clauses from initial examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -951,22 +951,6 @@ discount from a university. In the example below, Pat receives an alumni
       <span class='comment'>// name of the university</span>
       "name": "Example University"
     }
-  },
-  <span class='comment'>// digital proof that makes the credential tamper-evident</span>
-  <span class='comment'>// see the NOTE at end of this section for more detail</span>
-  "proof": {
-    <span class='comment'>// the type of embedded proof securing the verifiable credential</span>
-    "type": "DataIntegrityProof",
-    <span class='comment'>// the name of the cryptographic signature suite</span>
-    "cryptosuite": "eddsa-2022",
-    <span class='comment'>// the date the signature was created</span>
-    "created": "2023-06-18T21:19:10Z",
-    <span class='comment'>// purpose of this proof</span>
-    "proofPurpose": "assertionMethod",
-    <span class='comment'>// the identifier of the public key that can verify the signature</span>
-    "verificationMethod": "https://university.example/issuers/565049#key-123",
-    <span class='comment'>// the digital signature value</span>
-    "proofValue": "zQeVbY4oey5q2M3XKaxup3tmzN4DRFTLVqpLMweBrSxMY2xHX5XTYV8nQ<wbr>ApmEcqaqA3Q1gVHMrXFkXJeV6doDwLWx"
   }
 }
         </pre>
@@ -1006,39 +990,17 @@ the <a>verifier</a> and <a>verified</a>.
         "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
         "name": "Example University"
       }
-    },
-    "proof": {
-      "type": "DataIntegrityProof",
-      "cryptosuite": "eddsa-2022",
-      "created": "2023-06-18T21:19:10Z",
-      "proofPurpose": "assertionMethod",
-      "verificationMethod": "https://university.example/issuers/565049#key-1",
-      "proofValue": "zQeVbY4oey5q2M3XKaxup3tmzN4DRFTLVqpLMweBrSxMY2xHX5XTYV8nQA
-        pmEcqaqA3Q1gVHMrXFkXJeV6doDwLWx"
     }
-  }],
-  <span class='comment'>// digital signature by Pat on the presentation
-  // protects against replay attacks</span>
-  "proof": {
-    "type": "DataIntegrityProof",
-    "cryptosuite": "eddsa-2022",
-    "created": "2018-09-14T21:19:10Z",
-    "proofPurpose": "authentication",
-    "verificationMethod": "did:example:ebfeb1f712ebc6f1c276e12ec21#keys-1",
-    <span class='comment'>// 'challenge' and 'domain' protect against replay attacks</span>
-    "challenge": "1f44d55f-f161-4938-a659-f8026467f126",
-    "domain": "4jt78h47fh47",
-    "proofValue": "zqpLMweBrSxMY2xHX5XTYV8nQAJeV6doDwLWxQeVbY4oey5q2pmEcqaqA3Q1
-      gVHMrXFkXM3XKaxup3tmzN4DRFTLV"
-  }
+  }]
 }
         </pre>
 
         <p class="note">
-Implementers that are interested in understanding more about the
-<code>proof</code> mechanism used above can learn more in Section <a
-href="#proofs-signatures"></a> and by reading the following specifications:
-Data Integrity [[VC-DATA-INTEGRITY]] and the "Proofs" section of the Verifiable
+The examples above are unsecured.
+Implementers that are interested in understanding more about
+securing Verifiable Credentials can see the specifications
+Securing Verifiable Credentials using JOSE and COSE [[VC-JOSE-COSE]] and
+Verifiable Credential Data Integrity [[VC-DATA-INTEGRITY]] and the "Proofs" section of the Verifiable
 Credential Specifications Directory [[VC-SPECS]].
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -924,7 +924,7 @@ discount from a university. In the example below, Pat receives an alumni
 <a>verifiable credential</a> in a digital wallet.
         </p>
 
-        <pre class="example nohighlight" title="A simple example of a verifiable credential">
+        <pre class="example nohighlight" title="A simple example of the contents of a verifiable credential">
 {
   <span class='comment'>// set the context, which establishes the special terms we will be using
   // such as 'issuer' and 'alumniOf'.</span>
@@ -967,7 +967,7 @@ The digital wallet asks Pat if they would like to provide a previously issued
 <a>verifiable presentation</a>. The <a>verifiable presentation</a> is sent to
 the <a>verifier</a> and <a>verified</a>.
         </p>
-        <pre class="example nohighlight" title="A simple example of a verifiable presentation">
+        <pre class="example nohighlight" title="A simple example of the contents of a verifiable presentation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",


### PR DESCRIPTION
This PR needs to be merged to add the vc-jose-cose examples at https://github.com/w3c/vc-jose-cose/pull/162#pullrequestreview-1662677250


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/selfissued/vc-data-model/pull/1308.html" title="Last updated on Oct 13, 2023, 6:12 PM UTC (7878d79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1308/286c2b2...selfissued:7878d79.html" title="Last updated on Oct 13, 2023, 6:12 PM UTC (7878d79)">Diff</a>