### PR TITLE
Add suggestion to use Oblivious HTTP when fetching resources.

### DIFF
--- a/common.js
+++ b/common.js
@@ -85,7 +85,7 @@ var vcwg = {
     },
     'OHTTP': {
       title: 'Oblivious HTTP ',
-      href: 'https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html',
+      href: 'https://datatracker.ietf.org/doc/html/draft-ietf-ohai-ohttp',
       authors: ['Martin Thomson', 'Christopher A. Wood'],
       status: 'Working Group Draft',
       publisher: 'IETF Oblivious HTTP Application Intermediation'

--- a/common.js
+++ b/common.js
@@ -82,6 +82,13 @@ var vcwg = {
       authors: ['Daniel Buchner', 'Brent Zundel', 'Martin Riedel', 'Kim Hamilton Duffy'],
       status: 'DIF Ratified Specification',
       publisher: 'Decentralized Identity Foundation'
+    },
+    'OHTTP': {
+      title: 'Oblivious HTTP ',
+      href: 'https://ietf-wg-ohai.github.io/oblivious-http/draft-ietf-ohai-ohttp.html',
+      authors: ['Martin Thomson', 'Christopher A. Wood'],
+      status: 'Working Group Draft',
+      publisher: 'IETF Oblivious HTTP Application Intermediation'
     }
   }
 };

--- a/index.html
+++ b/index.html
@@ -4408,13 +4408,13 @@ transmit <a>verifiable credentials</a> on behalf of a <a>holder</a>.
         </p>
 
         <p>
-One mechanism that implementers might consider utilizing when fetching external
-resources that are associated with a <a>verifiable credential</a> or a
-<a>verifiable presentation</a> is the Oblivious HTTP protocol [[?OHTTP]].
+The Oblivious HTTP protocol [[?OHTTP]] is one mechanism that implementers might
+consider using when fetching external resources that are associated with a
+<a>verifiable credential</a> or a <a>verifiable presentation</a>.
 Oblivious HTTP allows a client to make multiple requests to an origin server
-without that server being able to link those requests to the client or to
-identify the requests as having come from the same client, while placing only
-limited trust in the nodes used to forward the messages. Using Oblivious HTTP
+without that server being able to link those requests to that client or even to
+identify those requests as having come from a single client, while placing only
+limited trust in the nodes used to forward the messages. Hence, Oblivious HTTP
 is one privacy-preserving mechanism that can be used to reduce the possibility
 of device tracking and fingerprinting.
         </p>

--- a/index.html
+++ b/index.html
@@ -4385,7 +4385,7 @@ shared.
       </section>
 
       <section class="informative">
-        <h3>Device Fingerprinting</h3>
+        <h3>Device Tracking and Fingerprinting</h3>
 
         <p>
 There are mechanisms external to <a>verifiable credentials</a> that are used to
@@ -4405,6 +4405,18 @@ It is recommended that privacy-respecting systems prevent the use of these
 other tracking technologies when <a>verifiable credentials</a> are being used.
 In some cases, tracking technologies might need to be disabled on devices that
 transmit <a>verifiable credentials</a> on behalf of a <a>holder</a>.
+        </p>
+
+        <p>
+One mechanism that implementers might consider utilizing when fetching external
+resources that are associated with a <a>verifiable credential</a> or a
+<a>verifiable presentation</a> is the Oblivious HTTP protocol [[?OHTTP]].
+Oblivious HTTP allows a client to make multiple requests to an origin server
+without that server being able to link those requests to the client or to
+identify the requests as having come from the same client, while placing only
+limited trust in the nodes used to forward the messages. Using Oblivious HTTP
+is one privacy-preserving mechanism that can be used to reduce the possibility
+of device tracking and fingerprinting.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -4416,8 +4416,26 @@ without that server being able to link those requests to that client or even to
 identify those requests as having come from a single client, while placing only
 limited trust in the nodes used to forward the messages. Hence, Oblivious HTTP
 is one privacy-preserving mechanism that can be used to reduce the possibility
-of device tracking and fingerprinting.
+of device tracking and fingerprinting. Concrete examples for how Oblivious HTTP
+can benefit ecosystem participants are included below.
         </p>
+
+        <ul>
+          <li>
+A <a>holder</a> using a digital wallet can reduce the chances that they
+will be tracked by a 3rd party when accessing external links within a
+<a>verifiable credential</a> stored in their digital wallet.
+For example, a digital wallet might fetch and render linked images, or
+check the validity of a <a>verifiable credential</a> by fetching an
+externally linked revocation list.
+          </li>
+          <li>
+A <a>verifier</a> can reduce signalling to an <a>issuer</a> that the
+<a>verifier</a> has received a specific <a>verifiable credential</a>.
+For example, a <a>verifier</a> might fetch an externally linked revocation
+list while performing status checks on a <a>verifiable credential</a>.
+          </li>
+        </ul>
       </section>
 
       <section class="informative">


### PR DESCRIPTION
This PR attempts to address issue #1267 by suggesting that implementers consider Oblivious HTTP when fetching external resources. /cc @kdenhartog


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1322.html" title="Last updated on Oct 29, 2023, 11:35 PM UTC (0234a2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1322/cc5cd92...0234a2b.html" title="Last updated on Oct 29, 2023, 11:35 PM UTC (0234a2b)">Diff</a>