### PR TITLE
Align JWT/JWS fields with IETF RFCs.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -6,18 +6,9 @@
     "id": "@id",
     "type": "@type",
 
-    "kid": {
-      "@id": "https://www.iana.org/assignments/jose#kid",
-      "@type": "@id"
-    },
-    "iss": {
-      "@id": "https://www.iana.org/assignments/jose#iss",
-      "@type": "@id"
-    },
-    "sub": {
-      "@id": "https://www.iana.org/assignments/jose#sub",
-      "@type": "@id"
-    },
+    "kid": "https://www.iana.org/assignments/jose#kid",
+    "iss": "https://www.iana.org/assignments/jose#iss",
+    "sub": "https://www.iana.org/assignments/jose#sub",
     "jku": {
       "@id": "https://www.iana.org/assignments/jose#jku",
       "@type": "@id"
@@ -26,10 +17,7 @@
       "@id": "https://www.iana.org/assignments/jose#x5u",
       "@type": "@id"
     },
-    "aud": {
-      "@id": "https://www.iana.org/assignments/jwt#aud",
-      "@type": "@id"
-    },
+    "aud": "https://www.iana.org/assignments/jwt#aud",
     "exp": {
       "@id": "https://www.iana.org/assignments/jwt#exp",
       "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
@@ -46,10 +34,7 @@
       "@id": "https://www.iana.org/assignments/jwt#cnf",
       "@context": {
         "@protected": true,
-        "kid": {
-          "@id": "https://www.iana.org/assignments/jwt#kid",
-          "@type": "@id"
-        },
+        "kid": "https://www.iana.org/assignments/jwt#kid",
         "jwk": {
           "@id": "https://www.iana.org/assignments/jwt#jwk",
           "@type": "@json"


### PR DESCRIPTION
This PR attempts to address issue #1275 by aligning the JSON-LD Context definitions in the base context with the IETF JOSE RFCs. The PR does this by allowing `kid`, `iss`, `sub`, and `aud` to be strings (they were previously limited to only being URLs).