### PR TITLE
Add conformance classes for issuers and verifiers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,41 +569,34 @@ serialization format.
         </p>
 
         <p>
-A <dfn>conforming processor</dfn> is any algorithm realized as software and/or
-hardware that generates and/or consumes a <a>conforming document</a>. <a>Conforming
-processors</a> MUST produce errors when non-conforming documents are
-encountered.
+A <dfn class="lint-ignore">conforming issuer implementation</dfn> produces
+<a>conforming documents</a>, MUST include all required properties in the
+<a>conforming documents</a> that it produces, and MUST secure the <a>conforming
+documents</a> it produces using a securing mechanism as described in Section <a
+href="#securing-verifiable-credentials"></a>.
         </p>
 
         <p>
-A <dfn class="lint-ignore">conforming issuer processor</dfn> is a <a>conforming
-processor</a> that produces <a>conforming documents</a>. A <a>conforming
-issuer processor</a> MUST include all required fields in the <a>conforming
-documents</a> that it produces. A <a>conforming issuer processor</a> MUST
-secure the <a>conforming documents</a> it produces using a securing mechanism
-as described in Section <a href="#securing-verifiable-credentials"></a>.
+A <dfn class="lint-ignore">conforming verifier implementation</dfn>
+consumes <a>conforming documents</a>, MUST perform <a>verification</a> on a
+<a>conforming document</a> as described in Section
+<a href="#securing-verifiable-credentials"></a>, and MUST check that each
+required property satisfies the normative requirements for that property.
         </p>
 
         <p>
-A <dfn class="lint-ignore">conforming verifier processor</dfn> is a
-<a>conforming processor</a> that consumes <a>conforming documents</a>. A
-<a>conforming verifier processor</a> SHOULD check that each required field
-satisfies the normative requirements for that field. A <a>conforming verifier
-processor</a> MUST perform <a>verification</a> on a <a>conforming document</a>.
+This specification includes both required and optional properties. Optional
+properties MAY be ignored by <a>conforming issuer implementations</a> and/or
+<a>conforming verifier implementations</a>.
         </p>
 
         <p>
-This specification includes both required and optional fields. Optional fields
-MAY be ignored by <a>conforming issuer processors</a> and/or
-<a>conforming verifier processors</a>.
-        </p>
-
-        <p>
-<a>Verifiable credential</a> and <a>verifiable presentation</a> MUST be
-protected using a digital proof mechanism such as a digital signature. Having
-and verifying proofs, which may be dependent on the syntax of the proof (for
-example, using the JSON Web Signature of a JSON Web Token for proofing a key
-holder), are an essential part of processing <a>verifiable credentials</a> and
+<a>Verifiable credentials</a> and <a>verifiable presentations</a> MUST be
+protected using a securing mechanism as described in Section
+<a href="#securing-verifiable-credentials"></a>. Having and verifying proofs,
+which may be dependent on the syntax of the proof (for example, using the JSON
+Web Signature of a JSON Web Token for proofing a key holder), are an essential
+part of processing <a>verifiable credentials</a> and
 <a>verifiable presentations</a>. At the time of publication, Working Group
 members had implemented such protection using at least three proof mechanisms:
         </p>

--- a/index.html
+++ b/index.html
@@ -570,8 +570,9 @@ serialization format.
 
         <p>
 A <dfn>conforming processor</dfn> is any algorithm realized as software and/or
-hardware that generates or consumes a <a>conforming document</a>. <a>Conforming
-processors</a> MUST produce errors when non-conforming documents are consumed.
+hardware that generates and/or consumes a <a>conforming document</a>. <a>Conforming
+processors</a> MUST produce errors when non-conforming documents are
+encountered.
         </p>
 
         <p>
@@ -593,7 +594,7 @@ processor</a> MUST perform <a>verification</a> on a <a>conforming document</a>.
 
         <p>
 This specification includes both required and optional fields. Optional fields
-MAY be ignored by <a>conforming issuer processors</a> and
+MAY be ignored by <a>conforming issuer processors</a> and/or
 <a>conforming verifier processors</a>.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -592,7 +592,7 @@ processor</a> MUST perform <a>verification</a> on a <a>conforming document</a>.
         </p>
 
         <p>
-This specification includes both required and optional fields.  Optional fields
+This specification includes both required and optional fields. Optional fields
 MAY be ignored by <a>conforming issuer processors</a> and
 <a>conforming verifier processors</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -572,16 +572,17 @@ serialization format.
 A <dfn class="lint-ignore">conforming issuer implementation</dfn> produces
 <a>conforming documents</a>, MUST include all required properties in the
 <a>conforming documents</a> that it produces, and MUST secure the <a>conforming
-documents</a> it produces using a securing mechanism as described in Section <a
-href="#securing-verifiable-credentials"></a>.
+documents</a> it produces using a securing mechanism as described in Section
+<a href="#securing-verifiable-credentials"></a>.
         </p>
 
         <p>
 A <dfn class="lint-ignore">conforming verifier implementation</dfn>
 consumes <a>conforming documents</a>, MUST perform <a>verification</a> on a
 <a>conforming document</a> as described in Section
-<a href="#securing-verifiable-credentials"></a>, and MUST check that each
-required property satisfies the normative requirements for that property.
+<a href="#securing-verifiable-credentials"></a>, MUST check that each
+required property satisfies the normative requirements for that property, and
+MUST produce errors when non-<a>conforming documents</a> are detected.
         </p>
 
         <p>
@@ -594,7 +595,7 @@ properties MAY be ignored by <a>conforming issuer implementations</a> and/or
 <a>Verifiable credentials</a> and <a>verifiable presentations</a> MUST be
 protected using a securing mechanism as described in Section
 <a href="#securing-verifiable-credentials"></a>. Having and verifying proofs,
-which may be dependent on the syntax of the proof (for example, using the JSON
+which might be dependent on the syntax of the proof (for example, using the JSON
 Web Signature of a JSON Web Token for proofing a key holder), are an essential
 part of processing <a>verifiable credentials</a> and
 <a>verifiable presentations</a>. At the time of publication, Working Group

--- a/index.html
+++ b/index.html
@@ -569,18 +569,32 @@ serialization format.
         </p>
 
         <p>
-A <dfn class="lint-ignore">conforming processor</dfn> is any algorithm realized
-as software and/or hardware that generates or consumes a <a>conforming
-document</a>. Conforming processors MUST produce errors when non-conforming
-documents are consumed.
+A <dfn>conforming processor</dfn> is any algorithm realized as software and/or
+hardware that generates or consumes a <a>conforming document</a>. <a>Conforming
+processors</a> MUST produce errors when non-conforming documents are consumed.
         </p>
 
         <p>
-This specification includes both required and optional fields. An <a>issuer</a>
-MUST include all required fields. A <a>verifier</a> SHOULD check that each
-required field satisfies the normative requirements for that field.
-Optional fields MAY
-be ignored by <a>issuers</a> and/or <a>verifiers</a>.
+A <dfn class="lint-ignore">conforming issuer processor</dfn> is a <a>conforming
+processor</a> that produces <a>conforming documents</a>. A <a>conforming
+issuer processor</a> MUST include all required fields in the <a>conforming
+documents</a> that it produces. A <a>conforming issuer processor</a> MUST
+secure the <a>conforming documents</a> it produces using a securing mechanism
+as described in Section <a href="#securing-verifiable-credentials"></a>.
+        </p>
+
+        <p>
+A <dfn class="lint-ignore">conforming verifier processor</dfn> is a
+<a>conforming processor</a> that consumes <a>conforming documents</a>. A
+<a>conforming verifier processor</a> SHOULD check that each required field
+satisfies the normative requirements for that field. A <a>conforming verifier
+processor</a> MUST perform <a>verification</a> on a <a>conforming document</a>.
+        </p>
+
+        <p>
+This specification includes both required and optional fields.  Optional fields
+MAY be ignored by <a>conforming issuer processors</a> and
+<a>conforming verifier processors</a>.
         </p>
 
         <p>


### PR DESCRIPTION
This PR attempts to address issue #1300 by creating new conformance classes for "conforming issuer processors" and "conforming verifier processors". I expect we'll need to fine tune the language before this PR can be merged.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1336.html" title="Last updated on Nov 15, 2023, 8:55 PM UTC (7a68810)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1336/998a3dc...7a68810.html" title="Last updated on Nov 15, 2023, 8:55 PM UTC (7a68810)">Diff</a>