### PR TITLE
Add verification algorithm to specification.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2188,10 +2188,11 @@ for details.
             <li>
 If the verification of the securing mechanism is successful, set
 <var>verified</var>.<var>status</var> to `true`,
-<var>verified</var>.<var>document</var> to the information that was secured,
-<var>verified</var>.<var>mediaType</var> to the corresponding media type,
-and optionally <var>verified</var>.<var>warnings</var> to any warnings
-returned by the verification process for the securing mechanism.
+<var>verified</var>.<var>document</var> to the information that was checked and
+returned as successfully protected by the verification process for the securing
+mechanism as, <var>verified</var>.<var>mediaType</var> to the corresponding
+media type, and optionally <var>verified</var>.<var>warnings</var> to any
+warnings returned by the verification process for the securing mechanism.
               <ol class="algorithm">
                 <li>
 Check whether <var>verified</var>.<var>document</var> is a

--- a/index.html
+++ b/index.html
@@ -4460,7 +4460,7 @@ Ensure that the securing mechanism has properly protected the
 <var>conforming document</var> by performing the following steps:
             <ol class="algorithm">
               <li>
-Set <var>securingMechanisecuringMechanismVerified</var> to the result of executing the
+Set <var>securingMechanismVerified</var> to the result of executing the
 <a href="#verify-securing-mechanism">securing mechanism verification
 algorithm</a> with <var>inputBytes</var> and <var>mediaType</var> passed as
 input to the algorithm.
@@ -4468,7 +4468,7 @@ input to the algorithm.
               <li>
 Set <var>status</var>, <var>document</var>, <var>mediaType</var>,
 <var>warnings</var>, and <var>errors</var> in <var>verified</var> to the
-associated properties in <var>securingMechanisecuringMechanismVerified</var>.
+associated properties in <var>securingMechanismVerified</var>.
               </li>
               <li>
 If <var>verified</var>.<var>status</var> is `false`, the provided
@@ -4648,18 +4648,16 @@ byte sequence (bytes <var>inputBytes</var>) and a media type
 
         <ul>
           <li>
-a verification status (boolean <var>verified</var>.<var>status</var>)
+a verification status (boolean <var>status</var>)
           </li>
           <li>
-a verified document (object <var>verified</var>.<var>document</var>)
+a verified document (object <var>document</var>)
           </li>
           <li>
-zero or more optional warnings (array of <a>ProblemDetails</a>
-<var>verified</var>.<var>warnings</var>)
+zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)
           </li>
           <li>
-zero or more optional errors (array of <a>ProblemDetails</a>
-<var>verified</var>.<var>errors</var>)
+zero or more errors (array of <a>ProblemDetails</a> <var>errors</var>)
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -164,6 +164,18 @@ pre .comment {
   -ms-user-select: none;
   user-select: none;
 }
+ol.algorithm {
+  counter-reset: numsection;
+  list-style-type: none;
+}
+ol.algorithm li {
+  margin: 0.5em 0;
+}
+ol.algorithm li:before {
+  font-weight: bold;
+  counter-increment: numsection;
+  content: counters(numsection, ".") ") ";
+}
     </style>
   </head>
   <body>
@@ -5912,25 +5924,58 @@ identified attacks.
     </section>
 
     <section class="appendix normative">
-      <h2>Verification</h2>
+      <h2>Verification Algorithm</h2>
 
       <p>
-This section contains the algorithm that conforming verifiers run when verifying
-a <a>verifiable credential</a> or a <a>verifiable presentation</a>. The
-algorithm takes a <a>conforming document</a> (<var>document</var>) as input and
-produces an object <var>result</var> that contains a verification result and
-optional warning and error information.
+This section contains the algorithm that <a>conforming verifier processors</a>
+run when verifying a <a>verifiable credential</a> or a <a>verifiable
+presentation</a>. Any algorithm can be used that produces output that
+is equivalent to the algorithm defined in this section. The algorithm takes a
+byte stream (<var>inputBytes</var>) and media type (<var>inputMediaType</var>)
+as input and produces an object (<var>verified</var>) that contains a
+verification status (<var>verified</var>.<var>status</var>),
+verified document (<var>verified</var>.<var>document</var>),
+media type (<var>verified</var>.<var>mediaType</var>),
+and optional warning  (<var>verified</var>.<var>warnings</var>) and
+error (<var>verified</var>.<var>errors</var>) information.
       </p>
 
       <ol class="algorithm">
         <li>
-
+Set <var>verified</var> to an empty object.
         </li>
         <li>
-
+Verify that the securing mechanism in use on <var>inputBytes</var> has not been
+tampered with, using <var>inputMediaType</var> as additional input to the
+algorithm. See Section <a href="#securing-verifiable-credentials"></a>
+for details.
         </li>
         <li>
-
+If the verification of the securing mechanism is successful, set
+<var>verified</var>.<var>status</var> to `true`,
+<var>verified</var>.<var>document</var> to the information that was secured,
+and <var>verified</var>.<var>mediaType</var> to the corresponding media type,
+and optionally set <var>verified</var>.<var>warnings</var> to any warning
+objects returned by the verification process for the securing mechanism.
+          <ol class="algorithm">
+            <li>
+Ensure that <var>verified</var>.<var>document</var> is a
+<a>conforming document</a>, and if not, optionally add appropriate warnings
+and errors to <var>verified</var>.<var>warnings</var> and
+<var>verified</var>.<var>errors</var>, respectively.
+            </li>
+          </ol>
+        </li>
+        <li>
+If the verification of the securing mechanism is not successful, set
+<var>verified</var>.<var>status</var> to `false`, and optionally set
+<var>verified</var>.<var>errors</var> to any error objects returned by the
+verification process for the securing mechanism and
+<var>verified</var>.<var>warnings</var> to any warning objects returned by the
+verification process for the securing mechanism.
+        </li>
+        <li>
+Return <var>verified</var>.
         </li>
       </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -4538,8 +4538,7 @@ The verification algorithm is as follows:
         <ol class="algorithm">
           <li>
 Set <var>dataModelVerified</var> to an empty object. Initialize the following
-fields in <var>dataModelVerified</var>:
-<var>status</var> to `false`, <var>document</var> to <var>inputDocument</var>,
+fields in <var>dataModelVerified</var>: <var>status</var> to `false`,
 <var>warnings</var> to an empty array, and <var>errors</var> to an empty array.
           </li>
           <li>
@@ -4616,12 +4615,23 @@ the statements in Section <a href="#evidence"></a>.
           </li>
           <li>
 If no errors were detected to this point, set
+<var>dataModelVerified</var>.<var>document</var> to <var>inputDocument</var>,
 <var>dataModelVerified</var>.<var>verified</var> to `true`.
           </li>
           <li>
 Return <var>dataModelVerified</var>.
           </li>
         </ol>
+
+        <p class="note" title="Additional checks are expected">
+Implementers are advised that the checks in this section are the bare minimum
+set of tests to conform to this specification. Other checks that create helpful
+warnings for developers to help debug potential issues are expected to be
+provided by implementations. Additional checks that could result in new types of
+errors being detected to stop harmful content are also expected to be provided
+by implementations, which might be integrated into future versions of this
+specification.
+        </p>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -4519,7 +4519,7 @@ Return <var>result</var>.
         <p>
 The steps for verifying the state of the securing mechanism and verifying
 that the input document is a <a>conforming document</a> MAY be performed in
-a different order than the one provided above as long as the
+a different order than that provided above as long as the
 implementation returns errors for the same inputs.
 Implementations MAY produce different errors than described above.
         </p>
@@ -4531,7 +4531,7 @@ Implementations MAY produce different errors than described above.
 
         <p>
 The algorithm in this section can be used to determine if a provided document is
-conformant to the data model provided in this specification. This algorithm
+conformant with the data model provided in this specification. This algorithm
 takes a document (object <var>inputDocument</var>) and produces an object
 (<var>dataModelConformanceChecked</var>) that contains the following:
         </p>
@@ -4586,13 +4586,13 @@ If present, ensure that the `name` and/or `description` properties conform to
 the "MUST" statements in Section <a href="#names-and-descriptions"></a>.
               </li>
               <li>
-If the `type` property is present and contains the
-`VerifiablePresentation` type, ensure that the object conforms to the
+If the `type` property is present and contains an object with the type
+`VerifiablePresentation`, ensure that the object conforms to the
 "MUST" statements in Section <a href="#presentations-0"></a>.
               </li>
               <li>
-If the `type` property is present and contains the
-`VerifiableCredential` type, perform the following checks:
+If the `type` property is present and contains an object with the type
+`VerifiableCredential`, perform the following checks:
                 <ol class="algorithm">
                   <li>
 Ensure that the `credentialSubject` property conforms to the
@@ -4704,11 +4704,11 @@ of the specification will be included in this text.
 </div>
               </li>
               <li>
-Other extracting functions are possible, but need not be listed in
-the <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a>
-section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
-Implementers might find these other specifications through other standards
-bodies or communities that utilize this specification.
+Other extracting functions are possible. Specifications of such might be found
+in the <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a>
+section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]]
+or through other standards bodies or communities that utilize this
+specification, among other places.
               </li>
             </ol>
           </li>
@@ -4768,11 +4768,11 @@ function-specific options, to the <var>verifyProof</var> function.
                 </ol>
               </li>
               <li>
-Other proof verification functions are possible, but need not be listed in
-the <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a> section
-of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
-Implementers might find these other specifications through other standards
-bodies or communities that utilize this specification.
+Other proof verification functions are possible. Specifications of such might
+be found in the <a data-cite="?VC-SPECS#securing-mechanisms">Securing
+Mechanisms</a> section of the Verifiable Credentials Specifications Directory
+[[?VC-SPECS]] or through other standards bodies or communities that utilize
+this specification, among other places.
                 <ol class="algorithm">
                   <li>
 Set <var>securingMechanismVerified</var>.<var>status</var> to the
@@ -4830,7 +4830,7 @@ identifying the type of problem.
           <dt>code</dt>
           <dd>
 The `code` <a>property</a> is an OPTIONAL
-<a data-cite="RFC9457#name-extension-members">RFC9457 extension member</a> . If
+<a data-cite="RFC9457#name-extension-members">RFC9457 extension member</a>. If
 present, its value MUST be an integer that identifies the type of the problem.
 Integer codes are useful in systems that only provide integer return values.
           </dd>
@@ -4872,7 +4872,7 @@ https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR
           </dt>
           <dd>
 The securing mechanism for the document has detected a
-modification to the contents of the document since it was created;
+modification in the contents of the document since it was created;
 potential tampering detected. See Section
 <a href="#verify-securing-mechanism"></a>.
           </dd>

--- a/index.html
+++ b/index.html
@@ -2158,129 +2158,6 @@ single proof mechanisms for use with <a>verifiable credentials</a> or
 Directory [[VC-SPECS]].
         </p>
 
-        <section class="normative">
-          <h4>The Verification Algorithm</h4>
-
-          <p>
-This section contains an algorithm that <a>conforming verifier processors</a>
-can run when verifying a <a>verifiable credential</a> or a <a>verifiable
-presentation</a>. This algorithm takes a byte sequence (bytes
-<var>inputBytes</var>) and a media type (string <var>inputMediaType</var>) as
-inputs, and produces an object (<var>verified</var>) that contains the following:
-          </p>
-          <ul>
-            <li>
-a verification status (boolean <var>verified</var>.<var>status</var>)
-            </li>
-            <li>
-a verified document (object <var>verified</var>.<var>document</var>)
-            </li>
-            <li>
-a media type (string <var>verified</var>.<var>mediaType</var>)
-            </li>
-            <li>
-zero or more optional warnings (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>warnings</var>)
-            </li>
-            <li>
-zero or more optional errors (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>errors</var>)
-            </li>
-          </ul>
-          </p>
-
-          <ol class="algorithm">
-            <li>
-Set <var>verified</var> to an empty object.
-            </li>
-            <li>
-Verify that the securing mechanism in use on <var>inputBytes</var> has not been
-tampered with, using <var>inputMediaType</var> as additional input to the
-algorithm. See Section <a href="#securing-mechanisms"></a>
-for details.
-            </li>
-            <li>
-If the verification of the securing mechanism is successful, set the following:
-              <ul>
-                <li>
-<var>verified</var>.<var>status</var> to `true`
-                </li>
-                <li>
-<var>verified</var>.<var>document</var> to the information that was checked and
-returned as successfully protected by the verification process for the securing
-mechanism
-                </li>
-                <li>
-<var>verified</var>.<var>mediaType</var> to the corresponding
-media type
-                </li>
-                <li>
-<var>verified</var>.<var>warnings</var> optionally to any warnings returned by
-the verification process for the securing mechanism
-                </li>
-              </ul>
-              <ol class="algorithm">
-                <li>
-Check whether <var>verified</var>.<var>document</var> is a
-<a>conforming document</a>. If not, optionally add appropriate warnings
-and errors to <var>verified</var>.<var>warnings</var> and
-<var>verified</var>.<var>errors</var>, respectively.
-                </li>
-              </ol>
-            </li>
-            <li>
-If verification of the securing mechanism is not successful, set
-<var>verified</var>.<var>status</var> to `false`, and optionally set
-<var>verified</var>.<var>errors</var> and
-<var>verified</var>.<var>warnings</var>, respectively, to any error and
-warnings returned by the verification process for the securing mechanism. At least one error MUST be populated.
-            </li>
-            <li>
-Return <var>verified</var>.
-            </li>
-          </ol>
-        </section>
-
-        <section>
-          <h4>Anomaly Descriptions</h4>
-
-          <p>
-When an anomaly is detected by a <a>conforming processor</a>, an
-<dfn>anomalyDescription</dfn> is used to report the issue to software that
-invoked the process that led to the anomaly.
-The interface for these objects follows [[RFC9457]] to encode the data. An
-<a>anomalyDescription</a> object consists of the following properties:
-          </p>
-
-          <dl>
-            <dt>type</dt>
-            <dd>
-The `type` <a>property</a> MUST be present and its value MUST be a <a>URL</a>
-identifying the type of the anomaly.
-            </dd>
-            <dt>code</dt>
-            <dd>
-The `code` <a>property</a> is OPTIONAL. If present, its value MUST be an integer
-that identifies the type of the anomaly. Integer codes are useful in systems
-that only provide integer return values.
-            </dd>
-            <dt>title</dt>
-            <dd>
-The `title` <a>property</a> MUST be present and its value SHOULD provide a short
-but specific human-readable string for the anomaly.
-            </dd>
-            <dt>detail</dt>
-            <dd>
-The `detail` <a>property</a> MUST be present and its value SHOULD provide a
-longer human-readable string for the anomaly.
-            </dd>
-          </dl>
-
-          <p>
-Other properties that are useful for debugging purposes MAY be included in
-an <a>anomalyDescription</a> object.
-          </p>
-
-        </section>
-
       </section>
 
       <section>
@@ -4530,6 +4407,144 @@ Verifiable Credential Data Integrity [[VC-DATA-INTEGRITY]].
         </ul>
 
       </section>
+    </section>
+
+    <section class="normative">
+      <h2>Algorithms</h2>
+
+      <p>
+This section contains algorithms that can be used by implementations to
+perform common operations.
+      </p>
+
+      <section class="normative">
+        <h3>Verification</h3>
+
+        <p>
+This section contains an algorithm that <a>conforming verifier
+implementations</a> can run when verifying a <a>verifiable credential</a> or a
+<a>verifiable presentation</a>. This algorithm takes a byte sequence (bytes
+<var>inputBytes</var>) and a media type (string <var>inputMediaType</var>) as
+inputs, and produces an object (<var>verified</var>) that contains the
+following:
+        </p>
+
+        <ul>
+          <li>
+a verification status (boolean <var>verified</var>.<var>status</var>)
+          </li>
+          <li>
+a verified document (object <var>verified</var>.<var>document</var>)
+          </li>
+          <li>
+a media type (string <var>verified</var>.<var>mediaType</var>)
+          </li>
+          <li>
+zero or more optional warnings (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>warnings</var>)
+          </li>
+          <li>
+zero or more optional errors (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>errors</var>)
+          </li>
+        </ul>
+
+        <p>
+The verification algorithm is as follows:
+        </p>
+
+        <ol class="algorithm">
+          <li>
+Set <var>verified</var> to an empty object.
+          </li>
+          <li>
+Verify that the securing mechanism in use on <var>inputBytes</var> has not been
+tampered with, using <var>inputMediaType</var> as additional input to the
+algorithm. See Section <a href="#securing-mechanisms"></a>
+for details.
+          </li>
+          <li>
+If the verification of the securing mechanism is successful, set the following:
+            <ul>
+              <li>
+<var>verified</var>.<var>status</var> to `true`
+              </li>
+              <li>
+<var>verified</var>.<var>document</var> to the information that was checked and
+returned as successfully protected by the verification process for the securing
+mechanism
+              </li>
+              <li>
+<var>verified</var>.<var>mediaType</var> to the corresponding
+media type
+              </li>
+              <li>
+<var>verified</var>.<var>warnings</var> optionally to any warnings returned by
+the verification process for the securing mechanism
+              </li>
+            </ul>
+            <ol class="algorithm">
+              <li>
+Check whether <var>verified</var>.<var>document</var> is a
+<a>conforming document</a>. If not, optionally add appropriate warnings
+and errors to <var>verified</var>.<var>warnings</var> and
+<var>verified</var>.<var>errors</var>, respectively.
+              </li>
+            </ol>
+          </li>
+          <li>
+If verification of the securing mechanism is not successful, set
+<var>verified</var>.<var>status</var> to `false`, and optionally set
+<var>verified</var>.<var>errors</var> and
+<var>verified</var>.<var>warnings</var>, respectively, to any error and
+warnings returned by the verification process for the securing mechanism. At least one error MUST be populated.
+          </li>
+          <li>
+Return <var>verified</var>.
+          </li>
+        </ol>
+      </section>
+
+      <section>
+        <h3>Anomaly Descriptions</h3>
+
+        <p>
+When an anomaly is detected by a <a>conforming processor</a>, an
+<dfn>anomalyDescription</dfn> is used to report the issue to software that
+invoked the process that led to the anomaly.
+The interface for these objects follows [[RFC9457]] to encode the data. An
+<a>anomalyDescription</a> object consists of the following properties:
+        </p>
+
+        <dl>
+          <dt>type</dt>
+          <dd>
+The `type` <a>property</a> MUST be present and its value MUST be a <a>URL</a>
+identifying the type of the anomaly.
+          </dd>
+          <dt>code</dt>
+          <dd>
+The `code` <a>property</a> is OPTIONAL. If present, its value MUST be an integer
+that identifies the type of the anomaly. Integer codes are useful in systems
+that only provide integer return values.
+          </dd>
+          <dt>title</dt>
+          <dd>
+The `title` <a>property</a> MUST be present and its value SHOULD provide a short
+but specific human-readable string for the anomaly.
+          </dd>
+          <dt>detail</dt>
+          <dd>
+The `detail` <a>property</a> MUST be present and its value SHOULD provide a
+longer human-readable string for the anomaly.
+          </dd>
+        </dl>
+
+        <p>
+Other properties that are useful for debugging purposes MAY be included in
+an <a>anomalyDescription</a> object.
+        </p>
+
+      </section>
+
     </section>
 
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -4460,7 +4460,7 @@ Ensure that the securing mechanism has properly protected the
 <var>conforming document</var> by performing the following steps:
             <ol class="algorithm">
               <li>
-Set <var>securingMechanismVerified</var> to the result of executing the
+Set <var>securingMechanisecuringMechanismVerified</var> to the result of executing the
 <a href="#verify-securing-mechanism">securing mechanism verification
 algorithm</a> with <var>inputBytes</var> and <var>mediaType</var> passed as
 input to the algorithm.
@@ -4468,7 +4468,7 @@ input to the algorithm.
               <li>
 Set <var>status</var>, <var>document</var>, <var>mediaType</var>,
 <var>warnings</var>, and <var>errors</var> in <var>verified</var> to the
-associated properties in <var>securingMechanismVerified</var>.
+associated properties in <var>securingMechanisecuringMechanismVerified</var>.
               </li>
               <li>
 If <var>verified</var>.<var>status</var> is `false`, the provided
@@ -4512,36 +4512,114 @@ Return <var>verified</var>.
         <p>
 The algorithm in this section can be used to determine if a provided document is
 conformant to the data model provided in this specification. This algorithm
-takes a document (object <var>document</var>) and produces an object
-(<var>dmVerified</var>) that contains the following:
+takes a document (object <var>inputDocument</var>) and produces an object
+(<var>dataModelVerified</var>) that contains the following:
         </p>
 
         <ul>
           <li>
-a verification status (boolean <var>verified</var>.<var>status</var>)
+a verification status (boolean <var>status</var>)
           </li>
           <li>
-a verified document (object <var>verified</var>.<var>document</var>)
+a verified document (object <var>document</var>)
           </li>
           <li>
-zero or more optional warnings (array of <a>ProblemDetails</a>
-<var>verified</var>.<var>warnings</var>)
+zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)
           </li>
           <li>
-zero or more optional errors (array of <a>ProblemDetails</a>
-<var>verified</var>.<var>errors</var>)
+zero or more errors (array of <a>ProblemDetails</a> <var>errors</var>)
           </li>
         </ul>
 
         <p>
 The verification algorithm is as follows:
         </p>
+
         <ol class="algorithm">
           <li>
-Set <var>verified</var> to an empty object.
+Set <var>dataModelVerified</var> to an empty object. Initialize the following
+fields in <var>dataModelVerified</var>:
+<var>status</var> to `false`, <var>document</var> to <var>inputDocument</var>,
+<var>warnings</var> to an empty array, and <var>errors</var> to an empty array.
           </li>
           <li>
-Return <var>dmVerified</var>.
+Ensure that the `@context` property of <var>document</var> conforms to the
+statements in <a href="#contexts"></a>. If not, return
+<var>dataModelVerified</var>, which will contain a false verification status.
+          </li>
+          <li>
+Starting at the top level, recursively process each object <var>obj</var> in
+<var>document</var>, setting <a href="#MALFORMED_VALUE">MALFORMED_VALUE</a>
+errors in <var>dataModelVerified</var>.<var>errors</var> if errors are found,
+by performing the following checks:
+            <ol class="algorithm">
+              <li>
+If present, ensure that the `id` property conforms to the statements in
+Section <a href="#identifiers"></a>.
+              </li>
+              <li>
+If present, ensure that the `type` property conforms to the statements in
+Section <a href="#types"></a>.
+              </li>
+              <li>
+If present, ensure that the `name` and `description` properties conform to the
+statements in Section <a href="#names-and-descriptions"></a>.
+              </li>
+              <li>
+If present, ensure that the `proof` property conforms to
+the statements in Section <a href="#securing-mechanisms"></a>.
+              </li>
+              <li>
+If the `type` property is present and contains the
+`VerifiablePresentation` type, ensure that the object conforms to the
+statements in Section <a href="#presentations"></a>.
+              </li>
+              <li>
+If the `type` property is present and contains the
+`VerifiableCredential` type, perform the following checks:
+                <ol class="algorithm">
+                  <li>
+Ensure that the `credentialSubject` property conforms to the
+statements in Section <a href="#credential-subject"></a>.
+                  </li>
+                  <li>
+Ensure that the `issuer` property conforms to the
+statements in Section <a href="#issuer"></a>.
+                  </li>
+                  <li>
+If present, ensure that the `validFrom` and `validUntil` properties conform to
+the statements in Section <a href="#validity-period"></a>.
+                  </li>
+                  <li>
+If present, ensure that the `credentialStatus` property conforms to
+the statements in Section <a href="#status"></a>.
+                  </li>
+                  <li>
+If present, ensure that the `credentialSchema` property conforms to
+the statements in Section <a href="#data-schemas"></a>.
+                  </li>
+                  <li>
+If present, ensure that the `relatedResource` property conforms to
+the statements in Section <a href="#integrity-of-related-resources"></a>.
+                  </li>
+                  <li>
+If present, ensure that the `refreshService` property conforms to
+the statements in Section <a href="#refreshing"></a>.
+                  </li>
+                  <li>
+If present, ensure that the `evidence` property conforms to
+the statements in Section <a href="#evidence"></a>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>
+If no errors were detected to this point, set
+<var>dataModelVerified</var>.<var>verified</var> to `true`.
+          </li>
+          <li>
+Return <var>dataModelVerified</var>.
           </li>
         </ol>
 
@@ -4555,7 +4633,7 @@ The algorithm in this section can be used to verify if a securing mechanism
 that is associated with a sequence of bytes is valid. This algorithm takes a
 byte sequence (bytes <var>inputBytes</var>) and a media type
 (string <var>inputMediaType</var>) as inputs, and produces an object
-(<var>smVerified</var>) that contains the following:
+(<var>securingMechanismVerified</var>) that contains the following:
         </p>
 
         <ul>
@@ -4580,7 +4658,7 @@ The securing mechanism verification algorithm is as follows:
         </p>
         <ol class="algorithm">
           <li>
-Set <var>smVerified</var> to an empty object.
+Set <var>securingMechanismVerified</var> to an empty object.
           </li>
           <li>
 If the verification of the securing mechanism is successful:
@@ -4608,7 +4686,7 @@ the verification process for the securing mechanism
             </ol>
           </li>
           <li>
-Return <var>smVerified</var>.
+Return <var>securingMechanismVerified</var>.
           </li>
         </ol>
 

--- a/index.html
+++ b/index.html
@@ -4445,7 +4445,7 @@ following:
 a verification status (boolean <var>status</var>)
           </li>
           <li>
-a verified document (object <var>document</var>)
+a verified conforming document (object <var>document</var>)
           </li>
           <li>
 a media type (string <var>mediaType</var>)

--- a/index.html
+++ b/index.html
@@ -4722,8 +4722,9 @@ Determine the specific cryptographic verification algorithm
               <li>
 If the <var>inputMediaType</var> is `application/vc+ld+json` or
 `application/vp+ld+json`, the Verifiable Credential Data Integrity
-Specification [[?VC-DATA-INTEGRITY]] defines the process for identifying
-a specific cryptography suite type used for cryptographic verification by
+Specification [[?VC-DATA-INTEGRITY]] defines the
+<a data-cite="VC-DATA-INTEGRITY#verify-proof">process for identifying
+a specific cryptography suite type</a> used for cryptographic verification by
 utilizing the `proof`.`type` property. A list of registered proof types can be
 found in the
 <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a>

--- a/index.html
+++ b/index.html
@@ -4743,9 +4743,11 @@ If <var>securedDocument</var> was successfully set in the previous step, set
 <var>securingMechanismVerified</var>.<var>status</var> to the result of passing
 <var>securedDocument</var>, along with any relevant function-specific options,
 to the <var>verifyProof</var> function. For example, the
-<var>expectedProofPurpose</var> option is set to `assertionMethod`, and if the
-<a>conforming document</a> is expected to be a
-<a>verifiable presentation</a>, the <var>domain</var> and <var>challenge</var>
+<var>expectedProofPurpose</var> option is set to `assertionMethod` when
+the conforming document is expected to be a <a>verifiable credential</a>,
+and if the <a>conforming document</a> is expected to be a
+<a>verifiable presentation</a>, the <var>expectedProofPurpose</var> option
+is set to `authentication` and the <var>domain</var> and <var>challenge</var>
 are also provided as options.
                   </li>
                 </ol>

--- a/index.html
+++ b/index.html
@@ -4478,8 +4478,8 @@ input to the algorithm.
               </li>
               <li>
 Set <var>status</var>, <var>document</var>, <var>mediaType</var>,
-<var>warnings</var>, and <var>errors</var> in <var>verified</var> to the
-associated properties in <var>securingMechanismVerified</var>.
+<var>warnings</var>, and <var>errors</var> in <var>verified</var> to their
+respective properties in <var>securingMechanismVerified</var>.
               </li>
               <li>
 If <var>verified</var>.<var>status</var> is `false`, the provided
@@ -4500,7 +4500,7 @@ with <var>document</var> passed as input to the algorithm.
               </li>
               <li>
 Set <var>status</var>, <var>document</var>, <var>warnings</var>, and
-<var>errors</var> in <var>verified</var> to the associated properties in
+<var>errors</var> in <var>verified</var> to their respective properties in
 <var>dataModelVerified</var>.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -4708,7 +4708,7 @@ of the specification will be included in this text.
               </li>
               <li>
 Other extracting functions are possible, but need not be listed in
-the <a data-cite="?VC-SPECS#media-type-extensions">Media Type Extensions</a>
+the <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a>
 section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
 Implementers might find these other specifications through other standards
 bodies or communities that utilize this specification.
@@ -4724,8 +4724,9 @@ If the <var>inputMediaType</var> is `application/vc+ld+json` or
 `application/vp+ld+json`, the Verifiable Credential Data Integrity
 Specification [[?VC-DATA-INTEGRITY]] defines the process for identifying
 a specific cryptography suite type used for cryptographic verification by
-utilizing the `proof`.`type` property. The list of all registered
-proof types can be found in the <a data-cite="?VC-SPECS#proof">Proof Types</a>
+utilizing the `proof`.`type` property. A list of registered proof types can be
+found in the
+<a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a>
 section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
               </li>
               <li>
@@ -4736,8 +4737,8 @@ process.
               </li>
               <li>
 Other proof verification functions are possible, but need not be listed in
-the <a data-cite="?VC-SPECS#proof">Proof Types</a> section of the
-Verifiable Credentials Specifications Directory [[?VC-SPECS]].
+the <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a> section
+of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
 Implementers might find these other specifications through other standards
 bodies or communities that utilize this specification.
               </li>

--- a/index.html
+++ b/index.html
@@ -4691,10 +4691,10 @@ Determine the specific mechanism for extracting the <a>conforming document</a>
               <li>
 If the <var>inputMediaType</var> is `application/vc+ld+json` or
 `application/vp+ld+json`, the <var>extractDocument</var> function takes
-<var>inputBytes</var> as an input parameter, parses the value as JSON,
-and returns the result as an object. If JSON parsing fails, a
-<a href="#PARSING_ERROR">PARSING_ERROR</a> is appended to
-<var>securingMechanismVerified</var>.<var>errors</var>.
+<var>inputBytes</var> as an input parameter, parses the value as JSON into
+an object, removes the `proof` property, and returns the result as an object.
+If JSON parsing fails, a <a href="#PARSING_ERROR">PARSING_ERROR</a> is appended
+to <var>securingMechanismVerified</var>.<var>errors</var>.
               </li>
               <li>
 If the <var>inputMediaType</var> is associated with the JOSE or COSE

--- a/index.html
+++ b/index.html
@@ -4586,10 +4586,6 @@ If present, ensure that the `name` and/or `description` properties conform to
 the "MUST" statements in Section <a href="#names-and-descriptions"></a>.
               </li>
               <li>
-If present, ensure that the `proof` property conforms to
-the "MUST" statements in Section <a href="#securing-mechanisms"></a>.
-              </li>
-              <li>
 If the `type` property is present and contains the
 `VerifiablePresentation` type, ensure that the object conforms to the
 "MUST" statements in Section <a href="#presentations-0"></a>.

--- a/index.html
+++ b/index.html
@@ -4591,7 +4591,7 @@ the "MUST" statements in Section <a href="#securing-mechanisms"></a>.
               <li>
 If the `type` property is present and contains the
 `VerifiablePresentation` type, ensure that the object conforms to the
-"MUST" statements in Section <a href="#presentations"></a>.
+"MUST" statements in Section <a href="#presentations-0"></a>.
               </li>
               <li>
 If the `type` property is present and contains the

--- a/index.html
+++ b/index.html
@@ -4440,10 +4440,12 @@ a verified document (object <var>verified</var>.<var>document</var>)
 a media type (string <var>verified</var>.<var>mediaType</var>)
           </li>
           <li>
-zero or more optional warnings (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>warnings</var>)
+zero or more optional warnings (array of <a>ProblemDetails</a>
+<var>verified</var>.<var>warnings</var>)
           </li>
           <li>
-zero or more optional errors (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>errors</var>)
+zero or more optional errors (array of <a>ProblemDetails</a>
+<var>verified</var>.<var>errors</var>)
           </li>
         </ul>
 
@@ -4462,26 +4464,28 @@ algorithm. See Section <a href="#securing-mechanisms"></a>
 for details.
           </li>
           <li>
-If the verification of the securing mechanism is successful, set the following:
-            <ul>
-              <li>
+If the verification of the securing mechanism is successful:
+            <ol class="algorithm">
+              <li>Set the following:
+                <ol class="algorithm">
+                  <li>
 <var>verified</var>.<var>status</var> to `true`
-              </li>
-              <li>
+                  </li>
+                  <li>
 <var>verified</var>.<var>document</var> to the information that was checked and
 returned as successfully protected by the verification process for the securing
 mechanism
-              </li>
-              <li>
+                  </li>
+                  <li>
 <var>verified</var>.<var>mediaType</var> to the corresponding
 media type
-              </li>
-              <li>
+                  </li>
+                  <li>
 <var>verified</var>.<var>warnings</var> optionally to any warnings returned by
 the verification process for the securing mechanism
+                  </li>
+                </ol>
               </li>
-            </ul>
-            <ol class="algorithm">
               <li>
 Check whether <var>verified</var>.<var>document</var> is a
 <a>conforming document</a>. If not, optionally add appropriate warnings
@@ -4508,9 +4512,10 @@ Return <var>verified</var>.
 
         <p>
 When an implementation detects an anomaly while processing a document, a
-<dfn>ProblemDetail</dfn> can be used to report the issue to other software
-systems. The interface for these objects follows [[RFC9457]] to encode the data.
-An <a>ProblemDetail</a> object consists of the following properties:
+<dfn>ProblemDetails</dfn> object can be used to report the issue to other
+software systems. The interface for these types of objects follows [[RFC9457]]
+to encode the data. A <a>ProblemDetails</a> object consists of the following
+properties:
         </p>
 
         <dl>
@@ -4523,25 +4528,43 @@ identifying the type of problem.
           <dd>
 The `code` <a>property</a> is an OPTIONAL
 <a data-cite="RFC9457#name-extension-members">RFC9457 extension member</a> . If
-present, its value MUST be an integer that identifies the type of the anomaly.
+present, its value MUST be an integer that identifies the type of the problem.
 Integer codes are useful in systems that only provide integer return values.
           </dd>
           <dt>title</dt>
           <dd>
 The `title` <a>property</a> MUST be present and its value SHOULD provide a short
-but specific human-readable string for the anomaly.
+but specific human-readable string for the problem.
           </dd>
           <dt>detail</dt>
           <dd>
 The `detail` <a>property</a> MUST be present and its value SHOULD provide a
-longer human-readable string for the anomaly.
+longer human-readable string for the problem.
           </dd>
         </dl>
 
         <p>
 Other properties that are useful for debugging purposes MAY be included in
-a <a>ProblemDescription</a> object. See [[RFC9457]] for further details.
+a <a>ProblemDetails</a> object. See [[RFC9457]] for further guidance on
+using this mechanism.
         </p>
+
+        <p>
+The following problem description types and codes are defined by this
+specification:
+        </p>
+
+        <dl>
+          <dt id="MALFORMED_VALUE">
+https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE
+(-64)
+          </dt>
+          <dd>
+The value associated with a particular <a>property</a> is malformed. The
+name of the <a>property</a> and the path to the property SHOULD be provided
+in the <a>ProblemDetails</a> object. See Section <a href="#verification"></a>.
+          </dd>
+        </dl>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -4700,6 +4700,11 @@ and returns the result as an object. If JSON parsing fails, a
 If the <var>inputMediaType</var> is associated with the JOSE or COSE
 specifications, the [[?VC-JOSE-COSE]] specification defines a process for
 extracting the <a>conforming document</a>.
+<div class="issue" title="Document extraction process in vc-jose-cose">
+The process for extracting a conforming document is not clearly documented in
+the [[?VC-JOSE-COSE]] specification yet, but once it is, a link to that section
+of the specification will be included in this text.
+</div>
               </li>
               <li>
 Other extracting functions are possible, but need not be listed in

--- a/index.html
+++ b/index.html
@@ -4436,16 +4436,16 @@ This section contains an algorithm that <a>conforming verifier
 implementations</a> MUST run when verifying a <a>verifiable credential</a> or a
 <a>verifiable presentation</a>. This algorithm takes a byte sequence (bytes
 <var>inputBytes</var>) and a media type (string <var>inputMediaType</var>) as
-inputs, and produces an object (<var>verified</var>) that contains the
+inputs, and produces an object (<var>result</var>) that contains the
 following:
         </p>
 
         <ul>
           <li>
-a verification status (boolean <var>status</var>)
+a status (boolean <var>status</var>)
           </li>
           <li>
-a verified conforming document (object <var>document</var>)
+a conforming document (object <var>document</var>)
           </li>
           <li>
 a media type (string <var>mediaType</var>), including any media type parameters
@@ -4464,11 +4464,11 @@ The verification algorithm is as follows:
 
         <ol class="algorithm">
           <li>
-Set <var>verified</var> to an empty object.
+Set <var>result</var> to an empty object.
           </li>
           <li>
 Ensure that the securing mechanism has properly protected the
-<var>conforming document</var> by performing the following steps:
+<a>conforming document</a> by performing the following steps:
             <ol class="algorithm">
               <li>
 Set <var>securingMechanismVerified</var> to the result of executing the
@@ -4478,19 +4478,19 @@ inputs to the algorithm.
               </li>
               <li>
 Set <var>status</var>, <var>document</var>, <var>mediaType</var>,
-<var>warnings</var>, and <var>errors</var> in <var>verified</var> to their
+<var>warnings</var>, and <var>errors</var> in <var>result</var> to their
 respective properties in <var>securingMechanismVerified</var>.
               </li>
               <li>
-If <var>verified</var>.<var>status</var> is `false`, the provided
+If <var>result</var>.<var>status</var> is `false`, the provided
 <var>inputBytes</var> contains a document that cannot be considered to be
-secured. Return <var>verified</var>, which will contain warning and error
+secured. Return <var>result</var>, which will contain warning and error
 information related to the verification failure.
               </li>
             </ol>
           </li>
           <li>
-Ensure that the <var>verified</var>.<var>document</var> is a
+Ensure that the <var>result</var>.<var>document</var> is a
 <a>conforming document</a> by performing the following steps:
             <ol class="algorithm">
               <li>
@@ -4500,19 +4500,19 @@ algorithm</a> with <var>document</var> passed as input to the algorithm.
               </li>
               <li>
 Set <var>status</var>, <var>document</var>, <var>warnings</var>, and
-<var>errors</var> in <var>verified</var> to their respective properties in
+<var>errors</var> in <var>result</var> to their respective properties in
 <var>dataModelConformanceChecked</var>.
               </li>
               <li>
-If <var>verified</var>.<var>status</var> is `false`, the provided
+If <var>result</var>.<var>status</var> is `false`, the provided
 <var>inputBytes</var> contains a non-conforming document. Return
-<var>verified</var>, which will contain warning and error information
+<var>result</var>, which will contain warning and error information
 related to the verification failure.
               </li>
             </ol>
           </li>
           <li>
-Return <var>verified</var>.
+Return <var>result</var>.
           </li>
         </ol>
 
@@ -4637,7 +4637,7 @@ the "MUST" statements in Section <a href="#evidence"></a>.
           <li>
 If no errors were detected to this point, set
 <var>dataModelConformanceChecked</var>.<var>document</var> to <var>inputDocument</var>,
-<var>dataModelConformanceChecked</var>.<var>verified</var> to `true`.
+<var>dataModelConformanceChecked</var>.<var>status</var> to `true`.
           </li>
           <li>
 Return <var>dataModelConformanceChecked</var>.

--- a/index.html
+++ b/index.html
@@ -690,7 +690,7 @@ have associated media types. The concrete difference between these concepts
 credential</a> and <a>verifiable presentation</a> &mdash; is simply the fact
 that the "verifiable" objects are secured in a way that is cryptographically
 verifiable, and the others are not. For more details, see Section
-<a href="#securing-verifiable-credentials"></a>.
+<a href="#securing-mechanisms"></a>.
       </p>
 
       <section class="informative">
@@ -2051,7 +2051,7 @@ global identifier, such as a URL.
       </section>
 
       <section>
-        <h3>Securing Verifiable Credentials</h3>
+        <h3>Securing Mechanisms</h3>
 
         <p>
 A securing mechanism MUST express the details necessary to evaluate whether a
@@ -2155,6 +2155,62 @@ single proof mechanisms for use with <a>verifiable credentials</a> or
 [VC-JOSE-COSE], and the "Proofs" section of the Verifiable Credential Specifications
 Directory [[VC-SPECS]].
         </p>
+
+        <section class="normative">
+          <h2>The Verification Algorithm</h2>
+
+          <p>
+This section contains an algorithm that <a>conforming verifier processors</a>
+can run when verifying a <a>verifiable credential</a> or a <a>verifiable
+presentation</a>. Any algorithm can be used that produces output that
+is equivalent to the algorithm defined in this section. This algorithm takes a
+byte stream (<var>inputBytes</var>) and a media type (<var>inputMediaType</var>)
+as inputs, and produces an object (<var>verified</var>) that contains a
+verification status (<var>verified</var>.<var>status</var>),
+a verified document (<var>verified</var>.<var>document</var>),
+a media type (<var>verified</var>.<var>mediaType</var>), zero or more
+optional warnings (<var>verified</var>.<var>warnings</var>), and
+zero or more optional errors (<var>verified</var>.<var>errors</var>).
+          </p>
+
+          <ol class="algorithm">
+            <li>
+Set <var>verified</var> to an empty object.
+            </li>
+            <li>
+Verify that the securing mechanism in use on <var>inputBytes</var> has not been
+tampered with, using <var>inputMediaType</var> as additional input to the
+algorithm. See Section <a href="#securing-mechanisms"></a>
+for details.
+            </li>
+            <li>
+If the verification of the securing mechanism is successful, set
+<var>verified</var>.<var>status</var> to `true`,
+<var>verified</var>.<var>document</var> to the information that was secured,
+<var>verified</var>.<var>mediaType</var> to the corresponding media type,
+and optionally <var>verified</var>.<var>warnings</var> to any warning
+objects returned by the verification process for the securing mechanism.
+              <ol class="algorithm">
+                <li>
+Check whether <var>verified</var>.<var>document</var> is a
+<a>conforming document</a>. If not, optionally add appropriate warnings
+and errors to <var>verified</var>.<var>warnings</var> and
+<var>verified</var>.<var>errors</var>, respectively.
+                </li>
+              </ol>
+            </li>
+            <li>
+If verification of the securing mechanism is not successful, set
+<var>verified</var>.<var>status</var> to `false`, and optionally set
+<var>verified</var>.<var>errors</var> and
+<var>verified</var>.<var>warnings</var>, respectively, to any error and
+warning objects returned by the verification process for the securing mechanism.
+            </li>
+            <li>
+Return <var>verified</var>.
+            </li>
+          </ol>
+        </section>
 
       </section>
 
@@ -5427,7 +5483,7 @@ the <a>verifiable credential</a> itself. Linked content that exists outside a
 <a>verifiable credential</a>, such as images, JSON-LD Contexts, JSON Schemas,
 and other machine-readable data, are often not protected against tampering
 because the data resides outside of the protection of the
-<a href="#securing-verifiable-credentials">securing mechanism</a> on the
+<a href="#securing-mechanisms">securing mechanism</a> on the
 <a>verifiable credential</a>. For example, the content retrievable by
 dereferencing the following highlighted links is not integrity protected, but
 probably ought to be:
@@ -5527,7 +5583,7 @@ credential</a> data during transmission or storage.
 A <a>verifier</a> might need to ensure it is the intended recipient of a
 <a>verifiable presentation</a> and not the target of a
 <a href="https://en.wikipedia.org/wiki/Man-in-the-middle_attack">man-in-the-middle attack</a>.
-Some <a href="#securing-verifiable-credentials">securing mechanisms</a>,
+Some <a href="#securing-mechanisms">securing mechanisms</a>,
 like [[VC-JOSE-COSE]] or [[VC-DATA-INTEGRITY]], provide an option to specify
 the intended audience or domain of a <a>presentation</a>, which can help reduce
 this risk.
@@ -5647,7 +5703,7 @@ of non-repudiation mechanisms. These mechanisms solidify an <a>entity</a>'s resp
 for their actions or transactions, thereby reinforcing accountability and deterring
 malicious behaviors. The attainment of non-repudiation is a multifaceted endeavor,
 encompassing an array of techniques ranging from
-<a href="#securing-verifiable-credentials">securing mechanisms</a>, proofs of possession,
+<a href="#securing-mechanisms">securing mechanisms</a>, proofs of possession,
 and authentication schemes in a variety of protocols designed to foster trust and reliability.
         </p>
       </section>
@@ -5921,62 +5977,6 @@ identified attacks.
         </p>
       </section>
 
-    </section>
-
-    <section class="appendix normative">
-      <h2>Verification Algorithm</h2>
-
-      <p>
-This section contains an algorithm that <a>conforming verifier processors</a>
-can run when verifying a <a>verifiable credential</a> or a <a>verifiable
-presentation</a>. Any algorithm can be used that produces output that
-is equivalent to the algorithm defined in this section. This algorithm takes a
-byte stream (<var>inputBytes</var>) and a media type (<var>inputMediaType</var>)
-as inputs, and produces an object (<var>verified</var>) that contains a
-verification status (<var>verified</var>.<var>status</var>),
-a verified document (<var>verified</var>.<var>document</var>),
-a media type (<var>verified</var>.<var>mediaType</var>), zero or more
-optional warnings (<var>verified</var>.<var>warnings</var>), and
-zero or more optional errors (<var>verified</var>.<var>errors</var>).
-      </p>
-
-      <ol class="algorithm">
-        <li>
-Set <var>verified</var> to an empty object.
-        </li>
-        <li>
-Verify that the securing mechanism in use on <var>inputBytes</var> has not been
-tampered with, using <var>inputMediaType</var> as additional input to the
-algorithm. See Section <a href="#securing-verifiable-credentials"></a>
-for details.
-        </li>
-        <li>
-If the verification of the securing mechanism is successful, set
-<var>verified</var>.<var>status</var> to `true`,
-<var>verified</var>.<var>document</var> to the information that was secured,
-<var>verified</var>.<var>mediaType</var> to the corresponding media type,
-and optionally <var>verified</var>.<var>warnings</var> to any warning
-objects returned by the verification process for the securing mechanism.
-          <ol class="algorithm">
-            <li>
-Check whether <var>verified</var>.<var>document</var> is a
-<a>conforming document</a>. If not, optionally add appropriate warnings
-and errors to <var>verified</var>.<var>warnings</var> and
-<var>verified</var>.<var>errors</var>, respectively.
-            </li>
-          </ol>
-        </li>
-        <li>
-If verification of the securing mechanism is not successful, set
-<var>verified</var>.<var>status</var> to `false`, and optionally set
-<var>verified</var>.<var>errors</var> and 
-<var>verified</var>.<var>warnings</var>, respectively, to any error and
-warning objects returned by the verification process for the securing mechanism.
-        </li>
-        <li>
-Return <var>verified</var>.
-        </li>
-      </ol>
     </section>
 
     <section class="appendix informative">

--- a/index.html
+++ b/index.html
@@ -2164,8 +2164,8 @@ Directory [[VC-SPECS]].
           <p>
 This section contains an algorithm that <a>conforming verifier processors</a>
 can run when verifying a <a>verifiable credential</a> or a <a>verifiable
-presentation</a>. This algorithm takes a byte stream (<var>inputBytes</var>) and
-a media type (<var>inputMediaType</var>) as inputs, and produces an object
+presentation</a>. This algorithm takes a byte sequence (<var>inputBytes</var>)
+and a media type (<var>inputMediaType</var>) as inputs, and produces an object
 (<var>verified</var>) that contains a verification status
 (<var>verified</var>.<var>status</var>), a verified document
 (<var>verified</var>.<var>document</var>), a media type

--- a/index.html
+++ b/index.html
@@ -4729,6 +4729,26 @@ utilizing the `proof`.`type` property. A list of registered proof types can be
 found in the
 <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a>
 section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
+                <ol class="algorithm">
+                  <li>
+Set <var>securedDocument</var> to the result of a JSON parsing function that
+takes <var>inputBytes</var> as an input parameter, parses the value as JSON,
+and returns the result as an object. If JSON parsing fails,
+<var>securingMechanismVerified</var>.<var>status</var> is set to `false`, and a
+<a href="#PARSING_ERROR">PARSING_ERROR</a> is appended to
+<var>securingMechanismVerified</var>.<var>errors</var>.
+                  </li>
+                  <li>
+If <var>securedDocument</var> was successfully set in the previous step, set
+<var>securingMechanismVerified</var>.<var>status</var> to the result of passing
+<var>securedDocument</var>, along with any relevant function-specific options,
+to the <var>verifyProof</var> function. For example, the
+<var>expectedProofPurpose</var> option is set to `assertionMethod`, and if the
+<a>conforming document</a> is expected to be a
+<a>verifiable presentation</a>, the <var>domain</var> and <var>challenge</var>
+are also provided as options.
+                  </li>
+                </ol>
               </li>
               <li>
 If the <var>inputMediaType</var> is associated with the JOSE or COSE
@@ -4740,6 +4760,13 @@ The process for securing mechanism verification is not clearly documented in
 the [[?VC-JOSE-COSE]] specification yet, but once it is, a link to that section
 of the specification will be included in this text.
 </div>
+                <ol class="algorithm">
+                  <li>
+Set <var>securingMechanismVerified</var>.<var>status</var> to the
+result of passing <var>inputBytes</var>, along with any relevant
+function-specific options, to the <var>verifyProof</var> function.
+                  </li>
+                </ol>
               </li>
               <li>
 Other proof verification functions are possible, but need not be listed in
@@ -4747,18 +4774,15 @@ the <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a> section
 of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
 Implementers might find these other specifications through other standards
 bodies or communities that utilize this specification.
+                <ol class="algorithm">
+                  <li>
+Set <var>securingMechanismVerified</var>.<var>status</var> to the
+result of passing <var>inputBytes</var>, along with any relevant
+function-specific options, to the <var>verifyProof</var> function.
+                  </li>
+                </ol>
               </li>
             </ol>
-          </li>
-          <li>
-Set <var>securingMechanismVerified</var>.<var>status</var> to the
-result of passing <var>inputBytes</var>, along with any relevant function-specific
-options, to the <var>verifyProof</var> function. For example, for
-Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]] proof
-verification functions, the <var>expectedProofPurpose</var> option is set to
-`assertionMethod`, and if the <a>conforming document</a> is expected to be a
-<a>verifiable presentation</a>, the <var>domain</var> and <var>challenge</var>
-are also provided as options.
           </li>
           <li>
 If <var>securingMechanismVerified</var>.<var>status</var> is set to

--- a/index.html
+++ b/index.html
@@ -5927,17 +5927,17 @@ identified attacks.
       <h2>Verification Algorithm</h2>
 
       <p>
-This section contains the algorithm that <a>conforming verifier processors</a>
-run when verifying a <a>verifiable credential</a> or a <a>verifiable
+This section contains an algorithm that <a>conforming verifier processors</a>
+can run when verifying a <a>verifiable credential</a> or a <a>verifiable
 presentation</a>. Any algorithm can be used that produces output that
-is equivalent to the algorithm defined in this section. The algorithm takes a
-byte stream (<var>inputBytes</var>) and media type (<var>inputMediaType</var>)
-as input and produces an object (<var>verified</var>) that contains a
+is equivalent to the algorithm defined in this section. This algorithm takes a
+byte stream (<var>inputBytes</var>) and a media type (<var>inputMediaType</var>)
+as inputs, and produces an object (<var>verified</var>) that contains a
 verification status (<var>verified</var>.<var>status</var>),
-verified document (<var>verified</var>.<var>document</var>),
-media type (<var>verified</var>.<var>mediaType</var>),
-and optional warning  (<var>verified</var>.<var>warnings</var>) and
-error (<var>verified</var>.<var>errors</var>) information.
+a verified document (<var>verified</var>.<var>document</var>),
+a media type (<var>verified</var>.<var>mediaType</var>), zero or more
+optional warnings (<var>verified</var>.<var>warnings</var>), and
+zero or more optional errors (<var>verified</var>.<var>errors</var>).
       </p>
 
       <ol class="algorithm">
@@ -5954,25 +5954,24 @@ for details.
 If the verification of the securing mechanism is successful, set
 <var>verified</var>.<var>status</var> to `true`,
 <var>verified</var>.<var>document</var> to the information that was secured,
-and <var>verified</var>.<var>mediaType</var> to the corresponding media type,
-and optionally set <var>verified</var>.<var>warnings</var> to any warning
+<var>verified</var>.<var>mediaType</var> to the corresponding media type,
+and optionally <var>verified</var>.<var>warnings</var> to any warning
 objects returned by the verification process for the securing mechanism.
           <ol class="algorithm">
             <li>
-Ensure that <var>verified</var>.<var>document</var> is a
-<a>conforming document</a>, and if not, optionally add appropriate warnings
+Check whether <var>verified</var>.<var>document</var> is a
+<a>conforming document</a>. If not, optionally add appropriate warnings
 and errors to <var>verified</var>.<var>warnings</var> and
 <var>verified</var>.<var>errors</var>, respectively.
             </li>
           </ol>
         </li>
         <li>
-If the verification of the securing mechanism is not successful, set
+If verification of the securing mechanism is not successful, set
 <var>verified</var>.<var>status</var> to `false`, and optionally set
-<var>verified</var>.<var>errors</var> to any error objects returned by the
-verification process for the securing mechanism and
-<var>verified</var>.<var>warnings</var> to any warning objects returned by the
-verification process for the securing mechanism.
+<var>verified</var>.<var>errors</var> and 
+<var>verified</var>.<var>warnings</var>, respectively, to any error and
+warning objects returned by the verification process for the securing mechanism.
         </li>
         <li>
 Return <var>verified</var>.

--- a/index.html
+++ b/index.html
@@ -4519,8 +4519,9 @@ Return <var>verified</var>.
         <p>
 The steps for verifying the state of the securing mechanism and verifying
 that the input document is a <a>conforming document</a> MAY be performed in
-a different order than the one provided above as long as the different
-order results in the same errors being produced on invalid inputs.
+a different order than the one provided above as long as the
+implementation returns errors for the same inputs.
+Implementations MAY produce different errors than described above.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -601,7 +601,9 @@ A <dfn class="lint-ignore">conforming issuer implementation</dfn> produces
 <a>conforming documents</a>, MUST include all required properties in the
 <a>conforming documents</a> that it produces, and MUST secure the <a>conforming
 documents</a> it produces using a securing mechanism as described in Section
-<a href="#securing-verifiable-credentials"></a>.
+<a href="#securing-verifiable-credentials"></a>. Conformance requirements
+phrased as algorithms or specific steps MAY be implemented in any manner, so
+long as the end result is equivalent.
         </p>
 
         <p>
@@ -2162,15 +2164,14 @@ Directory [[VC-SPECS]].
           <p>
 This section contains an algorithm that <a>conforming verifier processors</a>
 can run when verifying a <a>verifiable credential</a> or a <a>verifiable
-presentation</a>. Any algorithm can be used that produces output that
-is equivalent to the algorithm defined in this section. This algorithm takes a
-byte stream (<var>inputBytes</var>) and a media type (<var>inputMediaType</var>)
-as inputs, and produces an object (<var>verified</var>) that contains a
-verification status (<var>verified</var>.<var>status</var>),
-a verified document (<var>verified</var>.<var>document</var>),
-a media type (<var>verified</var>.<var>mediaType</var>), zero or more
-optional warnings (<var>verified</var>.<var>warnings</var>), and
-zero or more optional errors (<var>verified</var>.<var>errors</var>).
+presentation</a>. This algorithm takes a byte stream (<var>inputBytes</var>) and
+a media type (<var>inputMediaType</var>) as inputs, and produces an object
+(<var>verified</var>) that contains a verification status
+(<var>verified</var>.<var>status</var>), a verified document
+(<var>verified</var>.<var>document</var>), a media type
+(<var>verified</var>.<var>mediaType</var>), zero or more optional warnings
+(<var>verified</var>.<var>warnings</var>), and zero or more optional errors
+(<var>verified</var>.<var>errors</var>).
           </p>
 
           <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -4532,7 +4532,7 @@ zero or more errors (array of <a>ProblemDetails</a> <var>errors</var>)
         </ul>
 
         <p>
-The verification algorithm is as follows:
+The data model verification algorithm is as follows:
         </p>
 
         <ol class="algorithm">
@@ -4548,9 +4548,10 @@ statements in <a href="#contexts"></a>. If not, return
           </li>
           <li>
 Starting at the top level, recursively process each object <var>obj</var> in
-<var>document</var>, setting <a href="#MALFORMED_VALUE">MALFORMED_VALUE</a>
-errors in <var>dataModelVerified</var>.<var>errors</var> if errors are found,
-by performing the following checks:
+<var>document</var>, setting <a href="#MALFORMED_VALUE_ERROR">
+MALFORMED_VALUE_ERROR</a> errors in
+<var>dataModelVerified</var>.<var>errors</var> if errors are found, by
+performing the following checks:
             <ol class="algorithm">
               <li>
 If present, ensure that the `id` property conforms to the statements in
@@ -4654,6 +4655,9 @@ a verification status (boolean <var>status</var>)
 a verified document (object <var>document</var>)
           </li>
           <li>
+a media type (string <var>mediaType</var>)
+          </li>
+          <li>
 zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)
           </li>
           <li>
@@ -4664,32 +4668,94 @@ zero or more errors (array of <a>ProblemDetails</a> <var>errors</var>)
         <p>
 The securing mechanism verification algorithm is as follows:
         </p>
+
         <ol class="algorithm">
           <li>
-Set <var>securingMechanismVerified</var> to an empty object.
+Set <var>securingMechanismVerified</var> to an empty object and initialize the
+following fields: <var>status</var> to `false`, <var>warnings</var> to an
+empty array, and <var>errors</var> to an empty array.
           </li>
           <li>
-If the verification of the securing mechanism is successful:
+Determine the specific mechanism for extracting the <a>conforming document</a>
+(<var>extractDocument</var>):
             <ol class="algorithm">
-              <li>Set the following:
-                <ol class="algorithm">
-                  <li>
-<var>verified</var>.<var>status</var> to `true`
-                  </li>
-                  <li>
-<var>verified</var>.<var>document</var> to the information that was checked and
-returned as successfully protected by the verification process for the securing
-mechanism
-                  </li>
-                  <li>
-<var>verified</var>.<var>mediaType</var> to the corresponding
-media type
-                  </li>
-                  <li>
-<var>verified</var>.<var>warnings</var> optionally to any warnings returned by
-the verification process for the securing mechanism
-                  </li>
-                </ol>
+              <li>
+If the <var>inputMediaType</var> is `application/vc+ld+json` or
+`application/vp+ld+json`, the <var>extractDocument</var> function takes
+<var>inputBytes</var> as an input parameter, parses the value as JSON,
+and returns the result as an object. If JSON parsing fails, a
+<a href="#PARSING_ERROR">PARSING_ERROR</a> is appended to
+<var>securingMechanismVerified</var>.<var>errors</var>.
+              </li>
+              <li>
+If the <var>inputMediaType</var> is associated with the JOSE or COSE
+specifications, the [[?VC-JOSE-COSE]] specification defines a process for
+extracting the <a>conforming document</a>.
+              </li>
+              <li>
+Other extracting functions are possible, but need not be listed in
+the <a data-cite="?VC-SPECS#media-type-extensions">Media Type Extensions</a>
+section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
+Implementers might find these other specifications through other standards
+bodies or communities that utilize this specification.
+              </li>
+            </ol>
+          </li>
+          <li>
+Determine the specific cryptographic verification algorithm
+(<var>verifyProof</var>) required to verify the securing mechanism:
+            <ol class="algorithm">
+              <li>
+If the <var>inputMediaType</var> is `application/vc+ld+json` or
+`application/vp+ld+json`, the Verifiable Credential Data Integrity
+Specification [[?VC-DATA-INTEGRITY]] defines the process for identifying
+a specific cryptography suite type used for cryptographic verification by
+utilizing the `proof`.`type` property. The list of all registered
+proof types can be found in the <a data-cite="?VC-SPECS#proof">Proof Types</a>
+section of the Verifiable Credentials Specifications Directory [[?VC-SPECS]].
+              </li>
+              <li>
+If the <var>inputMediaType</var> is associated with the JOSE or COSE
+specifications, the [[?VC-JOSE-COSE]] specification defines a process for
+identification of a specific cryptography suite and cryptographic verification
+process.
+              </li>
+              <li>
+Other proof verification functions are possible, but need not be listed in
+the <a data-cite="?VC-SPECS#proof">Proof Types</a> section of the
+Verifiable Credentials Specifications Directory [[?VC-SPECS]].
+Implementers might find these other specifications through other standards
+bodies or communities that utilize this specification.
+              </li>
+            </ol>
+          </li>
+          <li>
+Set <var>securingMechanismVerified</var>.<var>status</var> to the
+result of passing <var>inputBytes</var> to the <var>verifyProof</var> function
+as well as any relevant function-specific options. For example, for
+Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]] proof
+verification functions, the <var>expectedProofPurpose</var> option is set to
+`assertionMethod` and if the <a>conforming document</a> is expected to be a
+<a>verifiable presentation</a>, the <var>domain</var> and <var>challenge</var>
+are also provided options.
+          </li>
+          <li>
+If <var>securingMechanismVerified</var>.<var>status</var> is set to
+`false`, add a <a href="#CRYPTOGRAPHIC_SECURITY_ERROR">
+  CRYPTOGRAPHIC_SECURITY_ERROR</a> to
+<var>securingMechanismVerified</var>.<var>errors</var>.
+          </li>
+          <li>
+If <var>securingMechanismVerified</var>.<var>status</var> is set to
+`true`:
+            <ol class="algorithm">
+              <li>
+Set <var>securingMechanismVerified</var>.<var>document</var> by passing
+<var>inputBytes</var> to the <var>extractDocument</var> function.
+              </li>
+              <li>
+Set <var>securingMechanismVerified</var>.<var>mediaType</var> to the media type
+associated with <var>securingMechanismVerified</var>.<var>document</var>.
               </li>
             </ol>
           </li>
@@ -4748,14 +4814,33 @@ specification:
         </p>
 
         <dl>
-          <dt id="MALFORMED_VALUE">
-https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE
+          <dt id="PARSING_ERROR">
+https://www.w3.org/TR/vc-data-model#PARSING_ERROR
 (-64)
+          </dt>
+          <dd>
+There was an error while parsing input. See Section
+<a href="#verify-securing-mechanism"></a>.
+          </dd>
+          <dt id="CRYPTOGRAPHIC_SECURITY_ERROR">
+https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR
+(-65)
+          </dt>
+          <dd>
+The securing mechanism for the document has detected a
+modification to the contents of the document since it was created;
+potential tampering detected. See Section
+<a href="#verify-securing-mechanism"></a>.
+          </dd>
+          <dt id="MALFORMED_VALUE_ERROR">
+https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE_ERROR
+(-66)
           </dt>
           <dd>
 The value associated with a particular <a>property</a> is malformed. The
 name of the <a>property</a> and the path to the property SHOULD be provided
-in the <a>ProblemDetails</a> object. See Section <a href="#verification"></a>.
+in the <a>ProblemDetails</a> object. See Section
+<a href="#verify-data-model"></a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -4448,7 +4448,7 @@ a verification status (boolean <var>status</var>)
 a verified conforming document (object <var>document</var>)
           </li>
           <li>
-a media type (string <var>mediaType</var>)
+a media type (string <var>mediaType</var>), including any media type parameters
           </li>
           <li>
 zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)

--- a/index.html
+++ b/index.html
@@ -2166,13 +2166,25 @@ This section contains an algorithm that <a>conforming verifier processors</a>
 can run when verifying a <a>verifiable credential</a> or a <a>verifiable
 presentation</a>. This algorithm takes a byte sequence (bytes
 <var>inputBytes</var>) and a media type (string <var>inputMediaType</var>) as
-inputs, and produces an object (<var>verified</var>) that contains a
-verification status (boolean <var>verified</var>.<var>status</var>), a verified
-document (object <var>verified</var>.<var>document</var>), a media type (string
-<var>verified</var>.<var>mediaType</var>), zero or more optional warnings (array
-of <a>anomalyDescriptions</a> <var>verified</var>.<var>warnings</var>), and zero
-or more optional errors (array of <a>anomalyDescriptions</a>
-<var>verified</var>.<var>errors</var>).
+inputs, and produces an object (<var>verified</var>) that contains the following:
+          </p>
+          <ul>
+            <li>
+a verification status (boolean <var>verified</var>.<var>status</var>)
+            </li>
+            <li>
+a verified document (object <var>verified</var>.<var>document</var>)
+            </li>
+            <li>
+a media type (string <var>verified</var>.<var>mediaType</var>)
+            </li>
+            <li>
+zero or more optional warnings (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>warnings</var>)
+            </li>
+            <li>
+zero or more optional errors (array of <a>anomalyDescriptions</a> <var>verified</var>.<var>errors</var>)
+            </li>
+          </ul>
           </p>
 
           <ol class="algorithm">

--- a/index.html
+++ b/index.html
@@ -4420,11 +4420,11 @@ perform common operations.
       <p class="note" title="Implementers can include additional checks, warnings, and errors.">
 Implementers are advised that the algorithms in this section contain the bare
 minimum set of checks used by implementations to test conformance to this
-specification. Additional checks that report helpful warnings for developers to
-help debug potential issues are expected to be provided by implementations.
-Similarly, additional checks that could result in new types of errors being
-reported in order to stop harmful content are also expected to be provided by
-implementations. Any of these additional checks might be integrated into future
+specification. Implementations are expected to provide additional checks that
+report helpful warnings for developers to help debug potential issues.
+Similarly, implementations are likely to provide additional checks that
+could result in new types of errors being reported in order to stop harmful
+content. Any of these additional checks might be integrated into future
 versions of this specification.
       </p>
 

--- a/index.html
+++ b/index.html
@@ -4445,7 +4445,7 @@ following:
 a status (boolean <var>status</var>)
           </li>
           <li>
-a conforming document (object <var>document</var>)
+a <a>conforming document</a> (object <var>document</var>)
           </li>
           <li>
 a media type (string <var>mediaType</var>), including any media type parameters

--- a/index.html
+++ b/index.html
@@ -4417,6 +4417,17 @@ This section contains algorithms that can be used by implementations to
 perform common operations.
       </p>
 
+      <p class="note" title="Implementers can include additional checks, warnings, and errors.">
+Implementers are advised that the algorithms in this section contain the bare
+minimum set of checks used by implementations to test conformance to this
+specification. Additional checks that report helpful warnings for developers to
+help debug potential issues are expected to be provided by implementations.
+Similarly, additional checks that could result in new types of errors being
+reported in order to stop harmful content are also expected to be provided by
+implementations, which might be integrated into future versions of this
+specification.
+      </p>
+
       <section class="normative">
         <h3>Verification</h3>
 
@@ -4623,16 +4634,6 @@ If no errors were detected to this point, set
 Return <var>dataModelVerified</var>.
           </li>
         </ol>
-
-        <p class="note" title="Additional checks are expected">
-Implementers are advised that the checks in this section are the bare minimum
-set of tests to conform to this specification. Other checks that create helpful
-warnings for developers to help debug potential issues are expected to be
-provided by implementations. Additional checks that could result in new types of
-errors being detected to stop harmful content are also expected to be provided
-by implementations, which might be integrated into future versions of this
-specification.
-        </p>
 
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2231,7 +2231,7 @@ If verification of the securing mechanism is not successful, set
 <var>verified</var>.<var>status</var> to `false`, and optionally set
 <var>verified</var>.<var>errors</var> and
 <var>verified</var>.<var>warnings</var>, respectively, to any error and
-warnings returned by the verification process for the securing mechanism.
+warnings returned by the verification process for the securing mechanism. At least one error MUST be populated.
             </li>
             <li>
 Return <var>verified</var>.

--- a/index.html
+++ b/index.html
@@ -4735,6 +4735,11 @@ If the <var>inputMediaType</var> is associated with the JOSE or COSE
 specifications, the [[?VC-JOSE-COSE]] specification defines a process for
 identification of a specific cryptography suite and cryptographic verification
 process.
+<div class="issue" title="Document verification process in vc-jose-cose">
+The process for securing mechanism verification is not clearly documented in
+the [[?VC-JOSE-COSE]] specification yet, but once it is, a link to that section
+of the specification will be included in this text.
+</div>
               </li>
               <li>
 Other proof verification functions are possible, but need not be listed in

--- a/index.html
+++ b/index.html
@@ -4720,7 +4720,7 @@ Determine the specific cryptographic verification algorithm
 If the <var>inputMediaType</var> is `application/vc+ld+json` or
 `application/vp+ld+json`, the Verifiable Credential Data Integrity
 Specification [[?VC-DATA-INTEGRITY]] defines the
-<a data-cite="VC-DATA-INTEGRITY#verify-proof">process for identifying
+<a data-cite="?VC-DATA-INTEGRITY#verify-proof">process for identifying
 a specific cryptography suite type</a> used for cryptographic verification by
 utilizing the `proof`.`type` property. A list of registered proof types can be
 found in the

--- a/index.html
+++ b/index.html
@@ -4431,13 +4431,97 @@ following:
 
         <ul>
           <li>
+a verification status (boolean <var>status</var>)
+          </li>
+          <li>
+a verified document (object <var>document</var>)
+          </li>
+          <li>
+a media type (string <var>mediaType</var>)
+          </li>
+          <li>
+zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)
+          </li>
+          <li>
+zero or more errors (array of <a>ProblemDetails</a> <var>errors</var>)
+          </li>
+        </ul>
+
+        <p>
+The verification algorithm is as follows:
+        </p>
+
+        <ol class="algorithm">
+          <li>
+Set <var>verified</var> to an empty object.
+          </li>
+          <li>
+Ensure that the securing mechanism has properly protected the
+<var>conforming document</var> by performing the following steps:
+            <ol class="algorithm">
+              <li>
+Set <var>securingMechanismVerified</var> to the result of executing the
+<a href="#verify-securing-mechanism">securing mechanism verification
+algorithm</a> with <var>inputBytes</var> and <var>mediaType</var> passed as
+input to the algorithm.
+              </li>
+              <li>
+Set <var>status</var>, <var>document</var>, <var>mediaType</var>,
+<var>warnings</var>, and <var>errors</var> in <var>verified</var> to the
+associated properties in <var>securingMechanismVerified</var>.
+              </li>
+              <li>
+If <var>verified</var>.<var>status</var> is `false`, the provided
+<var>inputBytes</var> contains a document that cannot be considered to be
+secured; return <var>verified</var>, which will contain warning and error
+information related to the verification failure.
+              </li>
+            </ol>
+          </li>
+          <li>
+Ensure that the <var>verified</var>.<var>document</var> is a
+<a>conforming document</a> by performing the following steps:
+            <ol class="algorithm">
+              <li>
+Set <var>dataModelVerified</var> to the result of executing the
+<a href="#verify-data-model">data model verification algorithm</a>
+with <var>document</var> passed as input to the algorithm.
+              </li>
+              <li>
+Set <var>status</var>, <var>document</var>, <var>warnings</var>, and
+<var>errors</var> in <var>verified</var> to the associated properties in
+<var>dataModelVerified</var>.
+              </li>
+              <li>
+If <var>verified</var>.<var>status</var> is `false`, the provided
+<var>inputBytes</var> contains a non-conforming document; return
+<var>verified</var>, which will contain warning and error information
+related to the verification failure.
+              </li>
+            </ol>
+          </li>
+          <li>
+Return <var>verified</var>.
+          </li>
+        </ol>
+      </section>
+
+      <section class="normative">
+        <h3>Verify Data Model</h3>
+
+        <p>
+The algorithm in this section can be used to determine if a provided document is
+conformant to the data model provided in this specification. This algorithm
+takes a document (object <var>document</var>) and produces an object
+(<var>dmVerified</var>) that contains the following:
+        </p>
+
+        <ul>
+          <li>
 a verification status (boolean <var>verified</var>.<var>status</var>)
           </li>
           <li>
 a verified document (object <var>verified</var>.<var>document</var>)
-          </li>
-          <li>
-a media type (string <var>verified</var>.<var>mediaType</var>)
           </li>
           <li>
 zero or more optional warnings (array of <a>ProblemDetails</a>
@@ -4452,16 +4536,51 @@ zero or more optional errors (array of <a>ProblemDetails</a>
         <p>
 The verification algorithm is as follows:
         </p>
-
         <ol class="algorithm">
           <li>
 Set <var>verified</var> to an empty object.
           </li>
           <li>
-Verify that the securing mechanism in use on <var>inputBytes</var> has not been
-tampered with, using <var>inputMediaType</var> as additional input to the
-algorithm. See Section <a href="#securing-mechanisms"></a>
-for details.
+Return <var>dmVerified</var>.
+          </li>
+        </ol>
+
+      </section>
+
+      <section class="normative">
+        <h3>Verify Securing Mechanism</h3>
+
+        <p>
+The algorithm in this section can be used to verify if a securing mechanism
+that is associated with a sequence of bytes is valid. This algorithm takes a
+byte sequence (bytes <var>inputBytes</var>) and a media type
+(string <var>inputMediaType</var>) as inputs, and produces an object
+(<var>smVerified</var>) that contains the following:
+        </p>
+
+        <ul>
+          <li>
+a verification status (boolean <var>verified</var>.<var>status</var>)
+          </li>
+          <li>
+a verified document (object <var>verified</var>.<var>document</var>)
+          </li>
+          <li>
+zero or more optional warnings (array of <a>ProblemDetails</a>
+<var>verified</var>.<var>warnings</var>)
+          </li>
+          <li>
+zero or more optional errors (array of <a>ProblemDetails</a>
+<var>verified</var>.<var>errors</var>)
+          </li>
+        </ul>
+
+        <p>
+The securing mechanism verification algorithm is as follows:
+        </p>
+        <ol class="algorithm">
+          <li>
+Set <var>smVerified</var> to an empty object.
           </li>
           <li>
 If the verification of the securing mechanism is successful:
@@ -4486,25 +4605,13 @@ the verification process for the securing mechanism
                   </li>
                 </ol>
               </li>
-              <li>
-Check whether <var>verified</var>.<var>document</var> is a
-<a>conforming document</a>. If not, optionally add appropriate warnings
-and errors to <var>verified</var>.<var>warnings</var> and
-<var>verified</var>.<var>errors</var>, respectively.
-              </li>
             </ol>
           </li>
           <li>
-If verification of the securing mechanism is not successful, set
-<var>verified</var>.<var>status</var> to `false`, and optionally set
-<var>verified</var>.<var>errors</var> and
-<var>verified</var>.<var>warnings</var>, respectively, to any error and
-warnings returned by the verification process for the securing mechanism. At least one error MUST be populated.
-          </li>
-          <li>
-Return <var>verified</var>.
+Return <var>smVerified</var>.
           </li>
         </ol>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -4504,27 +4504,27 @@ Return <var>verified</var>.
       </section>
 
       <section>
-        <h3>Anomaly Descriptions</h3>
+        <h3>Problem Details</h3>
 
         <p>
-When an anomaly is detected by a <a>conforming processor</a>, an
-<dfn>anomalyDescription</dfn> is used to report the issue to software that
-invoked the process that led to the anomaly.
-The interface for these objects follows [[RFC9457]] to encode the data. An
-<a>anomalyDescription</a> object consists of the following properties:
+When an implementation detects an anomaly while processing a document, a
+<dfn>ProblemDetail</dfn> can be used to report the issue to other software
+systems. The interface for these objects follows [[RFC9457]] to encode the data.
+An <a>ProblemDetail</a> object consists of the following properties:
         </p>
 
         <dl>
           <dt>type</dt>
           <dd>
 The `type` <a>property</a> MUST be present and its value MUST be a <a>URL</a>
-identifying the type of the anomaly.
+identifying the type of problem.
           </dd>
           <dt>code</dt>
           <dd>
-The `code` <a>property</a> is OPTIONAL. If present, its value MUST be an integer
-that identifies the type of the anomaly. Integer codes are useful in systems
-that only provide integer return values.
+The `code` <a>property</a> is an OPTIONAL
+<a data-cite="RFC9457#name-extension-members">RFC9457 extension member</a> . If
+present, its value MUST be an integer that identifies the type of the anomaly.
+Integer codes are useful in systems that only provide integer return values.
           </dd>
           <dt>title</dt>
           <dd>
@@ -4540,7 +4540,7 @@ longer human-readable string for the anomaly.
 
         <p>
 Other properties that are useful for debugging purposes MAY be included in
-an <a>anomalyDescription</a> object.
+a <a>ProblemDescription</a> object. See [[RFC9457]] for further details.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -4515,6 +4515,14 @@ related to the verification failure.
 Return <var>verified</var>.
           </li>
         </ol>
+
+        <p>
+The steps for verifying the state of the securing mechanism and verifying
+that the input document is a <a>conforming document</a> MAY be performed in
+a different order than the one provided above as long as the different
+order results in the same errors being produced on invalid inputs.
+        </p>
+
       </section>
 
       <section class="normative">

--- a/index.html
+++ b/index.html
@@ -4417,6 +4417,18 @@ This section contains algorithms that can be used by implementations to
 perform common operations.
       </p>
 
+      <p class="issue atrisk" title="Issues need resolution before Candidate Recommendation">
+There are multiple issues that are associated with this section that will need
+to be resolved before the Working Group can enter the Candidate Recommendation
+phase. This entire section is at risk until those issues are resolved.
+      </p>
+
+      <p class="issue" data-number="1374"></p>
+      <p class="issue" data-number="1375"></p>
+      <p class="issue" data-number="1376"></p>
+      <p class="issue" data-number="1377"></p>
+      <p class="issue" data-number="1378"></p>
+
       <p class="note" title="Implementers can include additional checks, warnings, and errors.">
 Implementers are advised that the algorithms in this section contain the bare
 minimum set of checks used by implementations to test conformance to this

--- a/index.html
+++ b/index.html
@@ -2198,13 +2198,25 @@ algorithm. See Section <a href="#securing-mechanisms"></a>
 for details.
             </li>
             <li>
-If the verification of the securing mechanism is successful, set
-<var>verified</var>.<var>status</var> to `true`,
+If the verification of the securing mechanism is successful, set the following:
+              <ul>
+                <li>
+<var>verified</var>.<var>status</var> to `true`
+                </li>
+                <li>
 <var>verified</var>.<var>document</var> to the information that was checked and
 returned as successfully protected by the verification process for the securing
-mechanism as, <var>verified</var>.<var>mediaType</var> to the corresponding
-media type, and optionally <var>verified</var>.<var>warnings</var> to any
-warnings returned by the verification process for the securing mechanism.
+mechanism
+                </li>
+                <li>
+<var>verified</var>.<var>mediaType</var> to the corresponding
+media type
+                </li>
+                <li>
+<var>verified</var>.<var>warnings</var> optionally to any warnings returned by
+the verification process for the securing mechanism
+                </li>
+              </ul>
               <ol class="algorithm">
                 <li>
 Check whether <var>verified</var>.<var>document</var> is a

--- a/index.html
+++ b/index.html
@@ -4433,7 +4433,7 @@ versions of this specification.
 
         <p>
 This section contains an algorithm that <a>conforming verifier
-implementations</a> can run when verifying a <a>verifiable credential</a> or a
+implementations</a> MUST run when verifying a <a>verifiable credential</a> or a
 <a>verifiable presentation</a>. This algorithm takes a byte sequence (bytes
 <var>inputBytes</var>) and a media type (string <var>inputMediaType</var>) as
 inputs, and produces an object (<var>verified</var>) that contains the

--- a/index.html
+++ b/index.html
@@ -4424,8 +4424,8 @@ specification. Additional checks that report helpful warnings for developers to
 help debug potential issues are expected to be provided by implementations.
 Similarly, additional checks that could result in new types of errors being
 reported in order to stop harmful content are also expected to be provided by
-implementations, which might be integrated into future versions of this
-specification.
+implementations. Any of these additional checks might be integrated into future
+versions of this specification.
       </p>
 
       <section class="normative">
@@ -4474,7 +4474,7 @@ Ensure that the securing mechanism has properly protected the
 Set <var>securingMechanismVerified</var> to the result of executing the
 <a href="#verify-securing-mechanism">securing mechanism verification
 algorithm</a> with <var>inputBytes</var> and <var>mediaType</var> passed as
-input to the algorithm.
+inputs to the algorithm.
               </li>
               <li>
 Set <var>status</var>, <var>document</var>, <var>mediaType</var>,
@@ -4484,7 +4484,7 @@ respective properties in <var>securingMechanismVerified</var>.
               <li>
 If <var>verified</var>.<var>status</var> is `false`, the provided
 <var>inputBytes</var> contains a document that cannot be considered to be
-secured; return <var>verified</var>, which will contain warning and error
+secured. Return <var>verified</var>, which will contain warning and error
 information related to the verification failure.
               </li>
             </ol>
@@ -4505,7 +4505,7 @@ Set <var>status</var>, <var>document</var>, <var>warnings</var>, and
               </li>
               <li>
 If <var>verified</var>.<var>status</var> is `false`, the provided
-<var>inputBytes</var> contains a non-conforming document; return
+<var>inputBytes</var> contains a non-conforming document. Return
 <var>verified</var>, which will contain warning and error information
 related to the verification failure.
               </li>
@@ -4573,7 +4573,7 @@ If present, ensure that the `type` property conforms to the statements in
 Section <a href="#types"></a>.
               </li>
               <li>
-If present, ensure that the `name` and `description` properties conform to the
+If present, ensure that the `name` and/or `description` properties conform to the
 statements in Section <a href="#names-and-descriptions"></a>.
               </li>
               <li>
@@ -4598,7 +4598,7 @@ Ensure that the `issuer` property conforms to the
 statements in Section <a href="#issuer"></a>.
                   </li>
                   <li>
-If present, ensure that the `validFrom` and `validUntil` properties conform to
+If present, ensure that the `validFrom` and/or `validUntil` properties conform to
 the statements in Section <a href="#validity-period"></a>.
                   </li>
                   <li>
@@ -4641,7 +4641,7 @@ Return <var>dataModelVerified</var>.
         <h3>Verify Securing Mechanism</h3>
 
         <p>
-The algorithm in this section can be used to verify if a securing mechanism
+The algorithm in this section can be used to verify whether a securing mechanism
 that is associated with a sequence of bytes is valid. This algorithm takes a
 byte sequence (bytes <var>inputBytes</var>) and a media type
 (string <var>inputMediaType</var>) as inputs, and produces an object
@@ -4732,13 +4732,13 @@ bodies or communities that utilize this specification.
           </li>
           <li>
 Set <var>securingMechanismVerified</var>.<var>status</var> to the
-result of passing <var>inputBytes</var> to the <var>verifyProof</var> function
-as well as any relevant function-specific options. For example, for
+result of passing <var>inputBytes</var>, along with any relevant function-specific
+options, to the <var>verifyProof</var> function. For example, for
 Verifiable Credential Data Integrity [[?VC-DATA-INTEGRITY]] proof
 verification functions, the <var>expectedProofPurpose</var> option is set to
-`assertionMethod` and if the <a>conforming document</a> is expected to be a
+`assertionMethod`, and if the <a>conforming document</a> is expected to be a
 <a>verifiable presentation</a>, the <var>domain</var> and <var>challenge</var>
-are also provided options.
+are also provided as options.
           </li>
           <li>
 If <var>securingMechanismVerified</var>.<var>status</var> is set to

--- a/index.html
+++ b/index.html
@@ -4494,14 +4494,14 @@ Ensure that the <var>verified</var>.<var>document</var> is a
 <a>conforming document</a> by performing the following steps:
             <ol class="algorithm">
               <li>
-Set <var>dataModelVerified</var> to the result of executing the
-<a href="#verify-data-model">data model verification algorithm</a>
-with <var>document</var> passed as input to the algorithm.
+Set <var>dataModelConformanceChecked</var> to the result of executing the
+<a href="#data-model-conformance-checking">data model conformance checking
+algorithm</a> with <var>document</var> passed as input to the algorithm.
               </li>
               <li>
 Set <var>status</var>, <var>document</var>, <var>warnings</var>, and
 <var>errors</var> in <var>verified</var> to their respective properties in
-<var>dataModelVerified</var>.
+<var>dataModelConformanceChecked</var>.
               </li>
               <li>
 If <var>verified</var>.<var>status</var> is `false`, the provided
@@ -4527,13 +4527,13 @@ Implementations MAY produce different errors than described above.
       </section>
 
       <section class="normative">
-        <h3>Verify Data Model</h3>
+        <h3>Data Model Conformance Checking</h3>
 
         <p>
 The algorithm in this section can be used to determine if a provided document is
 conformant to the data model provided in this specification. This algorithm
 takes a document (object <var>inputDocument</var>) and produces an object
-(<var>dataModelVerified</var>) that contains the following:
+(<var>dataModelConformanceChecked</var>) that contains the following:
         </p>
 
         <ul>
@@ -4557,20 +4557,20 @@ The data model verification algorithm is as follows:
 
         <ol class="algorithm">
           <li>
-Set <var>dataModelVerified</var> to an empty object. Initialize the following
-fields in <var>dataModelVerified</var>: <var>status</var> to `false`,
+Set <var>dataModelConformanceChecked</var> to an empty object. Initialize the following
+fields in <var>dataModelConformanceChecked</var>: <var>status</var> to `false`,
 <var>warnings</var> to an empty array, and <var>errors</var> to an empty array.
           </li>
           <li>
 Ensure that the `@context` property of <var>document</var> conforms to the
 statements in <a href="#contexts"></a>. If not, return
-<var>dataModelVerified</var>, which will contain a false verification status.
+<var>dataModelConformanceChecked</var>, which will contain a false verification status.
           </li>
           <li>
 Starting at the top level, recursively process each object <var>obj</var> in
 <var>document</var>, setting <a href="#MALFORMED_VALUE_ERROR">
 MALFORMED_VALUE_ERROR</a> errors in
-<var>dataModelVerified</var>.<var>errors</var> if errors are found, by
+<var>dataModelConformanceChecked</var>.<var>errors</var> if errors are found, by
 performing the following checks:
             <ol class="algorithm">
               <li>
@@ -4636,11 +4636,11 @@ the "MUST" statements in Section <a href="#evidence"></a>.
           </li>
           <li>
 If no errors were detected to this point, set
-<var>dataModelVerified</var>.<var>document</var> to <var>inputDocument</var>,
-<var>dataModelVerified</var>.<var>verified</var> to `true`.
+<var>dataModelConformanceChecked</var>.<var>document</var> to <var>inputDocument</var>,
+<var>dataModelConformanceChecked</var>.<var>verified</var> to `true`.
           </li>
           <li>
-Return <var>dataModelVerified</var>.
+Return <var>dataModelConformanceChecked</var>.
           </li>
         </ol>
 
@@ -4888,7 +4888,7 @@ https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE_ERROR
 The value associated with a particular <a>property</a> is malformed. The
 name of the <a>property</a> and the path to the property SHOULD be provided
 in the <a>ProblemDetails</a> object. See Section
-<a href="#verify-data-model"></a>.
+<a href="#data-model-conformance-checking"></a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -5911,6 +5911,30 @@ identified attacks.
 
     </section>
 
+    <section class="appendix normative">
+      <h2>Verification</h2>
+
+      <p>
+This section contains the algorithm that conforming verifiers run when verifying
+a <a>verifiable credential</a> or a <a>verifiable presentation</a>. The
+algorithm takes a <a>conforming document</a> (<var>document</var>) as input and
+produces an object <var>result</var> that contains a verification result and
+optional warning and error information.
+      </p>
+
+      <ol class="algorithm">
+        <li>
+
+        </li>
+        <li>
+
+        </li>
+        <li>
+
+        </li>
+      </ol>
+    </section>
+
     <section class="appendix informative">
       <h2>Validation</h2>
 

--- a/index.html
+++ b/index.html
@@ -4573,25 +4573,25 @@ MALFORMED_VALUE_ERROR</a> errors in
 performing the following checks:
             <ol class="algorithm">
               <li>
-If present, ensure that the `id` property conforms to the statements in
+If present, ensure that the `id` property conforms to the "MUST" statements in
 Section <a href="#identifiers"></a>.
               </li>
               <li>
-If present, ensure that the `type` property conforms to the statements in
+If present, ensure that the `type` property conforms to the "MUST" statements in
 Section <a href="#types"></a>.
               </li>
               <li>
-If present, ensure that the `name` and/or `description` properties conform to the
-statements in Section <a href="#names-and-descriptions"></a>.
+If present, ensure that the `name` and/or `description` properties conform to
+the "MUST" statements in Section <a href="#names-and-descriptions"></a>.
               </li>
               <li>
 If present, ensure that the `proof` property conforms to
-the statements in Section <a href="#securing-mechanisms"></a>.
+the "MUST" statements in Section <a href="#securing-mechanisms"></a>.
               </li>
               <li>
 If the `type` property is present and contains the
 `VerifiablePresentation` type, ensure that the object conforms to the
-statements in Section <a href="#presentations"></a>.
+"MUST" statements in Section <a href="#presentations"></a>.
               </li>
               <li>
 If the `type` property is present and contains the
@@ -4599,35 +4599,35 @@ If the `type` property is present and contains the
                 <ol class="algorithm">
                   <li>
 Ensure that the `credentialSubject` property conforms to the
-statements in Section <a href="#credential-subject"></a>.
+"MUST" statements in Section <a href="#credential-subject"></a>.
                   </li>
                   <li>
 Ensure that the `issuer` property conforms to the
-statements in Section <a href="#issuer"></a>.
+"MUST" statements in Section <a href="#issuer"></a>.
                   </li>
                   <li>
-If present, ensure that the `validFrom` and/or `validUntil` properties conform to
-the statements in Section <a href="#validity-period"></a>.
+If present, ensure that the `validFrom` and/or `validUntil` properties conform
+to the "MUST" statements in Section <a href="#validity-period"></a>.
                   </li>
                   <li>
 If present, ensure that the `credentialStatus` property conforms to
-the statements in Section <a href="#status"></a>.
+the "MUST" statements in Section <a href="#status"></a>.
                   </li>
                   <li>
 If present, ensure that the `credentialSchema` property conforms to
-the statements in Section <a href="#data-schemas"></a>.
+the "MUST" statements in Section <a href="#data-schemas"></a>.
                   </li>
                   <li>
 If present, ensure that the `relatedResource` property conforms to
-the statements in Section <a href="#integrity-of-related-resources"></a>.
+the "MUST" statements in Section <a href="#integrity-of-related-resources"></a>.
                   </li>
                   <li>
 If present, ensure that the `refreshService` property conforms to
-the statements in Section <a href="#refreshing"></a>.
+the "MUST" statements in Section <a href="#refreshing"></a>.
                   </li>
                   <li>
 If present, ensure that the `evidence` property conforms to
-the statements in Section <a href="#evidence"></a>.
+the "MUST" statements in Section <a href="#evidence"></a>.
                   </li>
                 </ol>
               </li>

--- a/index.html
+++ b/index.html
@@ -2159,19 +2159,20 @@ Directory [[VC-SPECS]].
         </p>
 
         <section class="normative">
-          <h2>The Verification Algorithm</h2>
+          <h4>The Verification Algorithm</h4>
 
           <p>
 This section contains an algorithm that <a>conforming verifier processors</a>
 can run when verifying a <a>verifiable credential</a> or a <a>verifiable
-presentation</a>. This algorithm takes a byte sequence (<var>inputBytes</var>)
-and a media type (<var>inputMediaType</var>) as inputs, and produces an object
-(<var>verified</var>) that contains a verification status
-(<var>verified</var>.<var>status</var>), a verified document
-(<var>verified</var>.<var>document</var>), a media type
-(<var>verified</var>.<var>mediaType</var>), zero or more optional warnings
-(<var>verified</var>.<var>warnings</var>), and zero or more optional errors
-(<var>verified</var>.<var>errors</var>).
+presentation</a>. This algorithm takes a byte sequence (bytes
+<var>inputBytes</var>) and a media type (string <var>inputMediaType</var>) as
+inputs, and produces an object (<var>verified</var>) that contains a
+verification status (boolean <var>verified</var>.<var>status</var>), a verified
+document (object <var>verified</var>.<var>document</var>), a media type (string
+<var>verified</var>.<var>mediaType</var>), zero or more optional warnings (array
+of <a>anomalyDescriptions</a> <var>verified</var>.<var>warnings</var>), and zero
+or more optional errors (array of <a>anomalyDescriptions</a>
+<var>verified</var>.<var>errors</var>).
           </p>
 
           <ol class="algorithm">
@@ -2189,8 +2190,8 @@ If the verification of the securing mechanism is successful, set
 <var>verified</var>.<var>status</var> to `true`,
 <var>verified</var>.<var>document</var> to the information that was secured,
 <var>verified</var>.<var>mediaType</var> to the corresponding media type,
-and optionally <var>verified</var>.<var>warnings</var> to any warning
-objects returned by the verification process for the securing mechanism.
+and optionally <var>verified</var>.<var>warnings</var> to any warnings
+returned by the verification process for the securing mechanism.
               <ol class="algorithm">
                 <li>
 Check whether <var>verified</var>.<var>document</var> is a
@@ -2205,12 +2206,54 @@ If verification of the securing mechanism is not successful, set
 <var>verified</var>.<var>status</var> to `false`, and optionally set
 <var>verified</var>.<var>errors</var> and
 <var>verified</var>.<var>warnings</var>, respectively, to any error and
-warning objects returned by the verification process for the securing mechanism.
+warnings returned by the verification process for the securing mechanism.
             </li>
             <li>
 Return <var>verified</var>.
             </li>
           </ol>
+        </section>
+
+        <section>
+          <h4>Anomaly Descriptions</h4>
+
+          <p>
+When an anomaly is detected by a <a>conforming processor</a>, an
+<dfn>anomalyDescription</dfn> is used to report the issue to software that
+invoked the process that led to the anomaly.
+The interface for these objects follows [[RFC9457]] to encode the data. An
+<a>anomalyDescription</a> object consists of the following properties:
+          </p>
+
+          <dl>
+            <dt>type</dt>
+            <dd>
+The `type` <a>property</a> MUST be present and its value MUST be a <a>URL</a>
+identifying the type of the anomaly.
+            </dd>
+            <dt>code</dt>
+            <dd>
+The `code` <a>property</a> is OPTIONAL. If present, its value MUST be an integer
+that identifies the type of the anomaly. Integer codes are useful in systems
+that only provide integer return values.
+            </dd>
+            <dt>title</dt>
+            <dd>
+The `title` <a>property</a> MUST be present and its value SHOULD provide a short
+but specific human-readable string for the anomaly.
+            </dd>
+            <dt>detail</dt>
+            <dd>
+The `detail` <a>property</a> MUST be present and its value SHOULD provide a
+longer human-readable string for the anomaly.
+            </dd>
+          </dl>
+
+          <p>
+Other properties that are useful for debugging purposes MAY be included in
+an <a>anomalyDescription</a> object.
+          </p>
+
         </section>
 
       </section>


### PR DESCRIPTION
This PR attempts to address issue #1337 by adding a verification algorithm to the specification. The PR attempts to do this in a way that defers to the securing specifications on verifying the securing mechanism and defers to the rest of the normative statements in the specification (instead of re-stating them in the algorithm).

/cc @jyasskin (since he raised this issue as a major item of concern in his review)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1338.html" title="Last updated on Dec 7, 2023, 11:18 PM UTC (6041145)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1338/fcf867c...6041145.html" title="Last updated on Dec 7, 2023, 11:18 PM UTC (6041145)">Diff</a>