### PR TITLE
Explain default language expression.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5678,7 +5678,7 @@ transformation which is otherwise optional. See the <a
 data-cite="JSON-LD#string-internationalization">String Internationalization</a>
 section of the [[JSON-LD]] specification for more information. Natural language
 string values that do not have a language associated with them SHOULD be
-treated as if the language value is `Undefined` (language tag "`und`"). Natural
+treated as if the language value is `undefined` (language tag "`und`"). Natural
 language string values that do not have a base direction associated with them
 SHOULD be treated as if the direction value is "`auto`".
         </p>

--- a/index.html
+++ b/index.html
@@ -5665,7 +5665,7 @@ doing this is shown below.
         </pre>
       </section>
 
-      <section class="informative">
+      <section class="substantive">
         <h3>Providing Default Language and Direction</h3>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -5672,7 +5672,7 @@ doing this is shown below.
 A default language and direction MAY be provided for the entire credential.
 However, doing so introduces a higher demand on creating a compliant processor
 and fully compliant context files. Consequently, using default language and
-direction should be limited to scenarios where JSON-LD expansion-based
+direction is expected to be be limited to scenarios where JSON-LD expansion-based
 transformation can be assured. See the
 <a href="https://www.w3.org/TR/json-ld11/#string-internationalization">String
 Internationalization</a> section of the [[JSON-LD]] specification for more

--- a/index.html
+++ b/index.html
@@ -5670,8 +5670,8 @@ doing this is shown below.
 
         <p>
 A default language and direction MAY be provided for the entire credential.
-However, doing so introduces a higher demand on creating a compliant processor
-and fully compliant context files. Consequently, using default language and
+However, doing so introduces a higher demand on context creators and 
+downstream processors. Consequently, using default language and
 direction is expected to be be limited to scenarios where JSON-LD expansion-based
 transformation can be assured. See the
 <a href="https://www.w3.org/TR/json-ld11/#string-internationalization">String

--- a/index.html
+++ b/index.html
@@ -5663,7 +5663,21 @@ doing this is shown below.
   "@id": "https://www.w3.org/2018/credentials/examples#title"
 }
         </pre>
+      </section>
 
+      <section class="informative">
+        <h3>Providing Default Language and Direction</h3>
+
+        <p>
+A default language and direction MAY be provided for the entire credential.
+However, doing so introduces a higher demand on creating a compliant processor
+and fully compliant context files. Consequently, using default language and
+direction should be limited to scenarios where JSON-LD expansion-based
+transformation can be assured. See the
+<a href="https://www.w3.org/TR/json-ld11/#string-internationalization">String
+Internationalization</a> section of the [[JSON-LD]] specification for more
+information.
+        </p>
       </section>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -5674,7 +5674,7 @@ However, doing so introduces a higher demand on context creators and
 downstream processors. Consequently, using default language and
 direction is expected to be be limited to scenarios where JSON-LD expansion-based
 transformation can be assured. See the
-<a href="https://www.w3.org/TR/json-ld11/#string-internationalization">String
+<a date-cite="JSON-LD#string-internationalization">String
 Internationalization</a> section of the [[JSON-LD]] specification for more
 information.
         </p>

--- a/index.html
+++ b/index.html
@@ -5669,14 +5669,18 @@ doing this is shown below.
         <h3>Providing Default Language and Direction</h3>
 
         <p>
-A default language and direction MAY be provided for the entire credential.
-However, doing so introduces a higher demand on context creators and 
-downstream processors. Consequently, using default language and
-direction is expected to be be limited to scenarios where JSON-LD expansion-based
-transformation can be assured. See the
-<a date-cite="JSON-LD#string-internationalization">String
-Internationalization</a> section of the [[JSON-LD]] specification for more
-information.
+The language and base direction of each natural language string property SHOULD
+be provided, either via the language value structure for each property or via a
+default language and base direction for the entire credential. Using the
+language value structure is preferred, because document defaults can result in
+a requirement that downstream processors perform JSON-LD expansion-based
+transformation which is otherwise optional. See the <a
+data-cite="JSON-LD#string-internationalization">String Internationalization</a>
+section of the [[JSON-LD]] specification for more information. Natural language
+string values that do not have a language associated with them SHOULD be
+treated as if the language value is `Undefined` (language tag "`und`"). Natural
+language string values that do not have a base direction associated with them
+SHOULD be treated as if the direction value is "`auto`".
         </p>
       </section>
 


### PR DESCRIPTION
This PR seeks to address https://github.com/w3c/vc-data-model/issues/1335 by presenting how authors may provide a default language and direction using standard JSON-LD language affordances.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BigBlueHat/vc-data-model/pull/1339.html" title="Last updated on Nov 17, 2023, 2:43 PM UTC (b9d9115)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1339/998a3dc...BigBlueHat:b9d9115.html" title="Last updated on Nov 17, 2023, 2:43 PM UTC (b9d9115)">Diff</a>