### PR TITLE
Use JSON-LD keywords for languages.

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
             w3cid: 46156
           }
         ],
-        xref: ["url"],
+        xref: ["url", "i18n-glossary"],
         maxTocLevel: 2,
         inlineCSS: true
       };
@@ -1560,9 +1560,9 @@ without their having to look through the entirety of the <a>claims</a>.
 
         <p>
 Names and descriptions also support expressing content in different languages.
-To express a string with language and text direction information, one can use
+To express a string with language and <a>base direction</a> information, one can use
 an object that contains the `@value`, `@language`, and `@direction` properties
-to express the text value, language tag, and text direction, respectively.
+to express the text value, language tag, and base direction, respectively.
 See <a href="#language-and-base-direction"></a> for further information.
         </p>
 
@@ -5658,7 +5658,7 @@ document [[STRING-META]] that implementers might be interested in reading.
 Data publishers are strongly encouraged to read the section on
 Cross-Syntax Expression in the <em>Strings on the Web: Language and Direction
 Metadata</em> document [[STRING-META]] to ensure that the expression of
-language and base direction information is possible across multiple expression
+language and <a>base direction</a> information is possible across multiple expression
 syntaxes, such as [[JSON-LD]], [[JSON]], and CBOR [[?RFC7049]].
         </p>
 
@@ -5681,7 +5681,7 @@ When the language value object is used in place of a string value, the object
 MUST contain a `@value` property whose value is a string, and SHOULD contain a
 `@language` property whose value is a string containing a valid
 `Language-Tag` as defined by [[BCP47]], and MAY contain a `@direction` property
-whose value is a text direction string defined by the `@direction` attribute in
+whose value is a <a>base direction</a> string defined by the `@direction` attribute in
 [[JSON-LD]]. The language value object MUST NOT include any other keys beyond
 `@value`, `@language`, and `@direction`.
         </p>
@@ -5714,7 +5714,7 @@ base direction of right-to-left.
         <p class="note">
 The text above would most likely be rendered incorrectly as left-to-right
 without the explicit expression of language and direction because many systems
-use the first character of a text string to determine text direction.
+use the first character of a text string to determine its <a>base direction</a>.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -5760,10 +5760,9 @@ SHOULD be treated as if the direction value is "`auto`".
         <h3>Complex Language Markup</h3>
 
         <p>
-When a single natural language string contains multiple languages, base
-directions, and annotations, a more complex mechanism is typically required.
-It is possible to use markup languages, such as HTML, to encode text with
-multiple languages and base directions. It is also possible to use the
+When a single natural language string contains multiple languages or annotations,
+the contents of the string might require additional structure or markup in order to be
+presented correctly. It is possible to use markup languages, such as HTML, to label spans of text in different languages or to supply string-internal markup needed for proper display of <a>bidirectional text</a>. It is also possible to use the
 <code>rdf:HTML</code> datatype to encode such values accurately in JSON-LD.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -5679,7 +5679,7 @@ specific base direction.
         <p>
 When the language value object is used in place of a string value, the object
 MUST contain a `@value` property whose value is a string, and SHOULD contain a
-`@language` property whose value is a string containing a valid
+`@language` property whose value is a string containing a well-formed
 `Language-Tag` as defined by [[BCP47]], and MAY contain a `@direction` property
 whose value is a <a>base direction</a> string defined by the `@direction` attribute in
 [[JSON-LD]]. The language value object MUST NOT include any other keys beyond

--- a/index.html
+++ b/index.html
@@ -5705,7 +5705,7 @@ base direction of right-to-left.
 
         <pre class="example nohighlight" title="Arabic text with a base direction of right-to-left">
 "title": {
-  "@value": "<span class="highlight">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
+  "@value": "<span class="highlight" dir="rtl" lang="ar">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
   "@language": "<code>ar</code>",
   "@direction": "<code>rtl</code>"
 }

--- a/index.html
+++ b/index.html
@@ -5679,7 +5679,7 @@ specific base direction.
         <p>
 When the language value object is used in place of a string value, the object
 MUST contain a `@value` property whose value is a string, and SHOULD contain a
-`@language` property whose value is a string containing a well-formed
+`@language` property whose value is a string containing a valid
 `Language-Tag` as defined by [[BCP47]], and MAY contain a `@direction` property
 whose value is a text direction string defined by the `@direction` attribute in
 [[JSON-LD]]. The language value object MUST NOT include any other keys beyond

--- a/index.html
+++ b/index.html
@@ -5729,7 +5729,7 @@ property:
     "@language": "<code>en</code>"
   },
   {
-    "@value": "<span class="highlight">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
+    "@value": "<span class="highlight" dir="rtl" lang="ar">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
     "@language": "<code>ar</code>",
     "@direction": "<code>rtl</code>"
   }

--- a/index.html
+++ b/index.html
@@ -1512,28 +1512,21 @@ are meant to serve these purposes.
           <dd>
 An OPTIONAL property that expresses the name of the <a>credential</a>. If
 present, the value of the <code>name</code> <a>property</a> MUST be a string or
-an object. If the value is an object, the object MUST contain a `value` property
-whose value is a string, and SHOULD contain a `lang` property whose value is a
-string containing a well-formed `Language-Tag` as defined by [[BCP47]],
-and MAY contain a `dir` property whose
-value is a text direction string defined by the `dir` attribute in [[JSON-LD]].
-Ideally, the name of a <a>credential</a> is concise, human-readable, and could
-enable an individual to quickly differentiate one <a>credential</a>
-from any other <a>credentials</a> that they might hold.
+a language value object as described in
+<a href="#language-and-base-direction"></a>. Ideally, the name of a
+<a>credential</a> is concise, human-readable, and could enable an individual to
+quickly differentiate one <a>credential</a> from any other <a>credentials</a>
+that they might hold.
           </dd>
           <dt><dfn class="export">description</dfn></dt>
           <dd>
 An OPTIONAL property that conveys specific details about a <a>credential</a>. If
 present, the value of the <code>description</code> <a>property</a> MUST be a
-string or an object. If the value is an object, the object MUST contain a
-`value` property whose value is a string, and SHOULD contain a `lang` property
-whose value is a string containing a well-formed language tag as defined
-by [[BCP47]], and MAY contain a `dir`
-property whose value is a text direction string defined by the `dir` attribute
-in [[JSON-LD]]. Ideally, the description of a <a>credential</a> is no more than
-a few sentences in length and conveys enough information about the
-<a>credential</a> to remind an individual of its contents without their having to
-look through the entirety of the <a>claims</a>.
+string or a language value object as described in
+<a href="#language-and-base-direction"></a>. Ideally, the description of a
+<a>credential</a> is no more than a few sentences in length and conveys enough
+information about the <a>credential</a> to remind an individual of its contents
+without their having to look through the entirety of the <a>claims</a>.
           </dd>
         </dl>
 
@@ -1559,7 +1552,7 @@ look through the entirety of the <a>claims</a>.
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
       "type": "ExampleBachelorDegree",
-      "subtype": "Bachelor of Science and Arts"
+      "name": "Bachelor of Science and Arts"
     }
   }
 }
@@ -1568,8 +1561,8 @@ look through the entirety of the <a>claims</a>.
         <p>
 Names and descriptions also support expressing content in different languages.
 To express a string with language and text direction information, one can use
-an object that contains the `value`, `lang`, and `dir` properties to express
-the text value, language tag, and text direction, respectively.
+an object that contains the `@value`, `@language`, and `@direction` properties
+to express the text value, language tag, and text direction, respectively.
 See <a href="#language-and-base-direction"></a> for further information.
         </p>
 
@@ -1585,56 +1578,66 @@ See <a href="#language-and-base-direction"></a> for further information.
   "issuer": {
     "id": "https://university.example/issuers/565049",
     "name": [{
-      "value": "Example University",
-      "lang": "en"
+      "@value": "Example University",
+      "@language": "en"
     }, {
-      "value": "Université de Exemple",
-      "lang": "fr"
+      "@value": "Université de Exemple",
+      "@language": "fr"
     }, {
-      "value": "جامعة المثال",
-      "lang": "ar",
-      "dir": "rtl"
+      "@value": "جامعة المثال",
+      "@language": "ar",
+      "@direction": "rtl"
     }],
     "description": [{
-      "value": "A public university focusing on teaching examples.",
-      "lang": "en"
+      "@value": "A public university focusing on teaching examples.",
+      "@language": "en"
     }, {
-      "value": "Une université publique axée sur l'enseignement des exemples.",
-      "lang": "fr"
+      "@value": "Une université publique axée sur l'enseignement des exemples.",
+      "@language": "fr"
     }, {
-      "value": "جامعة عامة تركز على أمثلة التدريس.",
-      "lang": "ar",
-      "dir": "rtl"
+      "@value": "جامعة عامة تركز على أمثلة التدريس.",
+      "@language": "ar",
+      "@direction": "rtl"
     }]
   },
   "validFrom": "2015-05-10T12:30:00Z",
   "name": [{
-    "value": "Example University Degree",
-    "lang": "en"
+    "@value": "Example University Degree",
+    "@language": "en"
   }, {
-    "value": "Exemple de Diplôme Universitaire",
-    "lang": "fr"
+    "@value": "Exemple de Diplôme Universitaire",
+    "@language": "fr"
   }, {
-    "value": "مثال الشهادة الجامعية",
-    "lang": "ar",
-    "dir": "rtl"
+    "@value": "مثال الشهادة الجامعية",
+    "@language": "ar",
+    "@direction": "rtl"
   }],
   "description": [{
-    "value": "2015 Bachelor of Science and Arts Degree",
-    "lang": "en"
+    "@value": "2015 Bachelor of Science and Arts Degree",
+    "@language": "en"
   }, {
-    "value": "2015 Baccalauréat Scientifique et Arts",
-    "lang": "fr"
+    "@value": "2015 Baccalauréat Scientifique et Arts",
+    "@language": "fr"
   }, {
-    "value": "2015 بكالوريوس العلوم والآداب",
-    "lang": "ar",
-    "dir": "rtl"
+    "@value": "2015 بكالوريوس العلوم والآداب",
+    "@language": "ar",
+    "@direction": "rtl"
   }],
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
       "type": "ExampleBachelorDegree",
-      "subtype": "Bachelor of Science and Arts"
+      "name": [{
+        "@value": "Bachelor of Science and Arts Degree",
+        "@language": "en"
+      }, {
+        "@value": "Baccalauréat Scientifique et Arts",
+        "@language": "fr"
+      }, {
+        "@value": "بكالوريوس العلوم والآداب",
+        "@language": "ar",
+        "@direction": "rtl"
+      }]
     }
   }
 }
@@ -5648,7 +5651,7 @@ parts of the <em>Strings on the Web: Language and Direction Metadata</em>
 document [[STRING-META]] that implementers might be interested in reading.
       </p>
 
-      <section class="informative">
+      <section>
         <h3>Language and Base Direction</h3>
 
         <p>
@@ -5667,11 +5670,21 @@ specific base direction.
 
         <pre class="example nohighlight" title="Design pattern for natural language strings">
 "<a>property</a>": {
-  "value": "<span class="highlight">The string value</span>",
-  "lang": "<code>LANGUAGE</code>"
-  "dir": "<code>DIRECTION</code>"
+  "@value": "<span class="highlight">The string value</span>",
+  "@language": "<code>LANGUAGE</code>"
+  "@direction": "<code>DIRECTION</code>"
 }
         </pre>
+
+        <p>
+When the language value object is used in place of a string value, the object
+MUST contain a `@value` property whose value is a string, and SHOULD contain a
+`@language` property whose value is a string containing a well-formed
+`Language-Tag` as defined by [[BCP47]], and MAY contain a `@direction` property
+whose value is a text direction string defined by the `@direction` attribute in
+[[JSON-LD]]. The language value object MUST NOT include any other keys beyond
+`@value`, `@language`, and `@direction`.
+        </p>
 
         <p>
 Using the design pattern above, the following example expresses the title of a
@@ -5680,8 +5693,8 @@ book in the English language without specifying a text direction.
 
         <pre class="example nohighlight" title="Expressing natural language text as English">
 "title": {
-  "value": "<span class="highlight">HTML and CSS: Designing and Creating Websites</span>",
-  "lang": "<code>en</code>"
+  "@value": "<span class="highlight">HTML and CSS: Designing and Creating Websites</span>",
+  "@language": "<code>en</code>"
 }
         </pre>
 
@@ -5692,9 +5705,9 @@ base direction of right-to-left.
 
         <pre class="example nohighlight" title="Arabic text with a base direction of right-to-left">
 "title": {
-  "value": "<span class="highlight">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
-  "lang": "<code>ar</code>"
-  "dir": "<code>rtl</code>"
+  "@value": "<span class="highlight">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
+  "@language": "<code>ar</code>",
+  "@direction": "<code>rtl</code>"
 }
         </pre>
 
@@ -5705,20 +5718,22 @@ use the first character of a text string to determine text direction.
         </p>
 
         <p>
-Implementers utilizing JSON-LD are strongly urged to
-<a href="#extensibility">extend</a> the JSON-LD Context defining the
-internationalized <a>property</a> and use the Scoped Context feature of JSON-LD
-to alias the <code>@value</code>, <code>@language</code>, and
-<code>@direction</code> keywords to <code>value</code>, <code>lang</code>,
-and <code>dir</code>, respectively. An example of a JSON-LD Context snippet
-doing this is shown below.
+Multiple language value objects MAY be provided as an array value for the
+property:
         </p>
 
-        <pre class="example nohighlight" title="Specifying scoped aliasing for language information">
-"title": {
-  <span class="highlight">"@context": {"value": "@value", "lang": "@language", "dir": "@direction"}</span>,
-  "@id": "https://www.w3.org/2018/credentials/examples#title"
-}
+        <pre class="example nohighlight" title="Multiple language texts provided for title">
+"title": [
+  {
+    "@value": "<span class="highlight">HTML and CSS: Designing and Creating Websites</span>",
+    "@language": "<code>en</code>"
+  },
+  {
+    "@value": "<span class="highlight">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
+    "@language": "<code>ar</code>",
+    "@direction": "<code>rtl</code>"
+  }
+]
         </pre>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -5762,7 +5762,9 @@ SHOULD be treated as if the direction value is "`auto`".
         <p>
 When a single natural language string contains multiple languages or annotations,
 the contents of the string might require additional structure or markup in order to be
-presented correctly. It is possible to use markup languages, such as HTML, to label spans of text in different languages or to supply string-internal markup needed for proper display of <a>bidirectional text</a>. It is also possible to use the
+presented correctly. It is possible to use markup languages, such as HTML, to label
+spans of text in different languages or to supply string-internal markup needed for
+proper display of <a>bidirectional text</a>. It is also possible to use the
 <code>rdf:HTML</code> datatype to encode such values accurately in JSON-LD.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -5745,10 +5745,10 @@ SHOULD be treated as if the direction value is "`auto`".
         <h3>Complex Language Markup</h3>
 
         <p>
-When multiple languages, base directions, and annotations are used in a single
-natural language string, more complex mechanisms are typically required. It is
-possible to use markup languages, such as HTML, to encode text with multiple
-languages and base directions. It is also possible to use the
+When a single natural language string contains multiple languages, base
+directions, and annotations, a more complex mechanism is typically required.
+It is possible to use markup languages, such as HTML, to encode text with
+multiple languages and base directions. It is also possible to use the
 <code>rdf:HTML</code> datatype to encode such values accurately in JSON-LD.
         </p>
 


### PR DESCRIPTION
This PR uses the non-aliased values for `@language`, `@direction`, and `@value` to prevent confusion that these aliased terms may be used anywhere for any purpose--instead highlighting their sole application for providing language metadata for a single string value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BigBlueHat/vc-data-model/pull/1340.html" title="Last updated on Nov 20, 2023, 2:37 PM UTC (6c008dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1340/3fb62f8...BigBlueHat:6c008dc.html" title="Last updated on Nov 20, 2023, 2:37 PM UTC (6c008dc)">Diff</a>