### PR TITLE
Clarify credentialSubject requirements to improve testability.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1651,10 +1651,11 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
           <dt><dfn class="export"
                    id="defn-credentialSubject">credentialSubject</dfn></dt>
           <dd>
-The value of the <code>credentialSubject</code> <a>property</a> is defined as
-a set of objects that MUST contain one or more claims that are each related to a
-<a>subject</a> of the <a>verifiable credential</a>. Each object MAY contain an
-<code>id</code>, as described in Section <a href="#identifiers"></a>.
+The value of the <code>credentialSubject</code> <a>property</a> is defined as a
+set of objects where each object MUST contain one or more <a>claims</a>
+expressed as property-value pairs. Each object MAY also contain an
+<code>id</code> to identify the <a>subject</a>, as described in Section
+<a href="#identifiers"></a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -1653,9 +1653,9 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
           <dd>
 The value of the <code>credentialSubject</code> <a>property</a> is defined as a
 set of objects where each object MUST contain one or more <a>claims</a>
-expressed as property-value pairs. Each object MAY also contain an
-<code>id</code> to identify the <a>subject</a>, as described in Section
-<a href="#identifiers"></a>.
+expressed as property-value pairs of the <a>subject</a>. Each object MAY
+also contain an <code>id</code> to identify the <a>subject</a>, as
+described in Section <a href="#identifiers"></a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -1653,7 +1653,7 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
           <dd>
 The value of the <code>credentialSubject</code> <a>property</a> is defined as a
 set of objects where each object MUST be the <a>subject</a> of one or more <a>claims</a>,
-which MUST be serialized inside the <code>credentialSubject</code> <a>claim</a>.
+which MUST be serialized inside the <code>credentialSubject</code> <a>property</a>.
 Each object MAY
 also contain an <code>id</code> to identify the <a>subject</a>, as
 described in Section <a href="#identifiers"></a>.

--- a/index.html
+++ b/index.html
@@ -1652,8 +1652,9 @@ A <a>verifiable credential</a> MUST have a <code>credentialSubject</code>
                    id="defn-credentialSubject">credentialSubject</dfn></dt>
           <dd>
 The value of the <code>credentialSubject</code> <a>property</a> is defined as a
-set of objects where each object MUST contain one or more <a>claims</a>
-expressed as property-value pairs of the <a>subject</a>. Each object MAY
+set of objects where each object MUST be the <a>subject</a> of one or more <a>claims</a>,
+which MUST be serialized inside the <code>credentialSubject</code> <a>claim</a>.
+Each object MAY
 also contain an <code>id</code> to identify the <a>subject</a>, as
 described in Section <a href="#identifiers"></a>.
           </dd>


### PR DESCRIPTION
This PR has been raised to address issue #1341 by clarifying the normative statements around the `credentialSubject` property.

/cc @jyasskin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1346.html" title="Last updated on Nov 17, 2023, 2:53 PM UTC (5f82324)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1346/998a3dc...5f82324.html" title="Last updated on Nov 17, 2023, 2:53 PM UTC (5f82324)">Diff</a>