### PR TITLE
Update JSON Processing section to Credential-Type-Specific Processing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4253,12 +4253,13 @@ typing, and order, when performing credential-type-specific processing.
           <p>
 The rule above guarantees semantic interoperability between the two processing
 mechanisms for literal JSON keys mapped to URIs by the `@context` mechanism.
-While <a>general JSON-LD processing</a> will use `@context` values provided in
-its algorithms and verify that all terms are correctly specified,
-<a href="#dfn-credential-type-specific-processing">credential-type-specific
-processing</a> implicitly accepts the same semantics without invoking any
-JSON-LD APIs. In other words, the context in which the data exchange happens is
-explicitly stated for both processing approaches due to the use of
+While <a>general JSON-LD processing</a> can use previously unseen `@context`
+values provided in its algorithms to verify that all terms are correctly specified,
+<a href="#dfn-credential-type-specific-processing">credential-type-specific</a>
+implementations only accept specific `@context` values for which the implementation
+is engineered ahead of time to understand, resulting in the same semantics without
+invoking any JSON-LD APIs. In other words, the context in which the data exchange
+happens is explicitly stated for both processing approaches due to the use of
 `@context` in a way that leads to the same <a>conforming document</a> semantics.
           </p>
 

--- a/index.html
+++ b/index.html
@@ -4188,22 +4188,26 @@ content type, or return an error code such as
         </section>
 
         <section class="informative">
-          <h2>JSON Processing</h2>
+          <h2>Credential Type-Specific Processing</h2>
 
           <p>
-While the media types describing conforming documents defined in this
-specification always express JSON-LD, JSON-LD processing is not required to be
-performed, since JSON-LD is JSON. Some scenarios where processing a
-<a>verifiable credential</a> or a <a>verifiable presentation</a> as JSON is
-desirable include, but are not limited to:
+<dfn>General JSON-LD processing</dfn> is defined as a mechanism that utilizes a
+JSON-LD software library to process a <a>conforming document</a> by performing
+various <a data-cite="?JSON-LD11#forms-of-json-ld">transformations</a>.
+<dfn>Credential type-specific processing</dfn> is defined as a lighter-weight
+mechanism, that doesn't require a JSON-LD software library, to process
+<a>conforming documents</a>. General JSON-LD processing is not always required
+to be performed when working with <a>verifiable credentials</a> and
+<a>verifiable presentations</a>; one can use credential-type-specific
+processing, instead. Some scenarios where credential-type-specific processing
+is desirable include, but are not limited to:
           </p>
 
           <ul>
             <li>
-Before securing or after verifying content
-that requires <a href="https://csrc.nist.gov/glossary/term/data_integrity">data
-integrity</a>, such as a
-<a>verifiable credential</a> or <a>verifiable presentation</a>.
+Before applying a securing mechanism, or after verifying a
+<a>conforming document</a> protected by a securing mechanism to ensure
+<a href="https://csrc.nist.gov/glossary/term/data_integrity">data integrity</a>.
             </li>
             <li>
 When performing JSON Schema validation, as described in Section
@@ -4216,8 +4220,8 @@ When serializing or deserializing <a>verifiable credentials</a> or
             <li>
 When operating on <a>verifiable credentials</a> or <a>verifiable
 presentations</a> in a software application, after verification or validation
-is performed for securing mechanisms that require an understanding of
-and/or processing of JSON-LD.
+is performed for securing mechanisms that require
+<a>general JSON-LD processing</a>.
             </li>
             <li>
 When an application chooses to process the media type using the `+json`
@@ -4226,9 +4230,10 @@ structured media type suffix.
           </ul>
 
           <p>
-That is, JSON processing is allowed as long as the document being consumed or
-produced is a <a>conforming document</a>. If JSON processing is desired, an
-implementer is advised to follow the following rule:
+That is, <a href="#dfn-credential-type-specific-processing">
+credential-type-specific processing</a> is allowed as long as the document being
+consumed or produced is a <a>conforming document</a>. If this type of processing
+is desired, an implementer is advised to follow this rule:
           </p>
 
           <ul>
@@ -4243,19 +4248,19 @@ contents are appropriate for the intended use case.
           <p>
 Using static context files with a JSON Schema is one acceptable approach to
 implementing the rule above. This can ensure proper term identification,
-typing, and order, when a JSON document is processed as JSON-LD.
+typing, and order, when performing credential-type-specific processing.
           </p>
 
           <p>
-The rule above guarantees semantic interoperability between JSON and JSON-LD for
-literal JSON keys mapped to URIs by the `@context` mechanism. While JSON-LD
-processors will use the specific mechanism provided and can verify that all
-terms are correctly specified, JSON-based processors implicitly accept the same
-semantics without performing any JSON-LD transformations, but instead by
-applying the above rules. In other words, the context in which the data exchange
-happens is explicitly stated for both JSON and JSON-LD by using the same
-mechanism. With respect to JSON-based processors, this is achieved in a
-lightweight manner, without having to use JSON-LD processing libraries.
+The rule above guarantees semantic interoperability between the two processing
+mechanisms for literal JSON keys mapped to URIs by the `@context` mechanism.
+While <a>general JSON-LD processing</a> will use `@context` values provided in
+its algorithms and verify that all terms are correctly specified,
+<a href="#dfn-credential-type-specific-processing">credential-type-specific
+processing</a> implicitly accepts the same semantics without invoking any
+JSON-LD APIs. In other words, the context in which the data exchange happens is
+explicitly stated for both processing approaches due to the use of
+`@context` in a way that leads to the same <a>conforming document</a> semantics.
           </p>
 
         </section>

--- a/index.html
+++ b/index.html
@@ -4196,11 +4196,10 @@ JSON-LD software library to process a <a>conforming document</a> by performing
 various <a data-cite="?JSON-LD11#forms-of-json-ld">transformations</a>.
 <dfn>Credential type-specific processing</dfn> is defined as a lighter-weight
 mechanism, that doesn't require a JSON-LD software library, to process
-<a>conforming documents</a>. General JSON-LD processing is not always required
-to be performed when working with <a>verifiable credentials</a> and
-<a>verifiable presentations</a>; one can use credential-type-specific
-processing, instead. Some scenarios where credential-type-specific processing
-is desirable include, but are not limited to:
+<a>conforming documents</a>. Some consumers of <a>verifiable credentials</a>
+only need to consume credentials with specific types. These consumers can use
+credential-type-specific processing instead of generalized processing. Some scenarios
+where credential-type-specific processing is desirable include, but are not limited to:
           </p>
 
           <ul>

--- a/index.html
+++ b/index.html
@@ -4195,17 +4195,18 @@ content type, or return an error code such as
 JSON-LD software library to process a <a>conforming document</a> by performing
 various <a data-cite="?JSON-LD11#forms-of-json-ld">transformations</a>.
 <dfn>Credential type-specific processing</dfn> is defined as a lighter-weight
-mechanism, that doesn't require a JSON-LD software library, to process
-<a>conforming documents</a>. Some consumers of <a>verifiable credentials</a>
+mechanism for processing <a>conforming documents</a>, that doesn't require
+a JSON-LD software library. Some consumers of <a>verifiable credentials</a>
 only need to consume credentials with specific types. These consumers can use
-credential-type-specific processing instead of generalized processing. Some scenarios
-where credential-type-specific processing is desirable include, but are not limited to:
+credential-type-specific processing instead of generalized processing. Scenarios where
+credential-type-specific processing can be desirable include, but are not limited to,
+the following:
           </p>
 
           <ul>
             <li>
-Before applying a securing mechanism, or after verifying a
-<a>conforming document</a> protected by a securing mechanism to ensure
+Before applying a securing mechanism to a <a>conforming document</a>, or after
+verifying a <a>conforming document</a> protected by a securing mechanism, to ensure
 <a href="https://csrc.nist.gov/glossary/term/data_integrity">data integrity</a>.
             </li>
             <li>
@@ -4252,14 +4253,14 @@ typing, and order, when performing credential-type-specific processing.
 
           <p>
 The rule above guarantees semantic interoperability between the two processing
-mechanisms for literal JSON keys mapped to URIs by the `@context` mechanism.
+mechanisms for mapping literal JSON keys to URIs via the `@context` mechanism.
 While <a>general JSON-LD processing</a> can use previously unseen `@context`
 values provided in its algorithms to verify that all terms are correctly specified,
 <a href="#dfn-credential-type-specific-processing">credential-type-specific</a>
-implementations only accept specific `@context` values for which the implementation
+implementations only accept specific `@context` values which the implementation
 is engineered ahead of time to understand, resulting in the same semantics without
 invoking any JSON-LD APIs. In other words, the context in which the data exchange
-happens is explicitly stated for both processing approaches due to the use of
+happens is explicitly stated for both processing mechanisms by using
 `@context` in a way that leads to the same <a>conforming document</a> semantics.
           </p>
 


### PR DESCRIPTION
This PR attempts to address issue #1290 by applying the result of the VCWG poll to rename the section to "Credential-type-specific Processing". Here are the results of the poll:

![image](https://github.com/w3c/vc-data-model/assets/108611/36ee34bd-6979-40d6-beba-9c121c00d84c)

It also updates the language in an attempt to eliminate the use of "JSON Processing" and replace it with something that the VCWG, and @awoie -- specifically, will hopefully find more palatable.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1351.html" title="Last updated on Nov 19, 2023, 2:50 PM UTC (01a8f0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1351/da600f9...01a8f0a.html" title="Last updated on Nov 19, 2023, 2:50 PM UTC (01a8f0a)">Diff</a>