### PR TITLE
Massaging text for default language and direction

### DIFF
--- a/index.html
+++ b/index.html
@@ -5726,13 +5726,13 @@ doing this is shown below.
         <h3>Providing Default Language and Direction</h3>
 
         <p>
-The language and base direction of each natural language string property SHOULD
-be provided, either via the language value structure for each property or via a
-default language and base direction for the entire credential. Using the
-language value structure is preferred, because document defaults can result in
-a requirement that downstream processors perform JSON-LD expansion-based
-transformation which is otherwise optional. See the <a
-data-cite="JSON-LD#string-internationalization">String Internationalization</a>
+The language and base direction of each natural language string property value
+SHOULD be provided, either via the language value structure for each property 
+value, or via a default language and base direction for all values in the entire
+credential. Using the per-value language value structure is preferred, because
+using document defaults can result in a requirement that downstream processors
+perform JSON-LD expansion-based transformation which is otherwise optional. See the
+<a data-cite="JSON-LD#string-internationalization">String Internationalization</a>
 section of the [[JSON-LD]] specification for more information. Natural language
 string values that do not have a language associated with them SHOULD be
 treated as if the language value is `undefined` (language tag "`und`"). Natural


### PR DESCRIPTION
Rereading made me aware that some important words were omitted. I believe this to be editorial and clarification. Hopefully other readers will concur.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-model/pull/1353.html" title="Last updated on Nov 18, 2023, 12:33 AM UTC (f66a9aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1353/b3cff22...TallTed:f66a9aa.html" title="Last updated on Nov 18, 2023, 12:33 AM UTC (f66a9aa)">Diff</a>