### PR TITLE
Add section on Data Theft to Privacy Considerations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -5108,11 +5108,9 @@ minutes.
 The data expressed in <a>verifiable credentials</a> and
 <a>verifiable presentations</a> are valuable since they contain authentic
 statements made by trusted third parties, such as <a>issuers</a>, or
-individuals, such as <a>holders</a> and <a>subjects</a>. Storing this data,
-anywhere, can create sensitive data honeypots that attackers are motivated to
-break into in order to acquire information about certain <a>subjects</a> which
-might have financial value and be sold and bought through illegal data
-marketplaces.
+individuals, such as <a>holders</a> and <a>subjects</a>. Storing this data
+can create sensitive data honeypots that attackers are motivated to
+break into in order to acquire and exchange it for financial gain.
         </p>
         <p>
 <a>Issuers</a> are advised to hold on to the minimum amount of data

--- a/index.html
+++ b/index.html
@@ -5121,7 +5121,9 @@ manage the status and revocation of those credentials.
 <a>Holders</a> are advised to use implementations that appropriately
 encrypt their data in transit and at rest, and protect sensitive
 material (such as cryptographic secrets) in ways that cannot be easily
-extracted from hardware devices.
+extracted from hardware devices. Furthermore, it's suggested that
+<a>Holders<a> hold data at the edge whenever possible in order to
+reduce the likelihood of attack.
         </p>
         <p>
 <a>Verifiers</a> are advised to only ask for data necessary for a particular

--- a/index.html
+++ b/index.html
@@ -5102,6 +5102,48 @@ minutes.
       </section>
 
       <section class="informative">
+        <h3>Data Theft</h3>
+
+        <p>
+The data expressed in <a>verifiable credentials</a> and
+<a>verifiable presentations</a> are valuable since they contain authentic
+statements made by trusted third parties, such as <a>issuers</a>, or
+individuals, such as <a>holders</a> and <a>subjects</a>. Storing this data,
+anywhere, can create sensitive data honeypots that attackers are motivated to
+break into in order to acquire information about certain <a>subjects</a> which
+might have financial value and be sold and bought through illegal data
+marketplaces.
+        </p>
+        <p>
+<a>Issuers</a> are advised to hold on to the minimum amount of data
+necessary to issue <a>verifiable credentials</a> to <a>holders</a> and
+manage the status and revocation of those credentials.
+        </p>
+        <p>
+<a>Holders</a> are advised to use implementations that appropriately
+encrypt their data in transit and at rest, and protect sensitive
+material (such as cryptographic secrets) in ways that cannot be easily
+extracted from hardware devices.
+        </p>
+        <p>
+<a>Verifiers</a> are advised to only ask for data necessary for a particular
+transaction and to not hold on to any data beyond the needs of any particular
+transaction.
+        </p>
+        <p>
+Regulators are advised to rethink the audit requirements for any particular
+market vertical being regulated such that more privacy-preserving mechanisms
+can be used to achieve similar levels of enforcement and audit capabilities.
+For example, regulations that insist on the collection and long-term
+storage of personally identifiable information for the purposes of auditing
+can create harms to individuals and organizations if that same information
+is compromised and accessed by an attacker. Alternatives include keeping
+logs that the information was collected and checked along with random
+audits to ensure that compliance regimes are operating as expected.
+        </p>
+      </section>
+
+      <section class="informative">
         <h3>Frequency of Claim Issuance</h3>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -5131,15 +5131,17 @@ transaction and to not hold on to any data beyond the needs of any particular
 transaction.
         </p>
         <p>
-Regulators are advised to rethink the audit requirements for any particular
-market vertical being regulated such that more privacy-preserving mechanisms
-can be used to achieve similar levels of enforcement and audit capabilities.
-For example, regulations that insist on the collection and long-term
-storage of personally identifiable information for the purposes of auditing
-can create harms to individuals and organizations if that same information
-is compromised and accessed by an attacker. Alternatives include keeping
-logs that the information was collected and checked along with random
-audits to ensure that compliance regimes are operating as expected.
+Regulators are advised to rethink the audit requirements such that more
+privacy-preserving mechanisms can be used to achieve similar levels of
+enforcement and audit capabilities. For example, regulations that insist on the
+collection and long-term storage of personally identifiable information for the
+purposes of auditing can create harms to individuals and organizations if that
+same information is compromised and accessed by an attacker. The technologies
+described by this specification enable <a>holders</a> to more readily prove
+attributes about themselves and others, reducing the need for long-term data
+archival by <a>verifiers</a>. Alternatives include keeping logs that the
+information was collected and checked along with random audits to ensure that
+compliance regimes are operating as expected.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -5109,40 +5109,40 @@ The data expressed in <a>verifiable credentials</a> and
 <a>verifiable presentations</a> are valuable since they contain authentic
 statements made by trusted third parties, such as <a>issuers</a>, or
 individuals, such as <a>holders</a> and <a>subjects</a>. Storing this data
-can create sensitive data honeypots that attackers are motivated to
-break into in order to acquire and exchange it for financial gain.
+can create honeypots of sensitive data that attackers are motivated to
+break into in order to acquire and exchange that data for financial gain.
         </p>
         <p>
-<a>Issuers</a> are advised to hold on to the minimum amount of data
+<a>Issuers</a> are advised to retain the minimum amount of data
 necessary to issue <a>verifiable credentials</a> to <a>holders</a> and
 manage the status and revocation of those credentials.
         </p>
         <p>
 <a>Holders</a> are advised to use implementations that appropriately
-encrypt their data in transit and at rest, and protect sensitive
+encrypt their data both in transit and at rest, and protect sensitive
 material (such as cryptographic secrets) in ways that cannot be easily
 extracted from hardware devices. Furthermore, it is suggested that
-<a>holders<a> store and manipulate their data on devices that they control,
-away from centralized systems, in order to reduce the likelihood of attack
-on their data, or large-scale theft if an attack is successful.
+<a>holders<a> store and manipulate their data only on devices that they
+control, away from centralized systems, to reduce the likelihood of
+attack on their data, or large-scale theft if an attack is successful.
         </p>
         <p>
 <a>Verifiers</a> are advised to only ask for data necessary for a particular
-transaction and to not hold on to any data beyond the needs of any particular
+transaction and to not retain any data beyond the needs of any particular
 transaction.
         </p>
         <p>
-Regulators are advised to rethink the audit requirements such that more
+Regulators are advised to rethink audit requirements such that more
 privacy-preserving mechanisms can be used to achieve similar levels of
-enforcement and audit capabilities. For example, regulations that insist on the
-collection and long-term storage of personally identifiable information for the
-purposes of auditing can create harms to individuals and organizations if that
-same information is compromised and accessed by an attacker. The technologies
-described by this specification enable <a>holders</a> to more readily prove
+enforcement and audit capabilities. For example, audit-focused regulations
+that insist on collection and long-term retention of personally identifiable
+information can cause harm to individuals and organizations if that same
+information is compromised and accessed by an attacker. The technologies
+described by this specification enable <a>holders</a> to more-readily prove
 attributes about themselves and others, reducing the need for long-term data
-archival by <a>verifiers</a>. Alternatives include keeping logs that the
-information was collected and checked along with random audits to ensure that
-compliance regimes are operating as expected.
+retention by <a>verifiers</a>. Alternatives include keeping logs that the
+information was collected and checked, as well as random tests to ensure
+that compliance regimes are operating as expected.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -5121,9 +5121,10 @@ manage the status and revocation of those credentials.
 <a>Holders</a> are advised to use implementations that appropriately
 encrypt their data in transit and at rest, and protect sensitive
 material (such as cryptographic secrets) in ways that cannot be easily
-extracted from hardware devices. Furthermore, it's suggested that
-<a>Holders<a> hold data at the edge whenever possible in order to
-reduce the likelihood of attack.
+extracted from hardware devices. Furthermore, it is suggested that
+<a>holders<a> store and manipulate their data on devices that they control,
+away from centralized systems, in order to reduce the likelihood of attack
+on their data, or large-scale theft if an attack is successful.
         </p>
         <p>
 <a>Verifiers</a> are advised to only ask for data necessary for a particular


### PR DESCRIPTION
This PR attempts to address issue #1247 by adding a section on Data Theft, and advising all roles to be careful how much data they store and how long they store it. Advice is given to regulators to play an active role in reducing the collection of PII.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1356.html" title="Last updated on Nov 21, 2023, 3:05 PM UTC (ad252fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1356/b3cff22...ad252fb.html" title="Last updated on Nov 21, 2023, 3:05 PM UTC (ad252fb)">Diff</a>