### PR TITLE
Address @jyasskin's pre-Candidate Recommendation review comments

### DIFF
--- a/common.js
+++ b/common.js
@@ -42,6 +42,21 @@ var vcwg = {
       status: "WD",
       publisher: "Verifiable Credentials Working Group"
     },
+    "VC-CONTROLLER-DOCUMENT": {
+      title: "Verifiable Credential Controller Document",
+      href: "https://w3c.github.io/vc-controller-document/",
+      authors: [
+        "Manu Sporny",
+        "Dave Longley",
+        "Markus Sabadello",
+        "Drummond Reed",
+        "Orie Steele",
+        "Christopher Allen",
+        "Michael B. Jones"
+      ],
+      status: "ED",
+      publisher: "Verifiable Credentials Working Group"
+    },
     'RDF-NORMALIZATION': {
       title: 'RDF Dataset Normalization',
       href: 'http://json-ld.github.io/normalization/spec/',

--- a/index.html
+++ b/index.html
@@ -3610,24 +3610,6 @@ secure the <a>verifiable credential</a> in a manner that supports these
 capabilities.
         </p>
         <p>
-There are two requirements for <a>verifiable credentials</a> when they are to be
-used in zero-knowledge proof systems.
-        </p>
-        <ul>
-          <li>
-The <a>verifiable credential</a> MUST contain a Proof, using the
-<code>proof</code> <a>property</a>, so that the <a>holder</a> can derive a
-<a>verifiable presentation</a> that reveals only the information that the
-<a>holder</a> intends to reveal.
-          </li>
-          <li>
-If a <a>credential</a> definition is being used, the <a>credential</a>
-definition MUST be defined in the <code>credentialSchema</code> <a>property</a>,
-so that it can be used by all parties to perform various cryptographic
-operations in zero-knowledge.
-          </li>
-        </ul>
-        <p>
 When a <a>holder</a> has selectively disclosed a portion of a
 <a>verifiable credential</a>, it is important that the <a>verifier</a> check
 whether the information provided in the derived <a>verifiable credential</a> is
@@ -3646,34 +3628,13 @@ processing depending on the construction. If a schema is not formed with
 selective disclosure in mind, then validation is likely to fail.
         </p>
         <p>
-The examples below highlight how the data model might be used to issue and
+The diagram below highlights how the data model might be used to issue and
 present <a>verifiable credentials</a> in zero-knowledge.
         </p>
         <p class="issue">
 Examples of leveraging <a href="https://w3c.github.io/vc-di-bbs/">vc-di-bbs</a>,
 will be added here in the future, or this section will be removed.
         </p>
-
-        <ul>
-          <li>
-Each derived <a>verifiable credential</a> within a <a>verifiable
-presentation</a> MUST contain all information necessary to verify the
-<a>verifiable credential</a>, either by including it directly within the
-credential, or by referencing the necessary information.
-          </li>
-          <li>
-A <a>verifiable presentation</a> MUST NOT leak information that would enable
-the <a>verifier</a> to correlate the <a>holder</a> across multiple
-<a>verifiable presentations</a>.
-          </li>
-          <li>
-The <a>verifiable presentation</a> SHOULD contain a <code>proof</code>
-<a>property</a> to enable the <a>verifier</a> to check that all derived
-<a>verifiable credentials</a> in the <a>verifiable presentation</a> were issued
-to the same <a>holder</a> without leaking personally identifiable information
-that the <a>holder</a> did not intend to share.
-          </li>
-        </ul>
 
         <figure>
           <img style="margin: auto; display: block; width: 75%;"

--- a/index.html
+++ b/index.html
@@ -1153,10 +1153,7 @@ where the first item is a <a>URL</a> with the value
 <code>https://www.w3.org/ns/credentials/v2</code>. For reference, a copy of
 the base context is provided in Appendix <a href="#base-context"></a>.
 Subsequent items in the array MUST express context information and be composed
-of any combination of <a>URLs</a> or objects. It is RECOMMENDED that each
-<a>URL</a> in the <code>@context</code> be one which, if dereferenced, results
-in a document containing machine-readable information about the
-<code>@context</code>.
+of any combination of <a>URLs</a> or objects.
           </dd>
         </dl>
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -3108,6 +3108,11 @@ Any objects for which selective disclosure is desired SHOULD NOT be included as
 an object in the <code>relatedResource</code> array.
         </p>
         <p>
+Any failure to verify content integrity information that is vital to the
+validity of a <a>conforming document</a>, such as the integrity of related
+`@context` URLs, SHOULD result in a validation error.
+        </p>
+        <p>
 Implementers are urged to consult appropriate sources, such as the
 <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">
 FIPS 180-4 Secure Hash Standard</a> and the

--- a/index.html
+++ b/index.html
@@ -1152,8 +1152,9 @@ The value of the <code>@context</code> <a>property</a> MUST be an ordered set
 where the first item is a <a>URL</a> with the value
 <code>https://www.w3.org/ns/credentials/v2</code>. For reference, a copy of
 the base context is provided in Appendix <a href="#base-context"></a>.
-Subsequent items in the array MUST express context information and be composed
-of any combination of <a>URLs</a> or objects.
+Subsequent items in the array MUST be composed of any combination of
+<a>URLs</a> or objects where each is processable as a
+<a data-cite="JSON-LD11#the-context">JSON-LD Context</a>.
           </dd>
         </dl>
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -2231,9 +2231,9 @@ guideline:
 Status schemes MUST NOT be implemented in ways that enable tracking of
 individuals, such as an <a>issuer</a> being notified (either directly or
 indirectly) when a <a>verifier</a> is interested in a particular <a>holder</a>
-or <a>subject</a>. Unacceptable approaches include "phoning home", such that
+or <a>subject</a>. Unacceptable approaches include "phoning home," such that
 every use of a credential contacts the <a>issuer</a> of the credential to
-check the status for a specific individual, or "pseudonymity reduction",
+check the status for a specific individual, or "pseudonymity reduction,"
 such that every use of the credential causes a request for information
 from the <a>issuer</a> that can be used by the <a>issuer</a> to deduce
 <a>verifier</a> interest in a specific individual.

--- a/index.html
+++ b/index.html
@@ -3672,6 +3672,21 @@ credentials in a ZKP <a>presentation</a>.
           </figcaption>
         </figure>
 
+        <p>
+Specification authors that create <a href="#securing-verifiable-credentials">
+securing mechanisms</a> that provide unlinkability are provided the following
+guideline:
+        </p>
+
+        <ul>
+          <li>
+The unlinkable securing mechanism MUST NOT be designed in such a way that it
+leaks information that would enable the <a>verifier</a> to correlate the
+<a>holder</a> across multiple <a>verifiable presentations</a> to different
+<a>verifiers</a>.
+          </li>
+        </ul>
+
       </section>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -1458,10 +1458,10 @@ of this specification who want to support interoperable extensibility, do.
         </p>
 
         <p>
-All <a>credentials</a>, <a>presentations</a>, and encapsulated objects MUST
+All <a>credentials</a>, <a>presentations</a>, and encapsulated objects SHOULD
 specify, or be associated with, additional more narrow <a>types</a> (like
 <code>ExampleDegreeCredential</code>, for example) so software systems can
-process this additional information.
+more easily detect and process this additional information.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3128,9 +3128,11 @@ Any objects for which selective disclosure is desired SHOULD NOT be included as
 an object in the <code>relatedResource</code> array.
         </p>
         <p>
-Any failure to verify content integrity information that is vital to the
-validity of a <a>conforming document</a>, such as the integrity of content
-identified by related `@context` URLs, SHOULD result in a validation error.
+Specification authors that write algorithms that fetch a resource based on the
+`id` of an object inside a <a>conforming document</a> need to consider whether
+that resource's content is vital to the validity of that document. If it is, the
+specification MUST produce a validation error unless the resource has the
+expected media type and its bytes hash to the expected digest.
         </p>
         <p>
 Implementers are urged to consult appropriate sources, such as the

--- a/index.html
+++ b/index.html
@@ -651,7 +651,7 @@ information as a valid document.
 
     </section>
 
-    <section class="informative">
+    <section class="normative">
       <h2>Terminology</h2>
 
       <div data-include="./terms.html"></div>

--- a/index.html
+++ b/index.html
@@ -1153,7 +1153,7 @@ where the first item is a <a>URL</a> with the value
 <code>https://www.w3.org/ns/credentials/v2</code>. For reference, a copy of
 the base context is provided in Appendix <a href="#base-context"></a>.
 Subsequent items in the array MUST be composed of any combination of
-<a>URLs</a> or objects where each is processable as a
+<a>URLs</a> and/or objects where each is processable as a
 <a data-cite="JSON-LD11#the-context">JSON-LD Context</a>.
           </dd>
         </dl>
@@ -2229,14 +2229,14 @@ guideline:
         <ul>
           <li>
 Status schemes MUST NOT be implemented in ways that enable tracking of
-individuals, such as an <a>issuer</a> being notified (either directly, or
+individuals, such as an <a>issuer</a> being notified (either directly or
 indirectly) when a <a>verifier</a> is interested in a particular <a>holder</a>
 or <a>subject</a>. Unacceptable approaches include "phoning home", such that
 every use of a credential contacts the <a>issuer</a> of the credential to
-check the status for a specific individual, or reduction in pseudonymity,
-such that every use of the credential requests information from the
-<a>issuer</a> that can be used to deduce <a>verifier</a> interest in a
-specific individual.
+check the status for a specific individual, or "pseudonymity reduction",
+such that every use of the credential causes a request for information
+from the <a>issuer</a> that can be used by the <a>issuer</a> to deduce
+<a>verifier</a> interest in a specific individual.
           </li>
         </ul>
 
@@ -3129,8 +3129,8 @@ an object in the <code>relatedResource</code> array.
         </p>
         <p>
 Any failure to verify content integrity information that is vital to the
-validity of a <a>conforming document</a>, such as the integrity of related
-`@context` URLs, SHOULD result in a validation error.
+validity of a <a>conforming document</a>, such as the integrity of content
+identified by related `@context` URLs, SHOULD result in a validation error.
         </p>
         <p>
 Implementers are urged to consult appropriate sources, such as the
@@ -3693,15 +3693,15 @@ credentials in a ZKP <a>presentation</a>.
         </figure>
 
         <p>
-Specification authors that create <a href="#securing-verifiable-credentials">
-securing mechanisms</a> that provide unlinkability are provided the following
-guideline:
+The following guideline is provided for authors who create
+<a href="#securing-verifiable-credentials">securing mechanisms</a>
+specifications that provide unlinkability:
         </p>
 
         <ul>
           <li>
-The unlinkable securing mechanism MUST NOT be designed in such a way that it
-leaks information that would enable the <a>verifier</a> to correlate the
+Unlinkable securing mechanisms MUST NOT be designed in such a way that they
+leak information that would enable the <a>verifier</a> to correlate a
 <a>holder</a> across multiple <a>verifiable presentations</a> to different
 <a>verifiers</a>.
           </li>

--- a/index.html
+++ b/index.html
@@ -1756,14 +1756,14 @@ A <a>verifiable credential</a> MUST have an <code>issuer</code> <a>property</a>.
         <dl>
           <dt><var id="defn-issuer">issuer</var></dt>
           <dd>
-The value of the <code>issuer</code> <a>property</a> MUST either be a
-<a>URL</a>, or be an object containing an <code>id</code> <a>property</a>
+The value of the <code>issuer</code> <a>property</a> MUST be either a
+<a>URL</a>, or an object containing an <code>id</code> <a>property</a>
 whose value is a <a>URL</a>; in either case, the issuer selects this
 <a>URL</a> to identify itself in a globally unambiguous
 way. It is RECOMMENDED that the <a>URL</a> be one which, if dereferenced,
-results in a document containing machine-readable information about the
-<a>issuer</a> that can be used to <a>verify</a> the information expressed in the
-<a>credential</a>.
+results in a controller document [[?VC-CONTROLLER-DOCUMENT]] about the
+<a>issuer</a> that can be used to <a>verify</a> the information expressed in
+the <a>credential</a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -2220,6 +2220,26 @@ scope for this specification. A Verifiable Credential Specifications Directory
 for implementers who want to implement <a>verifiable credential</a>
 status checking.
         </p>
+
+        <p>
+Specification authors that create status schemes are provided the following
+guideline:
+        </p>
+
+        <ul>
+          <li>
+Status schemes MUST NOT be implemented in ways that enable tracking of
+individuals, such as an <a>issuer</a> being notified (either directly, or
+indirectly) when a <a>verifier</a> is interested in a particular <a>holder</a>
+or <a>subject</a>. Unacceptable approaches include "phoning home", such that
+every use of a credential contacts the <a>issuer</a> of the credential to
+check the status for a specific individual, or reduction in pseudonymity,
+such that every use of the credential requests information from the
+<a>issuer</a> that can be used to deduce <a>verifier</a> interest in a
+specific individual.
+          </li>
+        </ul>
+
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -3079,11 +3079,24 @@ There MUST NOT be more than one object in the <code>relatedResource</code> per
         <p>
 An object in the <code>relatedResource</code> array MAY contain a property named
 <code>mediaType</code> that indicates the expected media type for the indicated
-<code>resource</code>. If a <code>mediaType</code> is included it SHOULD be a
-valid media type as listed in the
-<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
-IANA Media Types</a> registry.
+<code>resource</code>. If a <code>mediaType</code> is included, its value
+SHOULD:
         </p>
+        <ul>
+          <li>
+be a valid media type as listed in the
+<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
+IANA Media Types</a> registry
+          </li>
+          <li>
+be used when retrieving the content, such as via the `Accept` HTTP Header
+          </li>
+          <li>
+match the retrieved content media type, such as via the `Content-Type` HTTP
+Header.
+          </li>
+        </ul>
+
         <p>
 Any object in the <a>verifiable credential</a> that contains an `id` [[URL]]
 property MAY be annotated with integrity information as specified in this


### PR DESCRIPTION
This PR attempts to address issue #1347 by making modifications to the specification based on @jyasskin's [review](https://github.com/w3c/vc-data-model/issues/1285):

#### 2. Terminology

- [x] Make section normative. [Fixed in e8a7c9f22d88bcc0777a63611348e267a659c0aa]

#### 4.1 Getting Started

- [x] Make section non-normative. [Fixed in cb3696e3d57352f498b05d47ef0364eb887d5e68]

#### 4.2 Contexts

- [x] Remove ""each URL in the @context be one which, if dereferenced, results in a document containing machine-readable information about the @context." statement since it just describes how JSON-LD works (the data model for the spec). [Fixed in f62f40c60802f6dc64eefd42785527a8909a917d]
- [x] Clarify what "express context information" means. [Fixed in 52dfb8cbbe41fa77f6bb202b632745f5be024cb0]

#### 4.4 Types

- [x] Downgrade "All credentials, presentations, and encapsulated objects MUST specify, or be associated with, additional more narrow types" from MUST to SHOULD. [Fixed in 9b210059852476736ac003c883d0d09aadc58962]

#### 4.7 Issuer

- [x] Update "the URL …, if dereferenced, results in a document … that can be used to verify the information expressed in the credential." to refer to controller documents. [Fixed in 6aa599c578cd87347ac117ebadf66e51a2b75a5c]

#### 5.4 Integrity of Related Resources

- [x] Update normative statements to say that the `Accept` header would be used for `mediaType` and the returned document would need to have that media type listed in the `Content-Type`. [Fixed in 9ebfe552e833ca62e02fc197b04e26e057172a59]
- [x] Specify that any `relatedResource` that fails content integrity protection results in a verification error. [Fixed in 8187708303a01c7ab5ef760cdcbdf2236b770113]

#### 5.8 Zero-Knowledge Proofs

- [x] Remove "The verifiable credential MUST contain a Proof" normative statement. [Fixed in 3a346e9cccb6f63e029b769f2902bbbe9ce8413f]
- [x] Delegate "not leaking information" to securing specifications. [Fixed in 3fdc1f7630bd6f28797ba2de41aa8725782017a9]
- [x] Delegate "The verifiable presentation SHOULD contain a proof property to enable …" to securing specifications. [Fixed in 3a346e9cccb6f63e029b769f2902bbbe9ce8413f, by not mentioning how to implement the securing mechanism -- which is up to the securing mechanism]

#### 7.10 Validity Checks

- [x] Add normative statements on `CredentialStatus` specifications to not enable individual tracking. [Fixed in fcfd9e5de575bedfc1b0281022fb13ce2e10a8c8]


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1357.html" title="Last updated on Nov 30, 2023, 2:41 PM UTC (90fb40d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1357/53450e9...90fb40d.html" title="Last updated on Nov 30, 2023, 2:41 PM UTC (90fb40d)">Diff</a>