### PR TITLE
Add `relatedResource` property to `VerifiablePresentation`

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -187,6 +187,10 @@
           "@container": "@graph",
           "@context": null
         },
+        "relatedResource": {
+          "@id": "https://www.w3.org/2018/credentials#relatedResource",
+          "@type": "@id"
+        },
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
           "@type": "@id"

--- a/index.html
+++ b/index.html
@@ -3080,7 +3080,7 @@ The requirement that contexts be listed in `relatedResource` is currently being
 debated in the VCWG. This requirement might be removed in future iterations of
 the specification.
         </p>
-        <p class="issue at-risk" title="Use of `relatedResource` in `VerifiablePresentation`">
+        <p class="issue atrisk" title="Use of `relatedResource` in `VerifiablePresentation`">
 The Working Group is seeking feedback from implementers on whether the
 `relatedResource` property is useful when used in `VerifiablePresentation`
 objects. Based on feedback, the Working Group might determine that the property

--- a/index.html
+++ b/index.html
@@ -3080,6 +3080,13 @@ The requirement that contexts be listed in `relatedResource` is currently being
 debated in the VCWG. This requirement might be removed in future iterations of
 the specification.
         </p>
+        <p class="issue at-risk" title="Use of `relatedResource` in `VerifiablePresentation`">
+The Working Group is seeking feedback from implementers on whether the
+`relatedResource` property is useful when used in `VerifiablePresentation`
+objects. Based on feedback, the Working Group might determine that the property
+is not useful and will then remove the feature during the Candidate
+Recommendation phase.
+        </p>
         <p>
 Each object in the <code>relatedResource</code> array MUST contain the
 following: the [[URL]] to the resource named <code>id</code> and the

--- a/index.html
+++ b/index.html
@@ -3054,25 +3054,26 @@ JSON-LD implementers seeking interoperability.
       <section>
         <h2>Integrity of Related Resources</h2>
         <p>
-When including a link to an external resource in a <a>verifiable credential</a>,
+When including a link to an external resource in a <a>conforming document</a>,
 it is desirable to know whether the resource that is pointed to is the same at
 signing time as it is at verification time. This applies to cases where there is
 an external resource that is remotely retrieved as well as to cases where the
-<a>issuer</a> and/or <a>verifier</a> may have local cached copies of a resource.
+<a>issuer</a> and/or <a>verifier</a> might have local cached copies of a
+resource.
         </p>
         <p>
 It is also desirable to know that the contents of the JSON-LD context(s) used in
-the <a>verifiable credential</a> are the same when used by both the
+a <a>conforming document</a> are the same when used by both the
 <a>issuer</a> and <a>verifier</a>.
         </p>
         <p>
-To validate that a resource referenced by a <a>verifiable credential</a> is the
+To validate that a resource referenced by a <a>conforming document</a> is the
 same at verification time as it is at issuing time, an implementer MAY include a
 property named <code id="defn-relatedResource">relatedResource</code> that
 stores an array of objects that describe additional integrity metadata about
-each resource referenced by the <a>verifiable credential</a>. If
+each resource referenced by the <a>conforming document</a>. If
 <code>relatedResource</code> is present, there MUST be an object in the array
-for each remote resource for each context used in the verifiable credential.
+for each remote resource used in the verifiable credential.
         </p>
         <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
 The requirement that contexts be listed in `relatedResource` is currently being
@@ -3118,7 +3119,7 @@ Header.
         </ul>
 
         <p>
-Any object in the <a>verifiable credential</a> that contains an `id` [[URL]]
+Any object in a <a>conforming document</a> that contains an `id` [[URL]]
 property MAY be annotated with integrity information as specified in this
 section by inclusion of <code>digestSRI</code>
 in the object.
@@ -3140,7 +3141,7 @@ Implementers are urged to consult appropriate sources, such as the
 FIPS 180-4 Secure Hash Standard</a> and the
 <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
 Commercial National Security Algorithm Suite 2.0</a> to ensure that they are
-chosing a current and reliable hash algorithm. At the time of this writing
+choosing a current and reliable hash algorithm. At the time of this writing
 `sha384` SHOULD be considered the minimum strength hash algorithm for use by
 implementers.
         </p>
@@ -3170,7 +3171,7 @@ An example of a related resource integrity object referencing JSON-LD contexts.
         </pre>
 
         <p>
-An example of an object in a `credentialSubject` that is refering to an
+An example of an object in a `credentialSubject` that is referring to an
 integrity protected image.
         </p>
 

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -103,10 +103,10 @@ property:
     label: Subresource integrity digest
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-digestSRI
     range: cred:sriString
-    see_also: 
+    see_also:
       - label: Subresource Integrity Metadata
         url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
-    
+
   - id: evidence
     label: Evidence
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-evidence
@@ -163,7 +163,7 @@ property:
 
   - id: relatedResource
     label: Related resource
-    domain: cred:VerifiableCredential
+    domain: [cred:VerifiableCredential, cred:VerifiablePresentation]
     range: IRI
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-relatedResource
 
@@ -198,7 +198,7 @@ datatype:
     label: Datatype for digest SRI values
     upper_value: xsd:string
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#the-sristring-datatype
-    see_also: 
+    see_also:
       - label: Subresource Integrity Metadata
         url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
- 
+


### PR DESCRIPTION
This PR attempts to address issue #1360 by allowing the `relatedResource` property to be used on a `VerifiablePresentation`. It also adds an "at risk" issue marker noting that the feature might be removed in the Candidate Recommendation phase based on implementer feedback.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1370.html" title="Last updated on Dec 4, 2023, 4:23 PM UTC (de83559)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1370/62a667c...de83559.html" title="Last updated on Dec 4, 2023, 4:23 PM UTC (de83559)">Diff</a>