### PR TITLE
Add support for Enveloped Verifiable Credentials (2nd attempt)

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -77,6 +77,9 @@
     "description": "https://schema.org/description",
     "name": "https://schema.org/name",
 
+    "EnvelopedVerifiableCredential":
+      "https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential",
+
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
       "@context": {

--- a/index.html
+++ b/index.html
@@ -2362,7 +2362,7 @@ enveloped <a>verifiable credential</a>:
   "type": ["VerifiablePresentation", "ExamplePresentation"],
   <span class="highlight">"verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
-    "id": "data:application/vc+ld+json+sd-jwt;base64,QzVjV...RMjUK==",
+    "id": "data:application/vc+ld+json+sd-jwt;QzVjV...RMjU",
     "type": "EnvelopedVerifiableCredential"
   }]</span>
 }

--- a/index.html
+++ b/index.html
@@ -2342,7 +2342,7 @@ Used to associate an object containing an enveloped <a>verifiable credential</a>
 with the `verifiableCredential` property in a <a>verifiable presentation</a>.
 The `@context` value of the object MUST follow all of the "MUST" statements in
 Section <a href="#contexts"></a>. The `id` value of the object MUST be a `data:`
-URL that expresses a secured <a>verifiable credential</a> using an enveloping
+URL [[RFC2397]] that expresses a secured <a>verifiable credential</a> using an enveloping
 security scheme, such as [[[VC-JOSE-COSE]]] [[VC-JOSE-COSE]]. The `type` value
 of the object MUST be `EnvelopedVerifiableCredential`.
             </dd>

--- a/index.html
+++ b/index.html
@@ -2325,6 +2325,52 @@ provided in the Securing Verifiable Credentials using JOSE and COSE
         </p>
 
         <section>
+          <h4>Enveloped Verifiable Credentials</h4>
+
+          <p>
+It is possible to include one or more <a>verifiable credentials</a> in a
+<a>verifiable presentation</a> that have been secured using a securing mechanism
+that "envelopes" the payload, such as [[[?VC-JOSE-COSE]]] [[?VC-JOSE-COSE]].
+This can be accomplished by associating the `verifiableCredential` property with
+an object that has a `type` of `EnvelopedVerifiableCredential`.
+          </p>
+
+          <dl>
+            <dt id="defn-EnvelopedVerifiableCredential">EnvelopedVerifiableCredential</dt>
+            <dd>
+Used to associate an object containing an enveloped <a>verifiable credential</a>
+with the `verifiableCredential` property in a <a>verifiable presentation</a>.
+The `@context` value of the object MUST follow all of the "MUST" statements in
+Section <a href="#contexts"></a>. The `id` value of the object MUST be a `data:`
+URL that expresses a secured <a>verifiable credential</a> using an enveloping
+security scheme, such as [[[VC-JOSE-COSE]]] [[VC-JOSE-COSE]]. The `type` value
+of the object MUST be `EnvelopedVerifiableCredential`.
+            </dd>
+          </dl>
+
+        <p>
+The example below shows a <a>verifiable presentation</a> that contains an
+enveloped <a>verifiable credential</a>:
+        </p>
+
+        <pre class="example nohighlight" title="Basic structure of a presentation">
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
+  "type": ["VerifiablePresentation", "ExamplePresentation"],
+  <span class="highlight">"verifiableCredential": [{
+    "@context": "https://www.w3.org/ns/credentials/v2",
+    "id": "data:application/vc+ld+json+sd-jwt;base64,QzVjV...RMjUK==",
+    "type": "EnvelopedVerifiableCredential"
+  }]</span>
+}
+        </pre>
+
+        </section>
+
+        <section>
           <h4>Presentations Using Derived Credentials</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -2328,8 +2328,8 @@ provided in the Securing Verifiable Credentials using JOSE and COSE
           <h4>Enveloped Verifiable Credentials</h4>
 
           <p>
-It is possible to include one or more <a>verifiable credentials</a> in a
-<a>verifiable presentation</a> that have been secured using a securing mechanism
+It is possible for a <a>verifiable presentation</a> to include one or more
+<a>verifiable credentials</a> that have been secured using a securing mechanism
 that "envelopes" the payload, such as [[[?VC-JOSE-COSE]]] [[?VC-JOSE-COSE]].
 This can be accomplished by associating the `verifiableCredential` property with
 an object that has a `type` of `EnvelopedVerifiableCredential`.

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -35,6 +35,10 @@ class:
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-confidence-method
     status: reserved
 
+  - id: EnvelopedVerifiableCredential
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential
+    label: Enveloped verifiable credential
+
   - id: JsonSchema
     label: JSON schema validator
     defined_by: https://www.w3.org/TR/vc-json-schema/#jsonschema
@@ -102,10 +106,10 @@ property:
     label: Subresource integrity digest
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-digestSRI
     range: cred:sriString
-    see_also: 
+    see_also:
       - label: Subresource Integrity Metadata
         url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
-    
+
   - id: evidence
     label: Evidence
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-evidence
@@ -195,7 +199,7 @@ datatype:
     label: Datatype for digest SRI values
     upper_value: xsd:string
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#the-sristring-datatype
-    see_also: 
+    see_also:
       - label: Subresource Integrity Metadata
         url:  https://www.w3.org/TR/SRI/#the-integrity-attribute
- 
+


### PR DESCRIPTION
This PR attempts to address issue #1352 by adding a new feature for embedding "enveloped" Verifiable Credentials in Verifiable Presentations. This PR integrates @iherman's PR #1372.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1379.html" title="Last updated on Dec 15, 2023, 5:23 PM UTC (3884d4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1379/40be9e0...3884d4e.html" title="Last updated on Dec 15, 2023, 5:23 PM UTC (3884d4e)">Diff</a>