### PR TITLE
Remove document conformance checking algorithm section

### DIFF
--- a/index.html
+++ b/index.html
@@ -585,15 +585,15 @@ license is suspended).
 
       <section id="conformance" class="normative">
         <p>
-A <dfn>conforming document</dfn> is any concrete expression of the data model
-that complies with the normative statements in this specification.
-Specifically, all relevant normative statements in Sections
+A <dfn>conforming document</dfn> is a compact JSON-LD document that
+complies with all of the normative "MUST" statements in this specification.
+Specifically, the relevant normative "MUST" statements in Sections
 <a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
-<a href="#syntaxes"></a> of this document MUST be enforced. A serialization
-format for the conforming document MUST be deterministic, bi-directional,
-and lossless as described in Section <a href="#syntaxes"></a>.
-The <a>conforming document</a> MAY be transmitted or stored in any such
-serialization format.
+<a href="#syntaxes"></a> of this document MUST be enforced. Other serialization
+formats for the conforming document MAY be used, and if they are, any
+transformation to or from a conforming document MUST be deterministic,
+bi-directional, and lossless. The <a>conforming document</a> MAY be transmitted
+or stored in any such serialization format.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -594,10 +594,7 @@ Sections <a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
 A conforming document is either a <a>verifiable credential</a> that MUST be
 serialized using the `application/vc+ld+json` media type or a
 <a>verifiable presentation</a> that MUST be serialized using the
-`application/vp+ld+json` media type. Other serialization formats for the
-conforming document MAY be used, and if they are, further guidance in Section <a
-href="#ecosystem-compatibility"></a> MUST be followed. The <a>conforming
-document</a> MAY be transmitted or stored in any such serialization format.
+`application/vp+ld+json` media type.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -585,15 +585,16 @@ license is suspended).
 
       <section id="conformance" class="normative">
         <p>
-A <dfn>conforming document</dfn> is a compact JSON-LD document that
-complies with all of the relevant "MUST" statements in this specification.
-Specifically, the relevant normative "MUST" statements in Sections
-<a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
+A <dfn>conforming document</dfn> is a
+<a data-cite="JSON-LD11-API#compaction-algorithms">compacted</a> JSON-LD
+document that complies with all of the relevant "MUST" statements in this
+specification. Specifically, the relevant normative "MUST" statements in
+Sections <a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
 <a href="#syntaxes"></a> of this document MUST be enforced. Other serialization
 formats for the conforming document MAY be used, and if they are, further
-guidance in Section <a href="#ecosystem-compatibility"></a> MUST be
-followed. The <a>conforming document</a> MAY be transmitted
-or stored in any such serialization format.
+guidance in Section <a href="#ecosystem-compatibility"></a> MUST be followed.
+The <a>conforming document</a> MAY be transmitted or stored in any such
+serialization format.
         </p>
 
         <p>
@@ -4016,7 +4017,7 @@ storage engines.
 
         <p>
 [[!JSON-LD]] is useful when extending the data model described in this
-specification. Instances of the data model are encoded in JSON-LD compact
+specification. Instances of the data model are encoded in JSON-LD compacted
 form [[!JSON-LD]] and include the <code>@context</code> <a>property</a>. The
 <a href="https://www.w3.org/TR/json-ld/#the-context">JSON-LD context</a>
 is described in detail in the [[!JSON-LD]] specification and its use is
@@ -4037,7 +4038,7 @@ Model is available at <code>https://www.w3.org/2018/credentials</code>.
         <p>
 This specification restricts the usage of JSON-LD representations of
 the data model. JSON-LD <a
-href="https://www.w3.org/TR/json-ld/#compacted-document-form">compact document
+href="https://www.w3.org/TR/json-ld/#compacted-document-form">compacted document
 form</a> MUST be utilized for all representations of the data model in the
 base media type, `application/vc+ld+json`.
         </p>
@@ -7218,7 +7219,7 @@ Add table of reserved properties for properties that are not yet standardized
 or are at risk for removal.
         </li>
         <li>
-Restrict data model expression to JSON-LD in compact document form.
+Restrict data model expression to JSON-LD in compacted document form.
         </li>
         <li>
 Update ZKP section to remove older content.

--- a/index.html
+++ b/index.html
@@ -4503,25 +4503,12 @@ information related to the verification failure.
           </li>
           <li>
 Ensure that the <var>result</var>.<var>document</var> is a
-<a>conforming document</a> by performing the following steps:
-            <ol class="algorithm">
-              <li>
-Set <var>dataModelConformanceChecked</var> to the result of executing the
-<a href="#data-model-conformance-checking">data model conformance checking
-algorithm</a> with <var>document</var> passed as input to the algorithm.
-              </li>
-              <li>
-Set <var>status</var>, <var>document</var>, <var>warnings</var>, and
-<var>errors</var> in <var>result</var> to their respective properties in
-<var>dataModelConformanceChecked</var>.
-              </li>
-              <li>
-If <var>result</var>.<var>status</var> is `false`, the provided
-<var>inputBytes</var> contains a non-conforming document. Return
-<var>result</var>, which will contain warning and error information
-related to the verification failure.
-              </li>
-            </ol>
+<a>conforming document</a>. If it is not, set
+<var>result</var>.<var>status</var> to `false`, remove the
+<var>document</var> property from <var>result</var>, and add at least
+one <a href="#MALFORMED_VALUE_ERROR">MALFORMED_VALUE_ERROR</a> to
+<var>result</var>.<var>errors</var>. Other warnings and errors MAY be included
+to aid any debugging process.
           </li>
           <li>
 Return <var>result</var>.
@@ -4535,122 +4522,6 @@ a different order than that provided above as long as the
 implementation returns errors for the same inputs.
 Implementations MAY produce different errors than described above.
         </p>
-
-      </section>
-
-      <section class="normative">
-        <h3>Data Model Conformance Checking</h3>
-
-        <p>
-The algorithm in this section can be used to determine if a provided document is
-conformant with the data model provided in this specification. This algorithm
-takes a document (object <var>inputDocument</var>) and produces an object
-(<var>dataModelConformanceChecked</var>) that contains the following:
-        </p>
-
-        <ul>
-          <li>
-a verification status (boolean <var>status</var>)
-          </li>
-          <li>
-a verified document (object <var>document</var>)
-          </li>
-          <li>
-zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)
-          </li>
-          <li>
-zero or more errors (array of <a>ProblemDetails</a> <var>errors</var>)
-          </li>
-        </ul>
-
-        <p>
-The data model verification algorithm is as follows:
-        </p>
-
-        <ol class="algorithm">
-          <li>
-Set <var>dataModelConformanceChecked</var> to an empty object. Initialize the following
-fields in <var>dataModelConformanceChecked</var>: <var>status</var> to `false`,
-<var>warnings</var> to an empty array, and <var>errors</var> to an empty array.
-          </li>
-          <li>
-Ensure that the `@context` property of <var>document</var> conforms to the
-statements in <a href="#contexts"></a>. If not, return
-<var>dataModelConformanceChecked</var>, which will contain a false verification status.
-          </li>
-          <li>
-Starting at the top level, recursively process each object <var>obj</var> in
-<var>document</var>, setting <a href="#MALFORMED_VALUE_ERROR">
-MALFORMED_VALUE_ERROR</a> errors in
-<var>dataModelConformanceChecked</var>.<var>errors</var> if errors are found, by
-performing the following checks:
-            <ol class="algorithm">
-              <li>
-If present, ensure that the `id` property conforms to the "MUST" statements in
-Section <a href="#identifiers"></a>.
-              </li>
-              <li>
-If present, ensure that the `type` property conforms to the "MUST" statements in
-Section <a href="#types"></a>.
-              </li>
-              <li>
-If present, ensure that the `name` and/or `description` properties conform to
-the "MUST" statements in Section <a href="#names-and-descriptions"></a>.
-              </li>
-              <li>
-If the `type` property is present and contains an object with the type
-`VerifiablePresentation`, ensure that the object conforms to the
-"MUST" statements in Section <a href="#presentations-0"></a>.
-              </li>
-              <li>
-If the `type` property is present and contains an object with the type
-`VerifiableCredential`, perform the following checks:
-                <ol class="algorithm">
-                  <li>
-Ensure that the `credentialSubject` property conforms to the
-"MUST" statements in Section <a href="#credential-subject"></a>.
-                  </li>
-                  <li>
-Ensure that the `issuer` property conforms to the
-"MUST" statements in Section <a href="#issuer"></a>.
-                  </li>
-                  <li>
-If present, ensure that the `validFrom` and/or `validUntil` properties conform
-to the "MUST" statements in Section <a href="#validity-period"></a>.
-                  </li>
-                  <li>
-If present, ensure that the `credentialStatus` property conforms to
-the "MUST" statements in Section <a href="#status"></a>.
-                  </li>
-                  <li>
-If present, ensure that the `credentialSchema` property conforms to
-the "MUST" statements in Section <a href="#data-schemas"></a>.
-                  </li>
-                  <li>
-If present, ensure that the `relatedResource` property conforms to
-the "MUST" statements in Section <a href="#integrity-of-related-resources"></a>.
-                  </li>
-                  <li>
-If present, ensure that the `refreshService` property conforms to
-the "MUST" statements in Section <a href="#refreshing"></a>.
-                  </li>
-                  <li>
-If present, ensure that the `evidence` property conforms to
-the "MUST" statements in Section <a href="#evidence"></a>.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-          <li>
-If no errors were detected to this point, set
-<var>dataModelConformanceChecked</var>.<var>document</var> to <var>inputDocument</var>,
-<var>dataModelConformanceChecked</var>.<var>status</var> to `true`.
-          </li>
-          <li>
-Return <var>dataModelConformanceChecked</var>.
-          </li>
-        </ol>
 
       </section>
 
@@ -4896,7 +4767,7 @@ https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE_ERROR
 The value associated with a particular <a>property</a> is malformed. The
 name of the <a>property</a> and the path to the property SHOULD be provided
 in the <a>ProblemDetails</a> object. See Section
-<a href="#data-model-conformance-checking"></a>.
+<a href="#verification"></a>.
           </dd>
         </dl>
 

--- a/index.html
+++ b/index.html
@@ -586,13 +586,13 @@ license is suspended).
       <section id="conformance" class="normative">
         <p>
 A <dfn>conforming document</dfn> is a compact JSON-LD document that
-complies with all of the normative "MUST" statements in this specification.
+complies with all of the relevant "MUST" statements in this specification.
 Specifically, the relevant normative "MUST" statements in Sections
 <a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
 <a href="#syntaxes"></a> of this document MUST be enforced. Other serialization
-formats for the conforming document MAY be used, and if they are, any
-transformation to or from a conforming document MUST be deterministic,
-bi-directional, and lossless. The <a>conforming document</a> MAY be transmitted
+formats for the conforming document MAY be used, and if they are, further
+guidance in Section <a href="#ecosystem-compatibility"></a> MUST be
+followed. The <a>conforming document</a> MAY be transmitted
 or stored in any such serialization format.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -590,11 +590,14 @@ A <dfn>conforming document</dfn> is a
 document that complies with all of the relevant "MUST" statements in this
 specification. Specifically, the relevant normative "MUST" statements in
 Sections <a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
-<a href="#syntaxes"></a> of this document MUST be enforced. Other serialization
-formats for the conforming document MAY be used, and if they are, further
-guidance in Section <a href="#ecosystem-compatibility"></a> MUST be followed.
-The <a>conforming document</a> MAY be transmitted or stored in any such
-serialization format.
+<a href="#syntaxes"></a> of this document MUST be enforced.
+A conforming document is either a <a>verifiable credential</a> that MUST be
+serialized using the `application/vc+ld+json` media type or a
+<a>verifiable presentation</a> that MUST be serialized using the
+`application/vp+ld+json` media type. Other serialization formats for the
+conforming document MAY be used, and if they are, further guidance in Section <a
+href="#ecosystem-compatibility"></a> MUST be followed. The <a>conforming
+document</a> MAY be transmitted or stored in any such serialization format.
         </p>
 
         <p>
@@ -3865,12 +3868,9 @@ Authentic Chained Data Containers</a> (ACDCs).
         <p>
 If conceptually aligned digital credential formats can be transformed into a
 <a>conforming document</a> according to the rules provided in this section, they
-are considered <em>"compatible with the W3C Verifiable Credentials ecosystem"</em>.
-A <a>conforming document</a> is either a <a>verifiable credential</a> serialized
-as the `application/vc+ld+json` media type or a <a>verifiable presentation</a>
-serialized as the `application/vp+ld+json` media type. Specifications that
-describe how to perform transformations that enable compatibility with
-the Verifiable Credentials ecosystem:
+are considered <em>"compatible with the W3C Verifiable Credentials
+ecosystem"</em>. Specifications that describe how to perform transformations
+that enable compatibility with the Verifiable Credentials ecosystem:
         </p>
 
         <ul>


### PR DESCRIPTION
This PR attempts to address issue #1375 by removing the document conformance checking algorithm section, clarifying the definition of "document conformance", and then using the updated definition to reduce the (arguably) repeated conformance language.

/cc @jyasskin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1381.html" title="Last updated on Dec 17, 2023, 2:09 AM UTC (a515e6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1381/40be9e0...a515e6f.html" title="Last updated on Dec 17, 2023, 2:09 AM UTC (a515e6f)">Diff</a>