### PR TITLE
Remove mentions to media type parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -4460,7 +4460,7 @@ a status (boolean <var>status</var>)
 a <a>conforming document</a> (object <var>document</var>)
           </li>
           <li>
-a media type (string <var>mediaType</var>), including any media type parameters
+a media type (string <var>mediaType</var>)
           </li>
           <li>
 zero or more warnings (array of <a>ProblemDetails</a> <var>warnings</var>)
@@ -4500,6 +4500,15 @@ secured. Return <var>result</var>, which will contain warning and error
 information related to the verification failure.
               </li>
             </ol>
+          </li>
+          <li>
+Ensure that the <var>result</var>.<var>mediaType</var> value is either
+`application/vc+ld+json` or `application/vp+ld+json` and does not contain any
+media type parameters, as defined in [[RFC6838]]. If the checks fail, set
+<var>result</var>.<var>status</var> to `false`, and add at least one <a
+href="#MEDIA_TYPE_ERROR">MEDIA_TYPE_ERROR</a> to
+<var>result</var>.<var>errors</var>. Other warnings and errors MAY be included
+to aid any debugging process. Return <var>result</var>.
           </li>
           <li>
 Ensure that the <var>result</var>.<var>document</var> is a

--- a/index.html
+++ b/index.html
@@ -4502,15 +4502,6 @@ information related to the verification failure.
             </ol>
           </li>
           <li>
-Ensure that the <var>result</var>.<var>mediaType</var> value is either
-`application/vc+ld+json` or `application/vp+ld+json` and does not contain any
-media type parameters, as defined in [[RFC6838]]. If the checks fail, set
-<var>result</var>.<var>status</var> to `false`, and add at least one <a
-href="#MEDIA_TYPE_ERROR">MEDIA_TYPE_ERROR</a> to
-<var>result</var>.<var>errors</var>. Other warnings and errors MAY be included
-to aid any debugging process. Return <var>result</var>.
-          </li>
-          <li>
 Ensure that the <var>result</var>.<var>document</var> is a
 <a>conforming document</a> by performing the following steps:
             <ol class="algorithm">


### PR DESCRIPTION
This PR addresses issue #1363 by ensuring that the use of media type parameters will result in a verification failure.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1382.html" title="Last updated on Dec 17, 2023, 2:13 AM UTC (ed30f01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1382/40be9e0...ed30f01.html" title="Last updated on Dec 17, 2023, 2:13 AM UTC (ed30f01)">Diff</a>