### PR TITLE
Updating the vocab diagram

### DIFF
--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -21,18 +21,6 @@
     </script>
     <script class="remove">
       var respecConfig = {
-        localBiblio: {
-          "VC-DATA-MODEL": {
-            title: "Verifiable Credentials Data Model v2.0",
-            href: "https://www.w3.org/TR/vc-data-model-2.0/",
-            authors: [
-              "Manu Sporny", "Grant Noble", "Dave Longley",
-              "Daniel C. Burnett", "Brent Zundel", "Kyle Den Hartog",
-              "Orie Steel", "Michael B. Jones", "Gabe Cohen"
-            ],
-            publisher: "W3C"
-          }
-        },
         specStatus:  "base",
         shortName:   "2018/credentials/",
         thisVersion: "https://www.w3.org/2018/credentials/",
@@ -162,17 +150,6 @@
         In some cases, a local explanation is necessary to complement, or to replace, the definition found in an external specification. For instance, this is so when the term is needed to provide a consistent structure to the RDFS vocabulary, such as when the term defines a common supertype for class instances that are used as objects of specific properties, or when <a href="https://www.w3.org/TR/rdf12-concepts/#section-rdf-graph">RDF Graphs</a> are involved. For such cases, the extra definition is included in the current document (and the `rdfs:comment` property is used to include them in the RDFS representations).
       </p>
       <figure id="vocabulary-diagram" style="text-align:center">
-        <!--
-          Original diagram is in https://drive.google.com/file/d/1-kg7AzhahSzIwiIHeh5ANGJB_JK-kugs/view?usp=drive_link
-          using the draw.io (diagrams.net plugin for google).
-          The diagram is exported into SVG, and then the following editorial changes should be done (using any text editor):
-          - The "width" and "height" attributes in the top level <svg> element must be removed (to make the diagram rescale if 
-            viewed directly)
-          - add the aria-details="#vocabulary-diagram-alt" attribute to the top level svg element
-
-          The exported SVG can also be viewed and edited inkscape. (The reason draw.io is used, instead of using
-          exclusively inkscape, is because the connecting line feature of inkscape is buggy.)
-        -->
         <div data-include="vocabulary.svg" data-include-replace="true" data-oninclude="massageSVGLinks"></div>
         <figcaption>Overview diagram of the vocabulary (without the deprecated items).<br />
           A separate, stand-alone <a href="vocabulary.svg" target="_blank">SVG version</a> of the diagram, as well as a <a href="#vocabulary-diagram-alt">textual description</a>,
@@ -270,15 +247,14 @@
         </p>
         <p>  
           In the middle of the diagram there is a column of labeled boxes, all styled as Property. 
-          The labels, from top to bottom, are: "credentialSchema",
-          "credentialStatus", "credentialSubject", "issuer", "evidence",
-          "refreshService", "renderMethod", "confidenceMethod", "termsOfUse", "validFrom",
+          The labels, from top to bottom, are: "credentialSchema", "credentialStatus", "credentialSubject", 
+          "issuer", "evidence", "refreshService", "renderMethod", "confidenceMethod", "termsOfUse", "validFrom",
           "validUntil", and "holder". 
-          On the left side of this column, there are four labeled ellipses, styled as Class. 
+          On the left side of this column, there are five labeled ellipses, styled as Class. 
           These are, from top to bottom, "VerifiableCredential", "JsonSchemaCredential",
-          "VerifiableCredentialGraph", and "VerifiablePresentation". 
+          "EnvelopedVerifiableCredential", "VerifiableCredentialGraph", and "VerifiablePresentation". 
           There is also a small, unlabeled circle, which serves as an intersection point for connector
-          lines, with two pointing in, and three pointing out.
+          lines, with two pointing in, and four pointing out.
         </p>
         <p>
           The "VerifiableCredential" ellipse is connected to the "credentialSchema", "credentialStatus",
@@ -286,8 +262,8 @@
           and "confidenceMethod" boxes, through connecting lines styled as Domain Of. 
           It is also connected to the crossing point circle with a similar connecting line,
           styled as Domain Of.
-          The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" 
-          and "verifiableCredential" boxes, with a similar connecting line, styled as Domain Of. 
+          The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" and 
+          "verifiableCredential" boxes, with a similar connecting line styled as Domain Of. 
           The crossing point circle is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a 
           connecting line styled as Domain Of.
           The "verifiableCredential" box is connected to the "VerifiableCredentialGraph" ellipse with a connecting
@@ -295,7 +271,7 @@
           The "JsonSchemaCredential" ellipse is connected to the "VerifiableCredential" ellipse with a 
           connecting line styled as Superclass. 
           Finally, the "VerifiableCredentialGraph" ellipse is connected to the "VerifiableCredential"
-          ellipse with a connector line styled as Contains.
+          and "EnvelopedVerifiableCredential" ellipses with connector lines styled as Contains.
         </p>
         <p>
           On the right side of the column, there is another column of ellipses, styled as "Class", and labeled as "CredentialSchema",
@@ -307,14 +283,14 @@
         <p>
           The "CredentialSchema" ellipse is connected to one more ellipse, on the far right
           side of the diagram, styled as Class and labeled as "JsonSchema", with a connecting line
-          styled as Superclass. This "JsonSchema" ellipse is also connected to a Property box
-          labeled as "jsonSchema", through a connector line styled as Domain Of. This "jsonSchema"
-          box is connected to a Datatype shape labeled as "rdf:JSON", with a connecting line
-          styled as Range. 
+          styled as Superclass. 
+          This "JsonSchema" ellipse is also connected to a Property box labeled as "jsonSchema", 
+          through a connector line styled as Domain Of, and to a Datatype shape
+          labeled as "rdf:JSON", through a connecting line styled as Range. 
         </p>
         <p>
           Finally, on the lower far right side of the diagram, there is a separate Property box labeled as 
-          "digestSRI", connected to a Datatype shape labeled as "sristring", with a connecting line 
+          "digestSRI", connected to a Datatype shape labeled as "sriString", with a connecting line 
           styled as Range.
         </p>
       </details>

--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -1,12 +1,12 @@
-<mxfile host="Electron" modified="2023-09-30T08:19:13.594Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.0 Chrome/114.0.5735.289 Electron/25.8.3 Safari/537.36" etag="P2DNnCw8gU-rS8J6qqE1" version="22.0.0" type="device">
+<mxfile host="Electron" modified="2023-12-10T15:07:48.508Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.2 Chrome/114.0.5735.289 Electron/25.9.4 Safari/537.36" etag="pWKSvkn9tbMr6_T2Y-XU" version="22.1.2" type="device">
   <diagram name="Page-1" id="5wcF2D67hh1iBqyEtvuE">
-    <mxGraphModel dx="3310" dy="2042" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+    <mxGraphModel dx="3282" dy="2106" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-1451" y="-384.80545548121466" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-1451" y="-305.2954554812147" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
@@ -53,12 +53,15 @@
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-1474.5" y="-592.8857436953165" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-1474.5" y="-449.9957436953165" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="1oUjKqBKF74gJ-cnWfdO-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=classicThin;endFill=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="-1251" y="-640.9042717447246" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="-1290" y="-650" />
+            </Array>
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
@@ -88,32 +91,32 @@
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-486" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-881" y="-485" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-429" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-881" y="-428" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-372" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-881" y="-371" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-316" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-881" y="-315" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-259" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-881" y="-258" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-202.75913535769416" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-881" y="-201" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
@@ -247,37 +250,37 @@
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-433.84791559444164" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-434.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-546.8911477097273" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-548.0023160061761" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-490.86953165208445" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-491.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-377.8262995367988" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-377.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-321.80468347915604" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-321.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-830.9776119402985" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-830.9776119402986" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-774.9559958826557" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-591" y="-774.0023160061761" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-35" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-1" target="lZdwYr-LXM3OhQDUA7XR-33" edge="1">
@@ -336,113 +339,6 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="usrDyYZYH79wCYu34c_K-6" value="" style="group" parent="1" vertex="1" connectable="0">
-          <mxGeometry x="-1598" y="-62" width="1621" height="54.5" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-45" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="usrDyYZYH79wCYu34c_K-6" vertex="1">
-          <mxGeometry width="1595" height="54.5" as="geometry" />
-        </mxCell>
-        <mxCell id="usrDyYZYH79wCYu34c_K-5" value="" style="group" parent="usrDyYZYH79wCYu34c_K-6" vertex="1" connectable="0">
-          <mxGeometry x="7" y="2.5" width="1614" height="49.5" as="geometry" />
-        </mxCell>
-        <mxCell id="usrDyYZYH79wCYu34c_K-1" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="718" y="4.75" width="163.39999999999998" height="40" as="geometry" />
-        </mxCell>
-        <UserObject label="" id="usrDyYZYH79wCYu34c_K-2">
-          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="usrDyYZYH79wCYu34c_K-1" vertex="1">
-            <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <mxCell id="usrDyYZYH79wCYu34c_K-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="usrDyYZYH79wCYu34c_K-1" vertex="1">
-          <mxGeometry x="13" width="90" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="OI71fulDIgHqbVsoXd_f-4" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="1424" y="4.75" width="190" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="OI71fulDIgHqbVsoXd_f-1" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" parent="OI71fulDIgHqbVsoXd_f-4" edge="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="84" y="26.5" as="sourcePoint" />
-            <mxPoint x="157" y="26.72" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="OI71fulDIgHqbVsoXd_f-3" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" parent="OI71fulDIgHqbVsoXd_f-4" vertex="1">
-          <mxGeometry width="70" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-50" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="175" y="6.1875" width="170" height="37.125" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-51" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
-          <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-52" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-50" vertex="1">
-          <mxGeometry width="70" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-56" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="894" y="6.1875" width="170" height="37.125" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-57" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-56" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="87" y="17.94375" as="sourcePoint" />
-            <mxPoint x="167" y="18.5625" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-58" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-56" vertex="1">
-          <mxGeometry x="-5" width="80" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-59" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="1091" y="6.1875" width="136" height="37.125" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-60" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=5 2 2 2;" parent="lZdwYr-LXM3OhQDUA7XR-59" edge="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="74" y="18.5625" as="sourcePoint" />
-            <mxPoint x="154" y="18.5625" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="130" y="18.5625" />
-              <mxPoint x="130" y="18.5625" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-61" value="Domain&lt;br&gt;of" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-59" vertex="1">
-          <mxGeometry y="-5" width="60" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-62" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="1259" y="6.1875" width="160" height="37.125" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-63" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="lZdwYr-LXM3OhQDUA7XR-62" edge="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="67" y="18.5625" as="sourcePoint" />
-            <mxPoint x="147" y="18.5625" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-64" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-62" vertex="1">
-          <mxGeometry width="60" height="30" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-65" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="360" y="3.09375" width="160" height="43.3125" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-66" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
-          <mxGeometry x="65" y="4.95" width="100" height="28.004625" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-67" value="Reserved&lt;br&gt;class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-65" vertex="1">
-          <mxGeometry x="-10" y="1.8125" width="70" height="40" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-71" value="" style="group" parent="usrDyYZYH79wCYu34c_K-5" vertex="1" connectable="0">
-          <mxGeometry x="532" width="176" height="49.5" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-55" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
-          <mxGeometry y="7" width="70" height="40" as="geometry" />
-        </mxCell>
-        <UserObject label="" link="https://www.w3.org/2018/credentials#evidence" id="lZdwYr-LXM3OhQDUA7XR-70">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="lZdwYr-LXM3OhQDUA7XR-71" vertex="1">
-            <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-48" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" parent="usrDyYZYH79wCYu34c_K-5" vertex="1">
-          <mxGeometry x="60" y="11.1375" width="100" height="28.004625" as="geometry" />
-        </mxCell>
-        <mxCell id="lZdwYr-LXM3OhQDUA7XR-49" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="usrDyYZYH79wCYu34c_K-5" vertex="1">
-          <mxGeometry y="6.1875" width="50" height="30" as="geometry" />
-        </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-207.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
@@ -466,11 +362,11 @@
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
-            <mxGeometry x="-881" y="-599" width="171" height="27.21049922799794" as="geometry" />
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-881" y="-598" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="NdHKz3nYJsEpI_Vai11b-2" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" edge="1" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="NdHKz3nYJsEpI_Vai11b-1">
+        <mxCell id="NdHKz3nYJsEpI_Vai11b-2" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="NdHKz3nYJsEpI_Vai11b-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-1162" y="-840" as="sourcePoint" />
             <mxPoint x="-871" y="-631" as="targetPoint" />
@@ -480,20 +376,138 @@
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-207.5" y="-429.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
-        <UserObject label="&lt;font color=&quot;#000000&quot;&gt;sriString&lt;/font&gt;" link="https://w3id.org/security/#sriString" id="NdHKz3nYJsEpI_Vai11b-4">
-          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+        <UserObject label="&lt;font color=&quot;#000000&quot;&gt;sriString&lt;/font&gt;" link="https://www.w3.org/2018/credentials#sriString" id="NdHKz3nYJsEpI_Vai11b-4">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-195.99999999999994" y="-334.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="NdHKz3nYJsEpI_Vai11b-5" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" edge="1" parent="1" source="NdHKz3nYJsEpI_Vai11b-3" target="NdHKz3nYJsEpI_Vai11b-4">
+        <mxCell id="NdHKz3nYJsEpI_Vai11b-5" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="NdHKz3nYJsEpI_Vai11b-3" target="NdHKz3nYJsEpI_Vai11b-4" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-310" y="-178.80288214101893" as="sourcePoint" />
             <mxPoint x="-191" y="-178.80288214101893" as="targetPoint" />
           </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;EnvelopedVerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential" id="jcIRoWpeUHbpSJrjuQO4-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" vertex="1" parent="1">
+            <mxGeometry x="-1577" y="-638.22" width="250" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-2" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=classicThin;endFill=0;" edge="1" parent="1" target="jcIRoWpeUHbpSJrjuQO4-1" source="1oUjKqBKF74gJ-cnWfdO-15">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1361" y="-458" as="sourcePoint" />
+            <mxPoint x="-1189" y="-752.15" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1420" y="-520" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-4" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1598" y="-62" width="1595" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-5" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry width="1595" height="54.5" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-6" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="725" y="7.639812500000005" width="163.39999999999998" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="" id="jcIRoWpeUHbpSJrjuQO4-7">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-6">
+            <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-8" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-6">
+          <mxGeometry x="13" width="90" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-9" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="182" y="9.077312500000005" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-9">
+          <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-11" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-9">
+          <mxGeometry width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-12" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="901" y="9.077312500000005" width="170" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-13" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-12">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="87" y="17.94375" as="sourcePoint" />
+            <mxPoint x="167" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-14" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-12">
+          <mxGeometry x="-5" width="80" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-15" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="1098" y="9.077312500000005" width="136" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=5 2 2 2;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-15">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="74" y="18.5625" as="sourcePoint" />
+            <mxPoint x="154" y="18.5625" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="130" y="18.5625" />
+              <mxPoint x="130" y="18.5625" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-17" value="Domain&lt;br&gt;of" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-15">
+          <mxGeometry y="-5" width="60" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-18" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="1266" y="9.077312500000005" width="160" height="37.125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-18">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="67" y="18.5625" as="sourcePoint" />
+            <mxPoint x="147" y="18.5625" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-20" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-18">
+          <mxGeometry width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-21" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="367" y="5.983562500000005" width="160" height="43.3125" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-22" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-21">
+          <mxGeometry x="65" y="4.95" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-23" value="Reserved&lt;br&gt;class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-21">
+          <mxGeometry x="-10" y="1.8125" width="70" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-24" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="539" y="2.889812500000005" width="176" height="49.5" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-25" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-24">
+          <mxGeometry y="7" width="70" height="40" as="geometry" />
+        </mxCell>
+        <UserObject label="" link="https://www.w3.org/2018/credentials#evidence" id="jcIRoWpeUHbpSJrjuQO4-26">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-24">
+            <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-27" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="7" y="12.639812500000005" width="160" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-28" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-27">
+          <mxGeometry x="60" y="0.9976874999999978" width="100" height="28.004625" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-29" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-27">
+          <mxGeometry width="50" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-30" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="1515" y="27.139812500000005" as="sourcePoint" />
+            <mxPoint x="1588" y="27.359812500000004" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-31" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-4">
+          <mxGeometry x="1431" width="70" height="25.64" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -1,9 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1662 923">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1636 923">
     <a xlink:href="https://www.w3.org/2018/credentials#verifiableCredential">
-        <rect width="171" height="27.21" x="167" y="525.19" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="167" y="604.7" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:539px;margin-left:168px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:618px;margin-left:168px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -15,7 +15,7 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="253" y="544" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="253" y="623" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredential">
@@ -77,15 +77,15 @@
     </a>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M166 141.05q41-64.03 161.62-97.82" pointer-events="stroke"/>
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m334.85 41.21-8.28 7.51 1.05-5.49-3.75-4.14Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M252.5 525.19V366.07" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m252.5 358.57 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-80.19-216.75" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.57 554.64 5.32 9.84-5.08-2.34-4.92 2.65Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M252.5 604.7v-95.74" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m252.5 501.46 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-79.79-137.27" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.66 634.15 5.72 9.6-5.17-2.13-4.8 2.86Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredentialGraph">
-        <ellipse cx="252.5" cy="336.72" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="252.5" cy="479.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:337px;margin-left:145px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:480px;margin-left:145px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -97,11 +97,11 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="253" y="342" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredentialGraph</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="253" y="484" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredentialGraph</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 317.11 363.81 63.17" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m366.82 56.3-.96 10.5-2.05-3.63-4.05.95Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 460Q328 260 365.88 63.81" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m367.3 56.45 1.38 10.45-2.8-3.09-3.75 1.82Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#credentialSchema">
         <rect width="171" height="27.21" x="737" y="85.02" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
@@ -198,10 +198,10 @@
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#refreshService">
-        <rect width="171" height="27.21" x="737" y="424" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="425" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:438px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:439px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -213,14 +213,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="442" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="443" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#renderMethod">
-        <rect width="171" height="27.21" x="737" y="481" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="482" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:495px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:496px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -232,14 +232,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="500" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#confidenceMethod">
-        <rect width="171" height="27.21" x="737" y="538" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="539" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:552px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:553px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -251,14 +251,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="556" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#termsOfUse">
-        <rect width="171" height="27.21" x="737" y="594" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="595" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:608px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:609px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -270,14 +270,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="612" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#validFrom">
-        <rect width="171" height="27.21" x="737" y="651" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="652" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:665px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:666px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -289,14 +289,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="669" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="670" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#validUntil">
-        <rect width="171" height="27.21" x="737" y="707.24" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="709" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:721px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:723px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -308,7 +308,7 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="726" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="727" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#holder">
@@ -342,25 +342,25 @@
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 268.26-10.66 3.37 3.25-4.55-1.69-5.32Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q21 192.87 282.21 317.2" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.98 380.64-11.18.22 4.41-3.44-.11-5.59Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q11 224.88 282.45 372.73" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.04 436.54-11.18-.4 4.59-3.19.2-5.59Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-9 256.89 282.62 429.43" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.08 493.47-11.16-.79 4.7-3.03.4-5.58Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-29 256.89 283.15 485.63" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.2 550.28-11.03-1.87 4.98-2.56.94-5.51Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q11 224.88 282.46 373.7" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.04 437.53-11.17-.42 4.59-3.19.21-5.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-9 256.89 282.63 430.41" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.08 494.46-11.15-.81 4.7-3.02.41-5.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-29 256.89 283.16 486.61" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.2 551.28-11.02-1.9 4.98-2.55.95-5.5Z" pointer-events="all"/>
     <circle cx="552" cy="662" r="5" fill="#c00" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M442 759.28q46-69.28 100.84-88.99" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m549.9 667.76-7.72 8.08.66-5.55-4.05-3.86Z" pointer-events="all"/>
     <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22Q408 350 547.87 648.19" pointer-events="stroke"/>
     <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m551.05 654.98-8.77-6.93 5.59.14 3.46-4.39Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m557 662 170.27 2.46" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 664.57-10.07 4.86 2.58-4.97-2.43-5.03Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q91-52 170.27-54.13" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 607.67-9.86 5.26 2.37-5.06-2.64-4.93Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q81 48 170.32 57.79" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.78 720.6-10.49 3.88 3.03-4.69-1.94-5.25Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m557 662 170.27 3.41" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 665.56-10.09 4.8 2.6-4.95-2.4-5.05Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q91-52 170.27-53.24" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 608.64-9.92 5.16 2.43-5.04-2.58-4.96Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q81 48 170.34 59.38" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.78 722.32-10.55 3.7 3.11-4.64-1.85-5.28Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#RenderMethod">
-        <ellipse cx="1136" cy="495.76" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="495.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:496px;margin-left:1028px">
@@ -375,14 +375,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="501" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="500" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#CredentialEvidence">
-        <ellipse cx="1136" cy="382.72" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="381.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:383px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:382px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -394,11 +394,11 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="388" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#RefreshService">
-        <ellipse cx="1136" cy="438.74" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="438.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                 <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:439px;margin-left:1028px">
@@ -413,14 +413,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="444" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="443" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#ConfidenceMethod">
-        <ellipse cx="1136" cy="551.78" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="552.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:552px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:553px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -436,10 +436,10 @@
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#TermsOfUse">
-        <ellipse cx="1136" cy="607.8" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="608.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:608px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:609px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -474,10 +474,10 @@
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#CredentialStatus">
-        <ellipse cx="1136" cy="154.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1136" cy="155.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:155px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:156px;margin-left:1028px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -489,23 +489,23 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="159" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialStatus</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialStatus</text>
         </switch>
     </a>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 98.63h109.26" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 98.63-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 155.61 109.26-.88" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 154.67-9.96 5.08 2.46-5.02-2.54-4.98Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 381.61 109.26 1.02" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 382.7-10.04 4.9 2.54-4.97-2.45-5.03Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 437.61 109.26 1.04" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 438.72-10.04 4.9 2.54-4.97-2.45-5.03Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 494.61 109.26 1.06" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 495.74-10.04 4.9 2.54-4.97-2.45-5.03Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 551.61 109.26.16" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 551.78-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m908 607.61 109.26.18" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 607.8-10 4.98 2.5-4.99-2.49-5.01Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 155.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 155.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 381.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 381.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 438.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 438.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 495.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 495.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 552.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 552.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 608.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 608.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#JsonSchema">
         <ellipse cx="1496" cy="177.46" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
@@ -527,159 +527,6 @@
     </a>
     <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1496 157.85q-89-64.82-241.27-59.56" pointer-events="stroke"/>
     <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1247.23 98.55 9.83-5.34-2.33 5.08 2.67 4.91Z" pointer-events="all"/>
-    <rect width="1621" height="54.5" x="20" y="848" fill="none"/>
-    <rect width="1595" height="54.5" x="20" y="848" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
-    <rect width="1614" height="49.5" x="27" y="850.5" fill="none"/>
-    <rect width="163.4" height="40" x="745" y="855.25" fill="none"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M840 866.75h48.4l20 8.5-20 8.5H840l-20-8.5Z" pointer-events="all"/>
-    <rect width="90" height="40" x="758" y="855.25" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:862px;margin-left:760px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
-                            Datatype
-                        </span>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="760" y="878" font-family="Helvetica" font-size="16">Datatype</text>
-    </switch>
-    <rect width="190" height="40" x="1451" y="855.25" fill="none"/>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1535 881.75 63.26.19" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1605.76 881.96-10.01 4.97 2.51-4.99-2.48-5.01Z" pointer-events="all"/>
-    <rect width="70" height="40" x="1451" y="855.25" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:862px;margin-left:1452px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
-                            Graph containment
-                        </span>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1486" y="878" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
-    </switch>
-    <rect width="170" height="37.13" x="202" y="856.69" fill="none"/>
-    <rect width="80" height="23.69" x="285" y="861.64" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
-    <rect width="70" height="30" x="202" y="856.69" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:237px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Property
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="237" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
-    </switch>
-    <rect width="170" height="37.13" x="921" y="856.69" fill="none"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1008 874.63 71.76.56" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1085.76 875.23-8.03 3.94 2.03-3.98-1.96-4.02Z" pointer-events="all"/>
-    <rect width="80" height="30" x="916" y="856.69" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:956px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Superclass
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="956" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
-    </switch>
-    <rect width="136" height="37.13" x="1118" y="856.69" fill="none"/>
-    <path fill="none" stroke="#f33" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1192 875.25 56 .05 15.76-.03" pointer-events="stroke"/>
-    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1269.76 875.25-7.99 4.02 1.99-4-2-4Z" pointer-events="all"/>
-    <rect width="60" height="40" x="1118" y="851.69" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1148px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Domain
-                        <br/>
-                        of
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1148" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Domain...</text>
-    </switch>
-    <rect width="160" height="37.13" x="1286" y="856.69" fill="none"/>
-    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1353 875.25h71.76" pointer-events="stroke"/>
-    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1430.76 875.25-8 4 2-4-2-4Z" pointer-events="all"/>
-    <rect width="60" height="30" x="1286" y="856.69" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1316px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Range
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1316" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
-    </switch>
-    <rect width="160" height="43.31" x="387" y="853.59" fill="none"/>
-    <ellipse cx="502" cy="872.55" fill="none" stroke="#82b366" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
-    <rect width="70" height="40" x="377" y="855.41" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:875px;margin-left:412px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Reserved
-                        <br/>
-                        class
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="412" y="879" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
-    </switch>
-    <rect width="176" height="49.5" x="559" y="850.5" fill="none"/>
-    <rect width="70" height="40" x="559" y="857.5" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:878px;margin-left:594px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Reserved
-                        <br/>
-                        property
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="594" y="881" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
-    </switch>
-    <a xlink:href="https://www.w3.org/2018/credentials#evidence">
-        <rect width="91.25" height="24.75" x="640.75" y="864.73" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
-    </a>
-    <ellipse cx="137" cy="875.64" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
-    <rect width="50" height="30" x="27" y="856.69" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:52px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
-                        Class
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="52" y="875" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
-    </switch>
     <a xlink:href="https://www.w3.org/2018/credentials#credentialSubject">
         <rect width="171" height="27.21" x="1410.5" y="270" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
@@ -719,10 +566,10 @@
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#relatedResource">
-        <rect width="171" height="27.21" x="737" y="311" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="737" y="312" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:325px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:326px;margin-left:738px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -734,11 +581,11 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="329" font-family="Helvetica" font-size="16" text-anchor="middle">relatedResource</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="823" y="330" font-family="Helvetica" font-size="16" text-anchor="middle">relatedResource</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 178.86 281.83 261.12" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.89 323.85-11.09 1.36 4.03-3.87-.68-5.55Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 178.86 281.84 262.08" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.9 324.85-11.11 1.31 4.05-3.86-.66-5.55Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#digestSRI">
         <rect width="171" height="27.21" x="1410.5" y="481" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
@@ -758,7 +605,7 @@
             <text xmlns="http://www.w3.org/2000/svg" x="1496" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">digestSRI</text>
         </switch>
     </a>
-    <a xlink:href="https://w3id.org/security/#sriString">
+    <a xlink:href="https://www.w3.org/2018/credentials#sriString">
         <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 576h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -777,4 +624,177 @@
     </a>
     <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 508.21.59 58.05" pointer-events="stroke"/>
     <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 573.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
+    <a xlink:href="https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential">
+        <ellipse cx="166" cy="291.39" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="125" ry="19.61"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:248px;height:1px;padding-top:291px;margin-left:42px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    EnvelopedVerifiableCredential
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="166" y="296" font-family="Helvetica" font-size="16" text-anchor="middle">EnvelopedVerifiableCredential</text>
+        </switch>
+    </a>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 460q-54.5-70-82.84-139.98" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m166.84 313.07 6.84 8.02-4.02-1.07-2.16 3.57Z" pointer-events="all"/>
+    <rect width="1595" height="54.5" x="20" y="848" fill="none"/>
+    <rect width="1595" height="54.5" x="20" y="848" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
+    <rect width="163.4" height="40" x="745" y="855.64" fill="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M840 867.14h48.4l20 8.5-20 8.5H840l-20-8.5Z" pointer-events="all"/>
+    <rect width="90" height="40" x="758" y="855.64" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:88px;height:1px;padding-top:863px;margin-left:760px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-align:center;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
+                            Datatype
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="760" y="879" font-family="Helvetica" font-size="16">Datatype</text>
+    </switch>
+    <rect width="170" height="37.13" x="202" y="857.08" fill="none"/>
+    <rect width="80" height="23.69" x="285" y="862.03" fill="none" stroke="#300" stroke-width="2" pointer-events="all" rx="3.55" ry="3.55"/>
+    <rect width="70" height="30" x="202" y="857.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:237px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Property
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="237" y="876" font-family="Helvetica" font-size="12" text-anchor="middle">Property</text>
+    </switch>
+    <rect width="170" height="37.13" x="921" y="857.08" fill="none"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1008 875.02 71.76.56" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1085.76 875.62-8.03 3.94 2.03-3.98-1.96-4.02Z" pointer-events="all"/>
+    <rect width="80" height="30" x="916" y="857.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:956px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Superclass
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="956" y="876" font-family="Helvetica" font-size="12" text-anchor="middle">Superclass</text>
+    </switch>
+    <rect width="136" height="37.13" x="1118" y="857.08" fill="none"/>
+    <path fill="none" stroke="#f33" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1192 875.64 56-.04 15.76.03" pointer-events="stroke"/>
+    <path fill="#f33" stroke="#f33" stroke-miterlimit="10" stroke-width="2" d="m1269.76 875.64-8 3.98 2-3.99-1.99-4.01Z" pointer-events="all"/>
+    <rect width="60" height="40" x="1118" y="852.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1148px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Domain
+                        <br/>
+                        of
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1148" y="876" font-family="Helvetica" font-size="12" text-anchor="middle">Domain...</text>
+    </switch>
+    <rect width="160" height="37.13" x="1286" y="857.08" fill="none"/>
+    <path fill="none" stroke="#00c" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M1353 875.64h71.76" pointer-events="stroke"/>
+    <path fill="#00c" stroke="#00c" stroke-miterlimit="10" stroke-width="2" d="m1430.76 875.64-8 4 2-4-2-4Z" pointer-events="all"/>
+    <rect width="60" height="30" x="1286" y="857.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:872px;margin-left:1316px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Range
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1316" y="876" font-family="Helvetica" font-size="12" text-anchor="middle">Range</text>
+    </switch>
+    <rect width="160" height="43.31" x="387" y="853.98" fill="none"/>
+    <ellipse cx="502" cy="872.94" fill="none" stroke="#82b366" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="70" height="40" x="377" y="855.8" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:876px;margin-left:412px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Reserved
+                        <br/>
+                        class
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="412" y="879" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
+    </switch>
+    <rect width="176" height="49.5" x="559" y="850.89" fill="none"/>
+    <rect width="70" height="40" x="559" y="857.89" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:878px;margin-left:594px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Reserved
+                        <br/>
+                        property
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="594" y="881" font-family="Helvetica" font-size="12" text-anchor="middle">Reserved...</text>
+    </switch>
+    <a xlink:href="https://www.w3.org/2018/credentials#evidence">
+        <rect width="91.25" height="24.75" x="640.75" y="865.12" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="3.71" ry="3.71"/>
+    </a>
+    <rect width="160" height="30" x="27" y="860.64" fill="none"/>
+    <ellipse cx="137" cy="875.64" fill="none" stroke="#82b366" stroke-width="2" pointer-events="all" rx="50" ry="14.002"/>
+    <rect width="50" height="30" x="27" y="860.64" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:876px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                        Class
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="879" font-family="Helvetica" font-size="12" text-anchor="middle">Class</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="m1535 875.14 63.26.19" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1605.76 875.35-10.01 4.97 2.51-4.99-2.48-5.01Z" pointer-events="all"/>
+    <rect width="70" height="25.64" x="1451" y="848" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:68px;height:1px;padding-top:855px;margin-left:1452px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <span style="color:#000;font-family:Helvetica;font-size:12px;font-style:normal;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial;float:none;display:inline!important">
+                            Graph containment
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1486" y="871" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
+    </switch>
 </svg>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -11,7 +11,7 @@ ontology:
     value: Verifiable Credentials Vocabulary v2.0
 
   - property: dc:description
-    value: RDFS [[RDF-SCHEMA]] vocabulary used by the Verifiable Credentials [[VC-DATA-MODEL]]
+    value: RDFS [[RDF-SCHEMA]] vocabulary used by the Verifiable Credentials [[VC-DATA-MODEL-2.0]]
 
   - property: rdfs:seeAlso
     value: https://www.w3.org/TR/vc-data-model-2.0/


### PR DESCRIPTION
This PR completes #1379 (which has been merged) in adding the `EnvelopedVerifiableCredential` type to the vocabulary diagram.

Additionally, a minor change is in the vocabulary file itself: instead using a local reference entry to the VCDM spec, it now uses the "official" reference to ensure an up-to-date entry.

Because the preview does not properly handle inputs, etc, I will add a copy of the new SVG diagram into my comment below.

This is an editorial change, and not overly important at that, so I did not mark this PR as pre-CR. For consistency's sake it would be better to merge it, though.