### PR TITLE
Clarify that non-objects aren't allowed as VC graphs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2288,7 +2288,7 @@ related normative guidance in Section <a href="#types"></a> MUST be followed.
 The <code>verifiableCredential</code> <a>property</a> MAY be present. The value
 MUST be one or more <a>verifiable credential</a> and/or
 <a href="#enveloped-verifiable-credentials">enveloped verifiable credential</a>
-objects (for the avoidance of doubt, the values MUST NOT be non-object values such as
+objects (to be clear, the values MUST NOT be non-object values such as
 numbers, strings, or URLs). These types of objects are called
 <a href="#verifiable-credential-graphs">verifiable credential graphs</a> and
 MUST express information that is secured using a

--- a/index.html
+++ b/index.html
@@ -2288,10 +2288,11 @@ related normative guidance in Section <a href="#types"></a> MUST be followed.
 The <code>verifiableCredential</code> <a>property</a> MAY be present. The value
 MUST be one or more <a>verifiable credential</a> and/or
 <a href="#enveloped-verifiable-credentials">enveloped verifiable credential</a>
-objects. For the avoidance of doubt, the values MUST NOT be non-object values such as
-numbers, strings, or URLs. These types of objects are called
+objects (for the avoidance of doubt, the values MUST NOT be non-object values such as
+numbers, strings, or URLs). These types of objects are called
 <a href="#verifiable-credential-graphs">verifiable credential graphs</a> and
-MUST be secured using a <a href="#securing-mechanisms">securing mechanism</a>.
+MUST express information that is secured using a
+<a href="#securing-mechanisms">securing mechanism</a>.
 See Section <a href="#verifiable-credential-graphs"></a> for further details.
           </dd>
           <dt><var id="defn-holder">holder</var></dt>

--- a/index.html
+++ b/index.html
@@ -2286,10 +2286,13 @@ related normative guidance in Section <a href="#types"></a> MUST be followed.
           <dt><var id="defn-verifiableCredential">verifiableCredential</var></dt>
           <dd>
 The <code>verifiableCredential</code> <a>property</a> MAY be present. The value
-MUST be an array of one or more <a href="#verifiable-credential-graphs">
-verifiable credential graphs</a> in a cryptographically <a>verifiable</a> format.
-See Section <a href="#verifiable-credential-graphs"></a> for further details on
-this topic.
+MUST be one or more <a>verifiable credential</a> and/or
+<a href="#enveloped-verifiable-credentials">enveloped verifiable credential</a>
+objects. For the avoidance of doubt, the values MUST NOT be non-object values such as
+numbers, strings, or URLs. These types of objects are called
+<a href="#verifiable-credential-graphs">verifiable credential graphs</a> and
+MUST be secured using a <a href="#securing-mechanisms">securing mechanism</a>.
+See Section <a href="#verifiable-credential-graphs"></a> for further details.
           </dd>
           <dt><var id="defn-holder">holder</var></dt>
           <dd>


### PR DESCRIPTION
This PR attempts to address issue #1365 by clarifying that non-object values are not allowed for Verifiable Credential Graphs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1390.html" title="Last updated on Dec 21, 2023, 6:13 PM UTC (3356cbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1390/edcbf7e...3356cbd.html" title="Last updated on Dec 21, 2023, 6:13 PM UTC (3356cbd)">Diff</a>