### PR TITLE
Clarify that ProblemDetails can be extended for any reason.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4788,8 +4788,7 @@ identifying the type of problem.
           </dd>
           <dt>code</dt>
           <dd>
-The `code` <a>property</a> is an OPTIONAL
-<a data-cite="RFC9457#name-extension-members">RFC9457 extension member</a>. If
+The `code` <a>property</a> is an OPTIONAL value. If
 present, its value MUST be an integer that identifies the type of the problem.
 Integer codes are useful in systems that only provide integer return values.
           </dd>
@@ -4804,12 +4803,6 @@ The `detail` <a>property</a> MUST be present and its value SHOULD provide a
 longer human-readable string for the problem.
           </dd>
         </dl>
-
-        <p>
-Other properties that are useful for debugging purposes MAY be included in
-a <a>ProblemDetails</a> object. See [[RFC9457]] for further guidance on
-using this mechanism.
-        </p>
 
         <p>
 The following problem description types and codes are defined by this
@@ -4846,6 +4839,13 @@ in the <a>ProblemDetails</a> object. See Section
 <a href="#verification"></a>.
           </dd>
         </dl>
+
+        <p>
+Implementations MAY extend the <a>ProblemDetails</a> object by specifying
+additional types, codes, or properties. See the
+<a data-cite="RFC9457#name-extension-members">Extension Member</a> section
+in [[RFC9457]] for further guidance on using this mechanism.
+        </p>
 
       </section>
 


### PR DESCRIPTION
This PR is an attempt to address issue #1384 by specifying that the `ProblemDetails` object can be extended for any reason.