### PR TITLE
Add requirement for securing mechanisms to have post-verification documentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2022,10 +2022,10 @@ algorithm</a> section.
           </li>
           <li>
 MUST document post-processing considerations for data returned from verification
-processes. This includes, but is not limited to, what information can and cannot
-be used for decision making, for what period of time after verification, when
-additional information is required, and when care is necessary even when the
-returned data was properly secured.
+processes. This includes, but is not limited to, what information has been
+secured, for what period of time after verification, when or what additional
+information might be required to assist in decision making, and when
+care is necessary even when the returned data was properly secured.
           </li>
           <li>
 SHOULD provide integrity protection for any information referenced by a URL that

--- a/index.html
+++ b/index.html
@@ -2024,8 +2024,8 @@ algorithm</a> section.
 MUST document post-processing considerations for data returned from verification
 processes. This includes, but is not limited to, what information has been
 secured, for what period of time after verification, when or what additional
-information might be required to assist in decision making, and when
-care is necessary even when the returned data was properly secured.
+information might be recommended to assist in decision making, and when
+caution is advised even when the returned data was properly secured.
           </li>
           <li>
 SHOULD provide integrity protection for any information referenced by a URL that

--- a/index.html
+++ b/index.html
@@ -2021,6 +2021,13 @@ expected to be provided is detailed in the
 algorithm</a> section.
           </li>
           <li>
+MUST document post-processing considerations for data returned from verification
+processes. This includes, but is not limited to, what information can and cannot
+be used for decision making, for what period of time after verification, when
+additional information is required, and when care is necessary even when the
+returned data was properly secured.
+          </li>
+          <li>
 SHOULD provide integrity protection for any information referenced by a URL that
 is critical to validation. Mechanisms that can achieve this protection are
 discussed in Section <a href="#integrity-of-related-resources"></a> and Section


### PR DESCRIPTION
This PR attempts to address issue #1388 by requiring that securing mechanisms document what information can and cannot be used for decision making, for what period of time after verification, when additional information is required, and when care is necessary even when the returned data was properly secured.

/cc @jyasskin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1392.html" title="Last updated on Dec 26, 2023, 3:56 PM UTC (9561353)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1392/7b22399...9561353.html" title="Last updated on Dec 26, 2023, 3:56 PM UTC (9561353)">Diff</a>