### PR TITLE
Clarify how issuer validation occurs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6443,11 +6443,11 @@ to identify an <a>issuer</a> that is known to and trusted by the
 Relevant metadata that is related to the <code>issuer</code> <a>property</a>
 is available to the <a>verifier</a> through the
 <a href="#verify-securing-mechanism">securing mechanism verification
-algorithm</a>. This information includes the controller, which is typically the
-`issuer`, of the verification method used by the securing mechanism to secure
-each <a>verifiable credential</a>. When verifying a
-<a>verifiable presentation</a>, the controller of the verification method is
-typically the `holder`.
+algorithm</a> as defined in Section <a href="#securing-mechanisms"></a>. This
+information includes the controller, which is typically the `issuer`, of the
+verification method used by the securing mechanism to secure each <a>verifiable
+credential</a>. When verifying a <a>verifiable presentation</a>, the controller
+of the verification method is typically the `holder`.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -4640,28 +4640,6 @@ zero or more errors ([=list=] of <a>ProblemDetails</a> <var>errors</var>)
         </ul>
 
         <p>
-A securing mechanism's verification algorithm returns a verification result
-with at least the following [=struct/items=]:
-        </p>
-        <ul>
-          <li>
-a verification status ([=boolean=] <var>status</var>)
-          </li>
-          <li>
-a verified document ([=map=] <var>document</var>)
-          </li>
-          <li>
-a media type ([=string=] <var>mediaType</var>)
-          </li>
-          <li>
-a verification method controller ([=string=] <var>controller</var>)
-          </li>
-          <li>
-a controller document ([=map=] <var>controllerDocument</var>)
-          </li>
-        </ul>
-
-        <p>
 The securing mechanism verification algorithm is as follows:
         </p>
 

--- a/index.html
+++ b/index.html
@@ -2016,8 +2016,8 @@ Securing mechanism specifications MUST provide a verification mechanism that
 returns only the information in the <a>conforming document</a> that has been
 secured, without any securing mechanism information included, such as `proof` or
 JOSE/COSE metadata. Specifications MAY provide additional mechanisms to convey
-other information that might be helpful during validation or for debugging
-purposes, such as securing mechanism metadata. A securing mechanism's
+other information that might be helpful (for example, during validation or for debugging
+purposes), such as securing mechanism metadata. A securing mechanism's
 verification algorithm MUST provide an interface that receives a sequence of
 bytes ([=byte sequence=] |inputBytes|) or a document ([=map=] |inputDocument|)
 and a media type ([=string=] |inputMediaType|) as inputs and returns a

--- a/index.html
+++ b/index.html
@@ -2014,12 +2014,14 @@ algorithms MAY be general in nature and MAY be used to secure data other than
         <p>
 Securing mechanism specifications MUST provide a verification mechanism that
 returns only the information in the <a>conforming document</a> that has been
-secured. It MAY provide an additional mechanism to receive other information
-that might be helpful during validation or for debugging purposes. A securing
-mechanism's verification algorithm MUST provide an interface that
-receives an sequence of bytes ([=byte sequence=] |inputBytes|) and a media type
-([=string=] |inputMediaType|) as inputs and returns a verification result with
-at least the following [=struct/items=]:
+secured, without any securing mechanism information included, such as `proof` or
+JOSE/COSE metadata. Specifications MAY provide additional mechanisms to convey
+other information that might be helpful during validation or for debugging
+purposes, such as securing mechanism metadata. A securing mechanism's
+verification algorithm MUST provide an interface that receives a sequence of
+bytes ([=byte sequence=] |inputBytes|) and a media type ([=string=]
+|inputMediaType|) as inputs and returns a verification result with at least the
+following [=struct/items=]:
         </p>
 
         <dl>

--- a/index.html
+++ b/index.html
@@ -6413,11 +6413,20 @@ to identify an <a>issuer</a> that is known to and trusted by the
         </p>
 
         <p>
-Relevant metadata about the <code>issuer</code> <a>property</a> is expected
-to be available to the <a>verifier</a>. For example, an <a>issuer</a> can
-publish information containing the public keys it uses to digitally sign
-<a>verifiable credentials</a> that it issued. This metadata is relevant when
-checking the proofs on the <a>verifiable credentials</a>.
+Relevant metadata that is related to the <code>issuer</code> <a>property</a>
+is available to the <a>verifier</a> through the
+<a href="#verify-securing-mechanism">securing mechanism verification
+algorithm</a>. This information includes the controller, which is typically the
+`issuer`, of the verification method used by the securing mechanism to secure
+each <a>verifiable credential</a>. When verifying a
+<a>verifiable presentation</a>, the controller of the verification method is
+typically the `holder`.
+        </p>
+
+        <p>
+Some ecosystems might have more complex relationships between <a>issuers</a>
+and controllers of verification methods and might use lists of verified
+issuers in addition to, or instead of, the mapping described above.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -2001,37 +2001,64 @@ mechanisms are not mutually exclusive.
 
         <p>
 Securing mechanism specifications other than those
-referred to above might also be defined, as necessary. A securing mechanism
-specification:
+referred to above might also be defined, as necessary.
         </p>
 
-        <ul>
-          <li>
-MUST document normative algorithms that provide content integrity protection
-for <a>conforming documents</a>. The algorithms MAY be general in nature and
-MAY be used to secure data other than <a>conforming documents</a>.
-          </li>
-          <li>
-MUST provide a verification mechanism that returns only the information in the
-<a>conforming document</a> that has been secured. It MAY provide an
-additional mechanism to receive other information that might be helpful
-during validation or for debugging purposes. The concrete interface that is
-expected to be provided is detailed in the
-<a href="#verify-securing-mechanism">securing mechanism verification
-algorithm</a> section.
-          </li>
-          <li>
-SHOULD provide integrity protection for any information referenced by a URL that
-is critical to validation. Mechanisms that can achieve this protection are
-discussed in Section <a href="#integrity-of-related-resources"></a> and Section
+        <p>
+Securing mechanism specifications MUST document normative algorithms that
+provide content integrity protection for <a>conforming documents</a>. The
+algorithms MAY be general in nature and MAY be used to secure data other than
+<a>conforming documents</a>.
+        </p>
+
+        <p>
+Securing mechanism specifications MUST provide a verification mechanism that
+returns only the information in the <a>conforming document</a> that has been
+secured. It MAY provide an additional mechanism to receive other information
+that might be helpful during validation or for debugging purposes. A securing
+mechanism's verification algorithm MUST provide an interface that
+receives an sequence of bytes ([=byte sequence=] |inputBytes|) and a media type
+([=string=] |inputMediaType|) as inputs and returns a verification result with
+at least the following [=struct/items=]:
+        </p>
+
+        <dl>
+          <dt>[=boolean=] |status|</dt>
+          <dd>
+A verification status whose value is `true` if the verification succeeded and
+`false` if it did not.
+          </dd>
+          <dt>[=map=] |document|</dt>
+          <dd>
+A document that only contains information that was successfully secured.
+          </dd>
+          <dt>[=string=] |mediaType|</dt>
+          <dd>
+A media type as defined in [[RFC6838]].
+          </dd>
+          <dt>[=string=] |controller|</dt>
+          <dd>
+A verification method controller as defined in [[VC-CONTROLLER-DOCUMENT]].
+          </dd>
+          <dt>[=map=] |controllerDocument|</dt>
+          <dd>
+A controller document as defined in [[VC-CONTROLLER-DOCUMENT]].
+          </dd>
+        </dl>
+
+        <p>
+Securing mechanism specifications SHOULD provide integrity protection for any
+information referenced by a URL that is critical to validation. Mechanisms that
+can achieve this protection are discussed in Section
+<a href="#integrity-of-related-resources"></a> and Section
 <a href="#base-context"></a>.
-          </li>
-          <li>
-SHOULD register the securing mechanism in the
+        </p>
+
+        <p>
+Securing mechanism specifications SHOULD register the securing mechanism in the
 <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a> section
 of the [[[?VC-SPECS]]] [[?VC-SPECS]].
-          </li>
-        </ul>
+        </p>
 
         <p class="note"
            title="Choice of securing mechanism is use-case dependent">

--- a/index.html
+++ b/index.html
@@ -6444,7 +6444,7 @@ Relevant metadata that is related to the <code>issuer</code> <a>property</a>
 is available to the <a>verifier</a> through the
 <a href="#verify-securing-mechanism">securing mechanism verification
 algorithm</a> as defined in Section <a href="#securing-mechanisms"></a>. This
-information includes the controller, which is typically the `issuer`, of the
+information includes the verified controller, which is typically the `issuer`, of the
 verification method used by the securing mechanism to secure each <a>verifiable
 credential</a>. When verifying a <a>verifiable presentation</a>, the controller
 of the verification method is typically the `holder`.

--- a/index.html
+++ b/index.html
@@ -6440,14 +6440,14 @@ to identify an <a>issuer</a> that is known to and trusted by the
         </p>
 
         <p>
-Relevant metadata that is related to the <code>issuer</code> <a>property</a>
-is available to the <a>verifier</a> through the
-<a href="#verify-securing-mechanism">securing mechanism verification
-algorithm</a> as defined in Section <a href="#securing-mechanisms"></a>. This
-information includes the verified controller, which is typically the `issuer`, of the
-verification method used by the securing mechanism to secure each <a>verifiable
-credential</a>. When verifying a <a>verifiable presentation</a>, the controller
-of the verification method is typically the `holder`.
+Metadata related to the `issuer` <a>property</a> is available to the
+<a>verifier</a> through the <a href="#verify-securing-mechanism">verification
+algorithm of the securing mechanism</a> as defined in Section
+<a href="#securing-mechanisms"></a>. This metadata includes identification of
+the verified controller of the verification method used by the securing
+mechanism to secure each <a>verifiable credential</a> or <a>verifiable
+presentation</a>, of which the controller is typically the respective `issuer`
+or `holder`.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -4613,6 +4613,28 @@ zero or more errors ([=list=] of <a>ProblemDetails</a> <var>errors</var>)
         </ul>
 
         <p>
+A securing mechanism's verification algorithm returns a verification result
+with at least the following [=struct/items=]:
+        </p>
+        <ul>
+          <li>
+a verification status ([=boolean=] <var>status</var>)
+          </li>
+          <li>
+a verified document ([=map=] <var>document</var>)
+          </li>
+          <li>
+a media type ([=string=] <var>mediaType</var>)
+          </li>
+          <li>
+a verification method controller ([=string=] <var>controller</var>)
+          </li>
+          <li>
+a controller document ([=map=] <var>controllerDocument</var>)
+          </li>
+        </ul>
+
+        <p>
 The securing mechanism verification algorithm is as follows:
         </p>
 

--- a/index.html
+++ b/index.html
@@ -2019,9 +2019,9 @@ JOSE/COSE metadata. Specifications MAY provide additional mechanisms to convey
 other information that might be helpful during validation or for debugging
 purposes, such as securing mechanism metadata. A securing mechanism's
 verification algorithm MUST provide an interface that receives a sequence of
-bytes ([=byte sequence=] |inputBytes|) and a media type ([=string=]
-|inputMediaType|) as inputs and returns a verification result with at least the
-following [=struct/items=]:
+bytes ([=byte sequence=] |inputBytes|) or a document ([=map=] |inputDocument|)
+and a media type ([=string=] |inputMediaType|) as inputs and returns a
+verification result with at least the following [=struct/items=]:
         </p>
 
         <dl>
@@ -4534,7 +4534,8 @@ versions of this specification.
 This section contains an algorithm that <a>conforming verifier
 implementations</a> MUST run when verifying a <a>verifiable credential</a> or a
 <a>verifiable presentation</a>. This algorithm takes a sequence of bytes
-([=byte sequence=] <var>inputBytes</var>) and a media type
+([=byte sequence=] <var>inputBytes</var>) or a document
+([=map=] <var>inputDocument</var>) and a media type
 ([=string=] <var>inputMediaType</var>) as inputs, and returns a [=map=]
 that contains the following:
         </p>


### PR DESCRIPTION
This PR is an attempt to address issue #1386 by clarifying how issuer validation could occur. It establishes an interface between the VCDM and securing specifications for the securing mechanism verification algorithms. It also adds more detail to the issuer validation section in the specification.

NOTE: The algorithms haven't been updated to use the new interface (that will be done in a separate PR). What's important in this PR is that the controller and controller document is being returned by the securing mechanism verification algorithm such that a check between the `issuer` property and the `controller` is possible.

/cc @jyasskin (this PR starts to define the interface between the Securing Mechanisms and the VCDM)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1393.html" title="Last updated on Dec 26, 2023, 4:16 PM UTC (a59c20b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1393/7b22399...a59c20b.html" title="Last updated on Dec 26, 2023, 4:16 PM UTC (a59c20b)">Diff</a>