### PR TITLE
Add missing digestMultibase value in base context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -70,6 +70,11 @@
       "@id": "https://www.w3.org/2018/credentials#digestSRI",
       "@type": "https://www.w3.org/2018/credentials#sriString"
     },
+    "digestMultibase": {
+      "@id": "https://w3id.org/security#digestMultibase",
+      "@type": "https://www.w3.org/2018/credentials#multibase"
+    },
+
     "mediaType": {
       "@id": "https://schema.org/encodingFormat"
     },

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -72,7 +72,7 @@
     },
     "digestMultibase": {
       "@id": "https://w3id.org/security#digestMultibase",
-      "@type": "https://www.w3.org/2018/credentials#multibase"
+      "@type": "https://w3id.org/security#multibase"
     },
 
     "mediaType": {


### PR DESCRIPTION
The current specification notes that whether or not to allow `digestSRI`, `digestMultibase`, or both [will be determined during the Candidate Recommendation phase](https://w3c.github.io/vc-data-model/#integrity-of-related-resources). However, the current context only includes `digestSRI`. This PR adds `digestMultibase` to the base context such that a comparison between the two mechanisms can be made during the CR period.