### PR TITLE
Rename "Controller Document" to "Entity Document".

### DIFF
--- a/index.html
+++ b/index.html
@@ -1746,9 +1746,9 @@ The value of the `issuer` [=property=] MUST be either a
 whose value is a [=URL=]; in either case, the issuer selects this
 [=URL=] to identify itself in a globally unambiguous
 way. It is RECOMMENDED that the [=URL=] be one which, if dereferenced,
-results in a controller document [[?VC-CONTROLLER-DOCUMENT]] about the
-[=issuer=] that can be used to [=verify=] the information expressed in
-the [=credential=].
+results in a controller document, as defined in [[VC-DATA-INTEGRITY]] or
+[[VC-JOSE-COSE]], about the [=issuer=] that can be used to [=verify=] the
+information expressed in the [=credential=].
           </dd>
         </dl>
 
@@ -4000,11 +4000,13 @@ A media type as defined in [[RFC6838]].
           </dd>
           <dt>[=string=] |controller|</dt>
           <dd>
-A verification method controller as defined in [[VC-CONTROLLER-DOCUMENT]].
+A verification method controller as defined in [[VC-DATA-INTEGRITY]] or
+[[VC-JOSE-COSE]].
           </dd>
           <dt>[=map=] |controllerDocument|</dt>
           <dd>
-A controller document as defined in [[VC-CONTROLLER-DOCUMENT]].
+A controller document as defined in [[VC-DATA-INTEGRITY]] or
+[[VC-JOSE-COSE]].
           </dd>
         </dl>
 
@@ -4023,7 +4025,7 @@ of the [[[?VC-SPECS]]] [[?VC-SPECS]].
         </p>
 
         <p class="note"
-            title="Choice of securing mechanism is use-case dependent">
+           title="Choice of securing mechanism is use-case dependent">
 There are multiple acceptable securing mechanisms, and this specification does
 not mandate any particular securing mechanism for use with
 [=verifiable credentials=] or [=verifiable presentations=].
@@ -4034,6 +4036,17 @@ securing mechanism options, which are:
 can be found in the
 <a data-cite="?VC-SPECS#securing-mechanisms">Securing Mechanisms</a> section
 of the [[[?VC-SPECS]]] [[?VC-SPECS]].
+        </p>
+
+        <p class="issue atrisk"
+           title="Controller document reference might change">
+The Working Group is currently attempting to align the definitions of a
+controller document between [[[?DID-CORE]]], [[[VC-DATA-INTEGRITY]]], and
+[[[VC-JOSE-COSE]]]. The goal is to have one specification that each of the
+previously stated specifications, and this specification, can reference for
+the normative statements related to controller documents. The normative
+references to controller documents are expected to change during the
+Candidate Recommendation phase.
         </p>
 
       </section>


### PR DESCRIPTION
This PR renames the "Controller Document" terminology to "Entity Document" because the language for "controller documents" is getting increasingly confusing to use and reason about in this specification (and others, for reasons elaborated on below). 

ActivityPub also uses the concept of a "Controller Document", but calls them "Actor objects". This is an important consideration because, with the announcement of new implementers for ActivityPub -- that is, Threads (141 million users) and Flipboard (145 million users), it's important that we get the naming here right (such that it's easier to reason about the alignment in the future).

Here's how this language change is intended to play out:

* "Entity Documents" describe an entity (a thing with independent existence). 
* The description of an entity can contain properties that describe how to communicate with it in a secure manner (verification relationships, verification material, and service endpoints). 
* "Verification Methods" have controllers, which are entities. 
* "Actors" are a type of Entity that can perform an activity, they are expressed using an "Actor object", which could be viewed as being a subclass of "Entity Document" (we could provide explanatory text describing the the alignment in ActivityPub v2).
* Decentralized Identifier Documents (DID Documents) are also a type of "Entity Document" (which we could rename in DID Core v2).

All this to say, "Actor objects" and "DID Documents" are types of "Entity Documents".

If we continue to use the "Controller Document" terminology, the liklihood of making the statements above, and it making sense to people that have a common understanding of English, is low. It's just too hard to connect the dots. I imagine some people reading this, without the tribal knowledge from the last decade or so in these spaces, will express surprise that these things are related at all.

While this is an editorial change, it's an important one to make, IMHO. It's marked "Before CR" because we need to decide on the name before publishing the VC-CONTROLLER/ENTITY-DOCUMENT specification to TR space, which we have to do before VCDM goes into CR, because VCDM will depend on the VC-CONTROLLER/ENTITY-DOCUMENT (normatively) due to PR #1393.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1396.html" title="Last updated on Jan 6, 2024, 4:36 PM UTC (2d7d65b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1396/b59c955...2d7d65b.html" title="Last updated on Jan 6, 2024, 4:36 PM UTC (2d7d65b)">Diff</a>