### PR TITLE
Refine status language and make credential status `id` optional.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2160,29 +2160,29 @@ the signing date. The example below uses Ed25519 digital signatures.
         <h3>Status</h3>
 
         <p>
-This specification defines the following `credentialStatus`
-[=property=] for the discovery of information about the current status of a
-[=verifiable credential=], such as whether it is suspended or revoked.
+This specification defines the `credentialStatus` [=property=] for the
+discovery of information about the status of a [=verifiable credential=], such
+as whether it is suspended or revoked.
+        </p>
+
+        <p>
+The following properties are defined for object values associated with the
+<strong id="defn-credentialStatus">credentialStatus</strong> [=property=]:
         </p>
 
         <dl>
-          <dt><var id="defn-credentialStatus">credentialStatus</var></dt>
+          <dt>id</dt>
           <dd>
-If present, the value of the `credentialStatus` [=property=] MUST
-include the following:
-
-            <ul>
-              <li>
-`id` [=property=], which MUST be a [=URL=] which MAY be
-dereferenced.
-              </li>
-              <li>
-`type` [=property=], which expresses the [=credential=] status
-type.
-              </li>
-            </ul>
+The `id` [=property=] is OPTIONAL. It MAY be used to provide a
+unique identifier for the credential status object. If present, the
+normative guidance in Section <a href="#identifiers"></a> MUST be followed.
           </dd>
-        </dl>
+          <dt>type</dt>
+          <dd>
+The `type` [=property=] is REQUIRED. It is used to express the
+type of status information expressed by the object. The related normative
+guidance in Section <a href="#types"></a> MUST be followed.
+          </dd>
 
         <p>
 The precise content of the [=credential=] status information is determined by


### PR DESCRIPTION
This PR is an attempt at addressing issue #1398, which requests that the credential status `id` field is made optional.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1401.html" title="Last updated on Dec 26, 2023, 6:39 PM UTC (f1cd5c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1401/6de9b4c...f1cd5c4.html" title="Last updated on Dec 26, 2023, 6:39 PM UTC (f1cd5c4)">Diff</a>