### PR TITLE
Jwt example diagrams

### DIFF
--- a/diagrams/vc-jwt.drawio
+++ b/diagrams/vc-jwt.drawio
@@ -1,0 +1,166 @@
+<mxfile host="Electron" modified="2023-11-28T15:43:18.768Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.2 Chrome/114.0.5735.289 Electron/25.9.4 Safari/537.36" etag="mOiPHaxL3L57n1fm9-N2" version="22.1.2" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2363" dy="1701" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="l4elXfhYGXROxwvpLcCw-24" value="" style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;" parent="1" vertex="1">
+          <mxGeometry x="-1140" y="-720" width="186" height="590" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-27" value="&lt;i&gt;&lt;b&gt;JWS (Decoded)&lt;/b&gt;&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
+          <mxGeometry x="-1136.5" y="-710" width="179" height="34" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-32" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;" parent="1" source="l4elXfhYGXROxwvpLcCw-28" target="ER31MuB_UY-cCxpY8kVJ-3" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-887" y="-685" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-28" value="Header" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;fontStyle=2" parent="1" vertex="1">
+          <mxGeometry x="-1110" y="-640" width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-29" value="Payload&amp;nbsp;&amp;nbsp;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;fontStyle=2" parent="1" vertex="1">
+          <mxGeometry x="-1110" y="-422" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-30" value="Signature" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;fontStyle=2" parent="1" vertex="1">
+          <mxGeometry x="-1110" y="-210" width="80" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-33" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="l4elXfhYGXROxwvpLcCw-29" target="2GJPVY69K1nzuMpb44CU-1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1037" y="-390" as="sourcePoint" />
+            <mxPoint x="-877" y="-420.5" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-34" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="l4elXfhYGXROxwvpLcCw-30" target="l4elXfhYGXROxwvpLcCw-14" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1020" y="-195" as="sourcePoint" />
+            <mxPoint x="-877" y="-392" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ER31MuB_UY-cCxpY8kVJ-2" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-890" y="-563" width="870" height="306" as="geometry" />
+        </mxCell>
+        <mxCell id="2GJPVY69K1nzuMpb44CU-1" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=1 2;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+          <mxGeometry y="6" width="870" height="300" as="geometry" />
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-59" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;border-color: var(--border-color); font-size: 13px;&quot;&gt;verifiable credential graph&lt;br&gt;(serialized in JSON)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rotation=0;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+          <mxGeometry x="654" width="170" height="30" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example University&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-2">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+            <mxGeometry x="540" y="257" width="160" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;2010-01-01T10:37.24Z&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-8">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+            <mxGeometry x="29" y="147" width="190" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example Alumni Credential&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-9">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+            <mxGeometry x="359.5" y="16" width="180" height="50" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Credential123&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+            <mxGeometry x="376" y="147.39" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Pat&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-3">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="ER31MuB_UY-cCxpY8kVJ-2" vertex="1">
+            <mxGeometry x="707" y="147.39" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-8" target="I-3xDNqU13IutiKupr62-8" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-11" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-8" target="I-3xDNqU13IutiKupr62-8" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-36" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-1" target="I-3xDNqU13IutiKupr62-9" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-624" y="-333" as="sourcePoint" />
+            <mxPoint x="-574" y="-383" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-37" value="type" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-36" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-38" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-1" target="I-3xDNqU13IutiKupr62-8" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-754" y="-592.6100000000001" as="sourcePoint" />
+            <mxPoint x="-754" y="-692.6100000000001" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-39" value="type" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-38" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-40" value="validFrom&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-38" vertex="1" connectable="0">
+          <mxGeometry x="-0.0409" y="-1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-46" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=1;exitDx=0;exitDy=0;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-1" target="I-3xDNqU13IutiKupr62-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-611" y="-501.3899999999999" as="sourcePoint" />
+            <mxPoint x="-724" y="-425.3899999999999" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-47" value="issuer" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-46" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-41" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-1" target="I-3xDNqU13IutiKupr62-3" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-554" y="-513" as="sourcePoint" />
+            <mxPoint x="-854" y="-563" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-42" value="&amp;nbsp;credentialSubject&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-41" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-44" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;" parent="ER31MuB_UY-cCxpY8kVJ-2" source="I-3xDNqU13IutiKupr62-3" target="I-3xDNqU13IutiKupr62-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-314" y="-403" as="sourcePoint" />
+            <mxPoint x="-122" y="-403" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-45" value="alumniOf" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-44" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ER31MuB_UY-cCxpY8kVJ-5" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-890" y="-220" width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-14" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=1 2;" parent="ER31MuB_UY-cCxpY8kVJ-5" vertex="1">
+          <mxGeometry width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="JoZCwbDOvjXTbyjPgoR8-8" value="DtEhU3ljbEg8L38VWAfUA..." style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="ER31MuB_UY-cCxpY8kVJ-5" vertex="1">
+          <mxGeometry x="20" y="10" width="410" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="vhQtHSKfC6ez-OFtHlHv-1" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-890" y="-650" width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ER31MuB_UY-cCxpY8kVJ-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=1 2;" parent="vhQtHSKfC6ez-OFtHlHv-1" vertex="1">
+          <mxGeometry width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-8" value="&lt;i&gt;kid: https://example.com/keys/#1234&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="vhQtHSKfC6ez-OFtHlHv-1" vertex="1">
+          <mxGeometry x="28" y="10" width="263" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-9" value="&lt;i&gt;alg: E384&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="vhQtHSKfC6ez-OFtHlHv-1" vertex="1">
+          <mxGeometry x="384" y="10" width="160" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-11" value="&lt;i&gt;cty: vc+ld+json&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="vhQtHSKfC6ez-OFtHlHv-1" vertex="1">
+          <mxGeometry x="688" y="10" width="160" height="30" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/vc-jwt.svg
+++ b/diagrams/vc-jwt.svg
@@ -1,0 +1,313 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="background-color:#fff" viewBox="-0.5 -0.5 1161 631">
+    <rect width="186" height="590" x="20" y="20" fill="none" stroke="#000" pointer-events="all"/>
+    <rect width="179" height="34" x="23.5" y="30" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:177px;height:1px;padding-top:47px;margin-left:25px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                JWS (Decoded)
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="113" y="52" font-family="Helvetica" font-size="16" text-anchor="middle">JWS (Decoded)</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M110 115h152.13" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m268.88 115-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+    <rect width="60" height="30" x="50" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:58px;height:1px;padding-top:115px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;font-style:italic;white-space:normal;overflow-wrap:normal">
+                        Header
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="120" font-family="Helvetica" font-size="16" font-style="italic">Header</text>
+    </switch>
+    <rect width="70" height="30" x="50" y="318" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:68px;height:1px;padding-top:333px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;font-style:italic;white-space:normal;overflow-wrap:normal">
+                        Payload
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="338" font-family="Helvetica" font-size="16" font-style="italic">Payload  </text>
+    </switch>
+    <rect width="80" height="30" x="50" y="530" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:78px;height:1px;padding-top:545px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;font-style:italic;white-space:normal;overflow-wrap:normal">
+                        Signature
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="550" font-family="Helvetica" font-size="16" font-style="italic">Signature</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M120 333h142.13" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m268.88 333-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M130 545h132.13" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m268.88 545-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+    <rect width="870" height="300" x="270" y="183" fill="none" stroke="#000" stroke-dasharray="1 2" pointer-events="all" rx="45" ry="45"/>
+    <rect width="170" height="30" x="924" y="177" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:168px;height:1px;padding-top:184px;margin-left:925px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
+                            <font style="border-color:var(--border-color);font-size:13px">
+                                verifiable credential graph
+                                <br/>
+                                (serialized in JSON)
+                                <br/>
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1009" y="200" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable credential...</text>
+    </switch>
+    <ellipse cx="890" cy="453.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="80" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:454px;margin-left:811px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example University
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="890" y="458" font-family="Helvetica" font-size="16" text-anchor="middle">Example University</text>
+    </switch>
+    <rect width="190" height="40" x="299" y="324" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:344px;margin-left:300px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                2010-01-01T10:37.24Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="394" y="349" font-family="Helvetica" font-size="16" text-anchor="middle">2010-01-01T10:37.24Z</text>
+    </switch>
+    <ellipse cx="719.5" cy="218" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="90" ry="25"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:178px;height:1px;padding-top:218px;margin-left:631px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example Alumni Credential
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="720" y="223" font-family="Helvetica" font-size="16" text-anchor="middle">Example Alumni Credent...</text>
+    </switch>
+    <ellipse cx="719.5" cy="344" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:344px;margin-left:647px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Credential123
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="720" y="349" font-family="Helvetica" font-size="16" text-anchor="middle">Credential123</text>
+    </switch>
+    <ellipse cx="1050.5" cy="344" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:344px;margin-left:978px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Pat
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1051" y="349" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M719.5 324.39v-71.65" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m719.5 245.24 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:285px;margin-left:720px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="720" y="290" font-family="Helvetica" font-size="16" text-anchor="middle">type</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M646 344H498.74" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m491.24 344 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:345px;margin-left:570px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="570" y="349" font-family="Helvetica" font-size="16" text-anchor="middle">type</text>
+    </switch>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:344px;margin-left:572px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        validFrom
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="572" y="348" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m772.11 357.69 109.72 71.02" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m888.12 432.78-11.11-1.23 4.82-2.84.61-5.56Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:396px;margin-left:831px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        issuer
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="831" y="400" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M793 344h174.26" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m974.76 344-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:345px;margin-left:884px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        credentialSubject
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="884" y="349" font-family="Helvetica" font-size="16" text-anchor="middle"> credentialSubject </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m997.89 357.69-99.94 70.69" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m891.83 432.71 5.27-9.86.85 5.53 4.93 2.64Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:396px;margin-left:945px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        alumniOf
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="945" y="401" font-family="Helvetica" font-size="16" text-anchor="middle">alumniOf</text>
+    </switch>
+    <rect width="870" height="50" x="270" y="520" fill="none" stroke="#000" stroke-dasharray="1 2" pointer-events="all" rx="7.5" ry="7.5"/>
+    <rect width="410" height="30" x="290" y="530" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:408px;height:1px;padding-top:545px;margin-left:292px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        DtEhU3ljbEg8L38VWAfUA...
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="292" y="550" font-family="Helvetica" font-size="16">DtEhU3ljbEg8L38VWAfUA...</text>
+    </switch>
+    <rect width="870" height="50" x="270" y="90" fill="none" stroke="#000" stroke-dasharray="1 2" pointer-events="all" rx="7.5" ry="7.5"/>
+    <rect width="263" height="30" x="298" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:261px;height:1px;padding-top:115px;margin-left:300px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            kid: https://example.com/keys/#1234
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="300" y="120" font-family="Helvetica" font-size="16">kid: https://example.com/keys/#12...</text>
+    </switch>
+    <rect width="160" height="30" x="654" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:158px;height:1px;padding-top:115px;margin-left:656px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            alg: E384
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="656" y="120" font-family="Helvetica" font-size="16">alg: E384</text>
+    </switch>
+    <rect width="160" height="30" x="958" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:158px;height:1px;padding-top:115px;margin-left:960px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            cty: vc+ld+json
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="960" y="120" font-family="Helvetica" font-size="16">cty: vc+ld+json</text>
+    </switch>
+</svg>

--- a/diagrams/vp-jwt.drawio
+++ b/diagrams/vp-jwt.drawio
@@ -1,0 +1,232 @@
+<mxfile host="Electron" modified="2023-12-19T14:23:38.846Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.11 Chrome/114.0.5735.289 Electron/25.9.8 Safari/537.36" etag="H3FuUFcHGxfceCq2dSEN" version="22.1.11" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2851" dy="2033" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="l4elXfhYGXROxwvpLcCw-24" value="" style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;" parent="1" vertex="1">
+          <mxGeometry x="-1140" y="-810" width="186" height="930" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-27" value="&lt;i&gt;&lt;b&gt;JWT (Decoded)&lt;/b&gt;&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
+          <mxGeometry x="-1136.5" y="-800" width="179" height="34" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-32" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;" parent="1" source="l4elXfhYGXROxwvpLcCw-28" target="ER31MuB_UY-cCxpY8kVJ-3" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-887" y="-775" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-28" value="Header" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;fontStyle=2" parent="1" vertex="1">
+          <mxGeometry x="-1110" y="-730" width="60" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-29" value="Payload&amp;nbsp;&amp;nbsp;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;fontStyle=2" parent="1" vertex="1">
+          <mxGeometry x="-1110" y="-340" width="70" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-30" value="Signature" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;fontStyle=2" parent="1" vertex="1">
+          <mxGeometry x="-1120" y="50" width="80" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-33" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="l4elXfhYGXROxwvpLcCw-29" target="LiLZqgPSFhY8t4uFKLDl-37" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1037" y="-480" as="sourcePoint" />
+            <mxPoint x="-930" y="-290" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-34" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="l4elXfhYGXROxwvpLcCw-30" target="l4elXfhYGXROxwvpLcCw-14" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1030" y="65" as="sourcePoint" />
+            <mxPoint x="-887" y="-132" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="ER31MuB_UY-cCxpY8kVJ-5" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-889" y="40" width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-14" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=1 2;" parent="ER31MuB_UY-cCxpY8kVJ-5" vertex="1">
+          <mxGeometry width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="JoZCwbDOvjXTbyjPgoR8-8" value="XaOOh4ljklxH7L99RTVSfOl..." style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="ER31MuB_UY-cCxpY8kVJ-5" vertex="1">
+          <mxGeometry x="20" y="10" width="410" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="0PFf2DRD9uwXxl9YzXG2-1" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-889" y="-740" width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ER31MuB_UY-cCxpY8kVJ-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=1 2;" parent="0PFf2DRD9uwXxl9YzXG2-1" vertex="1">
+          <mxGeometry width="870" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-8" value="&lt;i&gt;kid: https://example.com/keys/#1234&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;flipH=0;" parent="0PFf2DRD9uwXxl9YzXG2-1" vertex="1">
+          <mxGeometry x="28" y="10" width="263" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-9" value="&lt;i&gt;alg: E384&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;flipH=0;" parent="0PFf2DRD9uwXxl9YzXG2-1" vertex="1">
+          <mxGeometry x="384" y="10" width="160" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="l4elXfhYGXROxwvpLcCw-11" value="&lt;i&gt;cty: vp+ld+json&lt;/i&gt;" style="text;strokeColor=none;fillColor=none;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;flipH=0;" parent="0PFf2DRD9uwXxl9YzXG2-1" vertex="1">
+          <mxGeometry x="688" y="10" width="160" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="8jJuMWRubzlYc9QQxYml-2" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-889" y="-640" width="870" height="630" as="geometry" />
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-37" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=1 2;arcSize=2;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+          <mxGeometry width="870" height="630" as="geometry" />
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-7" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+          <mxGeometry x="14.5" y="23.559999999999945" width="840.0454029511918" height="124.09752883031302" as="geometry" />
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="8jJuMWRubzlYc9QQxYml-2" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="28" y="144" as="sourcePoint" />
+            <mxPoint x="28" y="144" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-11" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="8jJuMWRubzlYc9QQxYml-2" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="218" y="144" as="sourcePoint" />
+            <mxPoint x="218" y="144" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-59" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;border-color: var(--border-color); font-size: 13px;&quot;&gt;verifiable presentation graph&lt;br&gt;(serialized in JSON)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rotation=0;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+          <mxGeometry x="641" y="21" width="205.5" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-8" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+          <mxGeometry x="15.454597048808182" y="237.5712026359143" width="840.0454029511918" height="369.42879736408565" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Presentation ABC&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-9">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="379.1560726447219" y="80.43509324546949" width="140.32576617480134" height="37.43926985172982" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-10">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="44.0925085130533" y="75.28981878088962" width="171.82746878547107" height="47.72981878088962" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;DoNotArchive&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-11">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="684.6271282633371" y="80.43509324546949" width="140.32576617480134" height="37.43926985172982" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-12" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;strokeWidth=2;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-9" target="LiLZqgPSFhY8t4uFKLDl-11" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-13" value="&amp;nbsp;termsOfUse&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-12" vertex="1" connectable="0">
+          <mxGeometry x="-0.0295" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-14" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;strokeWidth=2;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-9" target="LiLZqgPSFhY8t4uFKLDl-10" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="298.01532349602724" y="185.44069456342663" as="sourcePoint" />
+            <mxPoint x="589.1674233825199" y="185.44069456342663" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-15" value="&amp;nbsp;type&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-14" vertex="1" connectable="0">
+          <mxGeometry x="-0.1806" y="-3" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-16" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.517;entryY=-0.003;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;strokeWidth=2;entryPerimeter=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-9" target="LiLZqgPSFhY8t4uFKLDl-8" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="473.661180476731" y="132.5656013179571" as="sourcePoint" />
+            <mxPoint x="-12.450183881952285" y="258.1408453377265" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-17" value="verifiableCredential" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-16" vertex="1" connectable="0">
+          <mxGeometry x="-0.0295" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example University&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-18">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="537.6191827468786" y="522.0409225700164" width="152.7355278093076" height="37.43926985172982" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;2010-01-01T10:37.24Z&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-19">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="53.63847900113501" y="417.03532125205925" width="181.37343927355278" height="38.183855024711704" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example Alumni Credential&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-20">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="366.2690124858116" y="273.8458649093904" width="171.82746878547107" height="47.72981878088962" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Credential123&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-21">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="382.0198637911464" y="417.4076138385502" width="140.32576617480134" height="37.43926985172982" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Pat&lt;/font&gt;&lt;/i&gt;" id="LiLZqgPSFhY8t4uFKLDl-22">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="8jJuMWRubzlYc9QQxYml-2" vertex="1">
+            <mxGeometry x="696.0822928490352" y="417.4076138385502" width="140.32576617480134" height="37.43926985172982" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-23" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-19" target="LiLZqgPSFhY8t4uFKLDl-19" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-24" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-19" target="LiLZqgPSFhY8t4uFKLDl-19" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-25" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-21" target="LiLZqgPSFhY8t4uFKLDl-20" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-573.5317820658342" y="-41.17093904448109" as="sourcePoint" />
+            <mxPoint x="-525.8019296254256" y="-88.90075782537076" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-26" value="type" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-25" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-21" target="LiLZqgPSFhY8t4uFKLDl-19" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-697.6293984108966" y="-288.9937041186163" as="sourcePoint" />
+            <mxPoint x="-697.6293984108966" y="-384.4533416803956" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-28" value="type" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-27" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-29" value="validFrom&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-27" vertex="1" connectable="0">
+          <mxGeometry x="-0.0409" y="-1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-30" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=1;exitDx=0;exitDy=0;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-21" target="LiLZqgPSFhY8t4uFKLDl-18" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-561.1220204313281" y="-201.91542273476114" as="sourcePoint" />
+            <mxPoint x="-668.9914869466515" y="-129.36609818780892" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-31" value="issuer" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-30" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-32" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-21" target="LiLZqgPSFhY8t4uFKLDl-22" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-506.7099886492622" y="-212.99828665568373" as="sourcePoint" />
+            <mxPoint x="-793.0891032917139" y="-260.7281054365734" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-33" value="&amp;nbsp;credentialSubject&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-32" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-34" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;" parent="8jJuMWRubzlYc9QQxYml-2" source="LiLZqgPSFhY8t4uFKLDl-22" target="LiLZqgPSFhY8t4uFKLDl-18" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-277.60669693530076" y="-107.99268533772658" as="sourcePoint" />
+            <mxPoint x="-94.32406356413162" y="-107.99268533772658" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="LiLZqgPSFhY8t4uFKLDl-35" value="alumniOf" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="LiLZqgPSFhY8t4uFKLDl-34" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="8jJuMWRubzlYc9QQxYml-1" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;border-color: var(--border-color); font-size: 13px;&quot;&gt;verifiable credential graph&lt;br&gt;(serialized in JSON)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rotation=0;" vertex="1" parent="8jJuMWRubzlYc9QQxYml-2">
+          <mxGeometry x="641" y="232.85000000000002" width="205.5" height="30" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/vp-jwt.svg
+++ b/diagrams/vp-jwt.svg
@@ -1,0 +1,428 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="background-color:#fff" viewBox="-0.5 -0.5 1162 971">
+    <rect width="186" height="930" x="20" y="20" fill="none" stroke="#000" pointer-events="all"/>
+    <rect width="179" height="34" x="23.5" y="30" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:177px;height:1px;padding-top:47px;margin-left:25px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                JWT (Decoded)
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="113" y="52" font-family="Helvetica" font-size="16" text-anchor="middle">JWT (Decoded)</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M110 115h153.13" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m269.88 115-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+    <rect width="60" height="30" x="50" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:58px;height:1px;padding-top:115px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;font-style:italic;white-space:normal;overflow-wrap:normal">
+                        Header
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="120" font-family="Helvetica" font-size="16" font-style="italic">Header</text>
+    </switch>
+    <rect width="70" height="30" x="50" y="490" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:68px;height:1px;padding-top:505px;margin-left:52px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;font-style:italic;white-space:normal;overflow-wrap:normal">
+                        Payload
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="52" y="510" font-family="Helvetica" font-size="16" font-style="italic">Payload  </text>
+    </switch>
+    <rect width="80" height="30" x="40" y="880" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:78px;height:1px;padding-top:895px;margin-left:42px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;font-style:italic;white-space:normal;overflow-wrap:normal">
+                        Signature
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="42" y="900" font-family="Helvetica" font-size="16" font-style="italic">Signature</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M120 505h143.13" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m269.88 505-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M120 895h143.13" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m269.88 895-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+    <rect width="870" height="50" x="271" y="870" fill="none" stroke="#000" stroke-dasharray="1 2" pointer-events="all" rx="7.5" ry="7.5"/>
+    <rect width="410" height="30" x="291" y="880" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:408px;height:1px;padding-top:895px;margin-left:293px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        XaOOh4ljklxH7L99RTVSfOl...
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="293" y="900" font-family="Helvetica" font-size="16">XaOOh4ljklxH7L99RTVSfOl...</text>
+    </switch>
+    <rect width="870" height="50" x="271" y="90" fill="none" stroke="#000" stroke-dasharray="1 2" pointer-events="all" rx="7.5" ry="7.5"/>
+    <rect width="263" height="30" x="299" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:261px;height:1px;padding-top:115px;margin-left:301px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            kid: https://example.com/keys/#1234
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="301" y="120" font-family="Helvetica" font-size="16">kid: https://example.com/keys/#12...</text>
+    </switch>
+    <rect width="160" height="30" x="655" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:158px;height:1px;padding-top:115px;margin-left:657px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            alg: E384
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="657" y="120" font-family="Helvetica" font-size="16">alg: E384</text>
+    </switch>
+    <rect width="160" height="30" x="959" y="100" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:158px;height:1px;padding-top:115px;margin-left:961px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            cty: vp+ld+json
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="961" y="120" font-family="Helvetica" font-size="16">cty: vp+ld+json</text>
+    </switch>
+    <rect width="870" height="630" x="271" y="190" fill="none" stroke="#000" stroke-dasharray="1 2" pointer-events="all" rx="12.6" ry="12.6"/>
+    <rect width="840.05" height="124.1" x="285.5" y="213.56" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="18.61" ry="18.61"/>
+    <rect width="205.5" height="30" x="912" y="211" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:204px;height:1px;padding-top:218px;margin-left:913px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
+                            <font style="border-color:var(--border-color);font-size:13px">
+                                verifiable presentation graph
+                                <br/>
+                                (serialized in JSON)
+                                <br/>
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1015" y="234" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable presentation gr...</text>
+    </switch>
+    <rect width="840.05" height="369.43" x="286.45" y="427.57" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="55.41" ry="55.41"/>
+    <ellipse cx="720.32" cy="289.15" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="70.163" ry="18.72"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:289px;margin-left:651px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Presentation ABC
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="720" y="294" font-family="Helvetica" font-size="16" text-anchor="middle">Presentation ABC</text>
+    </switch>
+    <ellipse cx="401.01" cy="289.15" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="85.914" ry="23.865"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:170px;height:1px;padding-top:289px;margin-left:316px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                VerifiablePresentation
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="401" y="294" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiablePresentation</text>
+    </switch>
+    <ellipse cx="1025.79" cy="289.15" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="70.163" ry="18.72"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:289px;margin-left:957px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                DoNotArchive
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1026" y="294" font-family="Helvetica" font-size="16" text-anchor="middle">DoNotArchive</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M790.48 289.15h155.41" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m953.39 289.15-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:290px;margin-left:871px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        termsOfUse
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="871" y="294" font-family="Helvetica" font-size="16" text-anchor="middle"> termsOfUse </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M650.16 289.15h-153.5" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m489.16 289.15 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:287px;margin-left:584px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="584" y="291" font-family="Helvetica" font-size="16" text-anchor="middle"> type </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m720.32 307.87.4 108.86" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m720.75 424.23-5.04-9.98 5.01 2.48 4.99-2.52Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:366px;margin-left:721px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        verifiableCredential
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="721" y="371" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
+    </switch>
+    <ellipse cx="884.99" cy="730.76" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="76.368" ry="18.72"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:151px;height:1px;padding-top:731px;margin-left:810px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example University
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="885" y="736" font-family="Helvetica" font-size="16" text-anchor="middle">Example University</text>
+    </switch>
+    <rect width="181.37" height="38.18" x="324.64" y="607.04" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:179px;height:1px;padding-top:626px;margin-left:326px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                2010-01-01T10:37.24Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="415" y="631" font-family="Helvetica" font-size="16" text-anchor="middle">2010-01-01T10:37.24Z</text>
+    </switch>
+    <ellipse cx="723.18" cy="487.71" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="85.914" ry="23.865"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:170px;height:1px;padding-top:488px;margin-left:638px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example Alumni Credential
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="723" y="493" font-family="Helvetica" font-size="16" text-anchor="middle">Example Alumni Creden...</text>
+    </switch>
+    <ellipse cx="723.18" cy="626.13" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="70.163" ry="18.72"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:626px;margin-left:654px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Credential123
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="723" y="631" font-family="Helvetica" font-size="16" text-anchor="middle">Credential123</text>
+    </switch>
+    <ellipse cx="1037.25" cy="626.13" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="70.163" ry="18.72"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:626px;margin-left:968px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Pat
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1037" y="631" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M723.18 607.41v-86.1" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m723.18 513.81 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:561px;margin-left:724px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="724" y="566" font-family="Helvetica" font-size="16" text-anchor="middle">type</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M653.02 626.13H515.75" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m508.25 626.13 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:627px;margin-left:582px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="582" y="631" font-family="Helvetica" font-size="16" text-anchor="middle">type</text>
+    </switch>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:626px;margin-left:584px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        validFrom
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="584" y="630" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m773.7 639.12 103.14 67.58" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m883.12 710.82-11.11-1.3 4.83-2.82.65-5.55Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:675px;margin-left:829px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        issuer
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="829" y="680" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M793.35 626.13h164" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m964.85 626.13-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:627px;margin-left:879px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        credentialSubject
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="879" y="631" font-family="Helvetica" font-size="16" text-anchor="middle"> credentialSubject </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m986.73 639.12-93.83 67.25" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m886.8 710.74 5.22-9.89.88 5.52 4.94 2.61Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:676px;margin-left:937px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        alumniOf
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="937" y="681" font-family="Helvetica" font-size="16" text-anchor="middle">alumniOf</text>
+    </switch>
+    <rect width="205.5" height="30" x="912" y="422.85" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:204px;height:1px;padding-top:430px;margin-left:913px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
+                            <font style="border-color:var(--border-color);font-size:13px">
+                                verifiable credential graph
+                                <br/>
+                                (serialized in JSON)
+                                <br/>
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1015" y="446" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable credential grap...</text>
+    </switch>
+</svg>

--- a/index.html
+++ b/index.html
@@ -768,15 +768,18 @@ disclosure scheme that does not reveal the [=credential=] identifier.
 <a href="#basic-vc"></a> above shows the basic components of a
 [=verifiable credential=], but abstracts the details about how [=claims=]
 are organized into information [=graphs=], which are then organized into
-[=verifiable credentials=]. <a href="#info-graph-vc"></a> below shows a
-more complete depiction of a [=verifiable credential=], which is normally
-composed of at least two information [=graphs=]. The first [=graph=]
-(the [=verifiable credential graph=], in this case the [=default graph=])
-expresses the [=verifiable credential=] itself, which contains credential
-metadata and other [=claims=]. The second [=graph=]
-(the [=proof graph=] of the [=verifiable credential=], which is a <a>named
-graph</a>) expresses the digital proof, which is, in this case, a digital
-signature.
+[=verifiable credentials=]. 
+</p>
+        <p>
+          <a href="#info-graph-vc"></a> below shows a more complete depiction of a
+          [=verifiable credential=] using an [=embedded proof=] based on [[?VC-DATA-INTEGRITY]].
+          It is composed of at least two information [=graphs=].
+          The first [=graph=] (the [=verifiable credential graph=], in this case the [=default graph=])
+          expresses the [=verifiable credential=] itself through credential metadata and other [=claims=].
+          The second [=graph=], referred to by the <code>proof</code> property, is the [=proof graph=]
+          of the [=verifiable credential=], and is a separate [=named graph=].
+          The [=proof graph=] expresses the digital proof, which is, in this case, a digital
+          signature.
         </p>
 
         <figure id="info-graph-vc">
@@ -796,7 +799,39 @@ Example University.  The verifiable credential proof graph has an object
 parenthetical remark '(the default graph)', the verifiable credential proof
 graph is annotated with the parenthetical remark '(a named graph)'.">
           <figcaption style="text-align: center;">
-Information graphs associated with a basic verifiable credential.
+Information graphs associated with a basic verifiable credential, using an [=embedded proof=]
+based on [[[VC-DATA-INTEGRITY]]] [[?VC-DATA-INTEGRITY]].
+          </figcaption>
+        </figure>
+
+        <p>
+          <a href="#info-graph-vc-jwt"></a> below shows the same [=verifiable credential=]
+          as <a href="#info-graph-vc"></a>, but using an [=enveloping proof=] based on [[?VC-JOSE-COSE]].
+          The payload contains a single information graph, namely the the [=verifiable credential graph=]
+          containing credential metadata and other [=claims=].
+        </p>
+        
+        <figure id="info-graph-vc-jwt">
+          <img style="margin: auto; display: block; width: 100%;" src="diagrams/vc-jwt.svg" alt="Diagram with, on the left,
+                      a box, labeled as 'JWT (Decoded)', and with three textual labels
+                      stacked vertically, namely 'Header', 'Payload', and 'Signature'.
+                      The 'Header' label is connected, with an arrow, to a separate rectangle 
+                      on the right hand side containing three text fields: 'kid: https://example.com/keys/#1234',
+                      'alg: E384', and 'cty: vc+ld+json'. 
+                      The 'Payload' label of the left side is connected, with an arrow, to a separate rectangle, 
+                      containing a single graph. 
+                      The rectangle has a label: 'verifiable credential graph (serialized in JSON)'
+                      The claims in the graph include 'Credential 123' as a subject 
+                      with 4 properties: 'type' of value 'ExampleAlumniCredential',
+                      'issuer' of 'Example University', 'validFrom' of '2010-01-01T19:23:24Z', and
+                      'credentialSubject' of 'Pat', who also has an 'alumniOf' property with value of
+                      'Example University'.
+                      Finally, the 'Signature' label on the left side is connected, with an 
+                      arrow, to a separate rectangle, containing a single text field:
+                      'DtEhU3ljbEg8L38VWAfUA...'.">
+          <figcaption style="text-align: center;">
+            Information graphs associated with a basic verifiable credential, using an [=enveloping proof=]
+            based on [[[VC-JOSE-COSE]]] [[?VC-JOSE-COSE]].
           </figcaption>
         </figure>
 
@@ -858,21 +893,25 @@ Basic components of a verifiable presentation.
 which are then organized into [=verifiable presentations=].
         </p>
         <p>
-<a href="#info-graph-vp"></a> below shows a more complete depiction of a
-[=verifiable presentation=], which is normally composed of at least four
-information [=graphs=]. The first of these [=graphs=], the
-[=verifiable presentation graph=] (which is the [=default graph=]),
-expresses the [=verifiable presentation=] itself, and contains presentation
-metadata. The `verifiableCredential` property in the <a>verifiable
-presentation graph</a> refers to one or more [=verifiable credentials=], each
-being one of the second information [=graphs=], i.e., a self-contained
-[=verifiable credential graph=] which in turn contains credential metadata
-and other claims. Each of these graphs are separate [=named graphs=]. The
-third information [=graph=], the verifiable credential [=proof graph=],
-expresses the credential graph proof, which is usually a digital signature. The
-fourth information [=named graph=], the presentation [=proof graph=],
-expresses the presentation's digital proof, which is usually a digital
-signature.
+          <a href="#info-graph-vp"></a> below shows a more complete depiction of a
+          [=verifiable presentation=] using an <a>embedded proof</a>
+          based on [[?VC-DATA-INTEGRITY]].
+          It is composed of at least four information [=graphs=].
+          The first of these [=graphs=], the [=verifiable presentation graph=]
+          (which is the [=default graph=]), expresses the [=verifiable presentation=]
+          itself through presentation metadata.
+          The verifiable presentation refers, via the <code>verifiableCredential</code> property,
+          to a [=verifiable credential=].
+          This credential is a self-contained [=verifiable credential graph=] containing
+          credential metadata and other [=claims=].
+          This credential refers to a verifiable credential [=proof graph=] via a <code>proof</code> property,
+          expressing the proof of the credential (usually a digital signature).
+          This [=verifiable credential graph=], linked to the [=proof graph=], constitute
+          the second and third information graphs, respectively, and are both separate [=named graphs=].
+          The presentation also refers, via the <code>proof</code> property, to
+          the fourth information [=named graph=], namely the presentation's [=proof graph=].
+          This presentation proof graph represents the digital signature of the verifiable presentation graph,
+          the credential graph, and the proof graph linked from the credential graph.
         </p>
 
         <figure id="info-graph-vp">
@@ -893,14 +932,58 @@ d28348djsj3239, a 'nonce' of 'd28348djsj3239', and 'proofValue' of
 'p2KaZ...8Fj3K='. This graph is annotated with the parenthetical remark '(a
 named graph)'">
           <figcaption style="text-align: center;">
-Information graphs associated with a basic verifiable presentation.
+Information graphs associated with a basic verifiable presentation using an [=embedded proof=]
+based on [[[VC-DATA-INTEGRITY]]] [[?VC-DATA-INTEGRITY]].
           </figcaption>
         </figure>
+
+        <p>
+          <a href="#info-graph-vp-jwt"></a> below shows the same [=verifiable presentation=]
+          as <a href="#info-graph-vp"></a>, but using an [=enveloping proof=] based on [[?VC-JOSE-COSE]].
+          The payload contains only two information graphs: the [=verifiable presentation graph=]
+          expressing the [=verifiable presentation=] itself through presentation metadata,
+          and the corresponding [=verifiable credential graph=], referred to by
+          the <code>verifiableCredential</code> property.
+          The verifiable credential graph contains credential metadata and other claims.
+        </p>
+        
+        <figure id="info-graph-vp-jwt">
+          <img style="margin: auto; display: block; width: 100%;" src="diagrams/vp-jwt.svg" alt="Diagram with, on the left,
+                      a box, labeled as 'JWT (Decoded)', and with three textual labels
+                      stacked vertically, namely 'Header', 'Payload', and 'Signature'.
+                      The 'Header' label is connected, with an arrow, to a separate rectangle 
+                      on the right side of the diagram containing three text 
+                      fields: 'kid: https://example.com/keys/#1234', 'alg: E384', and 'cty: vp+ld+json'. 
+                      The 'Payload' label of the left side is connected, with an arrow, to a separate rectangle, 
+                      consisting of two related graphs (stacked vertically) connected 
+                      by a an arrow labeled 'verifiableCredential'.
+                      The two graphs have each a label 'verifiable presentation graphs (serialized in JSON)' and 
+                      'verifiable credential graph (serialized in JSON)', respectively.
+                      The top graph in the rectangle has and object 'Presentation ABC' with 3 properties: 'type'
+                      of value VerifiablePresentation, 'termsOfUse' of value 'Do Not Archive'.
+                      The bottom graph includes 'Credential 123' as a subject 
+                      with 4 properties: 'type' of value ExampleAlumniCredential,
+                      'issuer' of Example University, 'validFrom' of 2010-01-01T19:23:24Z, and
+                      credentialSubject of Pat, who also has an 'alumniOf' property with value of
+                      'Example University'.
+                      Finally, the 'Signature' label on the left side is connected, with an 
+                      arrow, to a separate rectangle, containing a single text field:
+                      'XaOOh4ljklxH7L99RTVSfOl...'.">
+          <figcaption style="text-align: center;">
+            Information graphs associated with a basic verifiable presentation, using an [=enveloping proof=]
+            based on [[[VC-JOSE-COSE]]] [[?VC-JOSE-COSE]].
+          </figcaption>
+        </figure>
+
 
         <p class="note">
 It is possible to have a [=presentation=], such as a business persona, which
 draws on multiple [=credentials=] about different [=subjects=] that are
 often, but not required to be, related.
+This is achieved by using the <code>verifiableCredential</code> property to
+refer to multiple verifiable credentials. In the [=embedded proof=] case this means adding several verifiable credential
+graphs, each with its own, separate proof graph; the number of information graphs becomes then six, eight, etc.
+In the [=enveloping proof=] case the additional verifiable credential graphs are added to the same payload.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -771,15 +771,15 @@ are organized into information [=graphs=], which are then organized into
 [=verifiable credentials=]. 
 </p>
         <p>
-          <a href="#info-graph-vc"></a> below shows a more complete depiction of a
-          [=verifiable credential=] using an [=embedded proof=] based on [[?VC-DATA-INTEGRITY]].
-          It is composed of at least two information [=graphs=].
-          The first [=graph=] (the [=verifiable credential graph=], in this case the [=default graph=])
-          expresses the [=verifiable credential=] itself through credential metadata and other [=claims=].
-          The second [=graph=], referred to by the <code>proof</code> property, is the [=proof graph=]
-          of the [=verifiable credential=], and is a separate [=named graph=].
-          The [=proof graph=] expresses the digital proof, which is, in this case, a digital
-          signature.
+<a href="#info-graph-vc"></a> below shows a more complete depiction of a
+[=verifiable credential=] using an [=embedded proof=] based on [[?VC-DATA-INTEGRITY]].
+It is composed of at least two information [=graphs=].
+The first [=graph=] (the [=verifiable credential graph=], in this case the [=default graph=])
+expresses the [=verifiable credential=] itself through credential metadata and other [=claims=].
+The second [=graph=], referred to by the <code>proof</code> property, is the [=proof graph=]
+of the [=verifiable credential=], and is a separate [=named graph=].
+The [=proof graph=] expresses the digital proof, which is, in this case, a digital
+signature.
         </p>
 
         <figure id="info-graph-vc">
@@ -893,25 +893,25 @@ Basic components of a verifiable presentation.
 which are then organized into [=verifiable presentations=].
         </p>
         <p>
-          <a href="#info-graph-vp"></a> below shows a more complete depiction of a
-          [=verifiable presentation=] using an <a>embedded proof</a>
-          based on [[?VC-DATA-INTEGRITY]].
-          It is composed of at least four information [=graphs=].
-          The first of these [=graphs=], the [=verifiable presentation graph=]
-          (which is the [=default graph=]), expresses the [=verifiable presentation=]
-          itself through presentation metadata.
-          The verifiable presentation refers, via the <code>verifiableCredential</code> property,
-          to a [=verifiable credential=].
-          This credential is a self-contained [=verifiable credential graph=] containing
-          credential metadata and other [=claims=].
-          This credential refers to a verifiable credential [=proof graph=] via a <code>proof</code> property,
-          expressing the proof of the credential (usually a digital signature).
-          This [=verifiable credential graph=], linked to the [=proof graph=], constitute
-          the second and third information graphs, respectively, and are both separate [=named graphs=].
-          The presentation also refers, via the <code>proof</code> property, to
-          the fourth information [=named graph=], namely the presentation's [=proof graph=].
-          This presentation proof graph represents the digital signature of the verifiable presentation graph,
-          the credential graph, and the proof graph linked from the credential graph.
+<a href="#info-graph-vp"></a> below shows a more complete depiction of a
+[=verifiable presentation=] using an <a>embedded proof</a>
+based on [[?VC-DATA-INTEGRITY]].
+It is composed of at least four information [=graphs=].
+The first of these [=graphs=], the [=verifiable presentation graph=]
+(which is the [=default graph=]), expresses the [=verifiable presentation=]
+itself through presentation metadata.
+The verifiable presentation refers, via the <code>verifiableCredential</code> property,
+to a [=verifiable credential=].
+This credential is a self-contained [=verifiable credential graph=] containing
+credential metadata and other [=claims=].
+This credential refers to a verifiable credential [=proof graph=] via a <code>proof</code> property,
+expressing the proof of the credential (usually a digital signature).
+This [=verifiable credential graph=], linked to the [=proof graph=], constitute
+the second and third information graphs, respectively, and are both separate [=named graphs=].
+The presentation also refers, via the <code>proof</code> property, to
+the fourth information [=named graph=], namely the presentation's [=proof graph=].
+This presentation proof graph represents the digital signature of the verifiable presentation graph,
+the credential graph, and the proof graph linked from the credential graph.
         </p>
 
         <figure id="info-graph-vp">


### PR DESCRIPTION
This is a PR to handle #1135: it adds JWT based diagrams (and corresponding explanation texts) to the informative section on the core data model. The two JWT-based diagrams themselves have been discussed on that issue (see https://github.com/w3c/vc-data-model/issues/1135#issuecomment-1827923621 and the thread of discussion that follows). 

@selfissued, this is the PR I was referring to in https://github.com/w3c/vc-data-model/pull/1397#discussion_r1432605059 and it incorporates what I think was the "spirit" of your relevant proposed changes in #1397.

This is a PR on an informative section, and the content is purely editorial, so it is not _necessary_ to include this into the upcoming CR version (although it would be nice, to make it complete).

Note that the automatic preview below does not properly work in this case: the diagrams are not shown. Reviewers can use the [gihtack.com preview](https://raw.githack.com/w3c/vc-data-model/jwt-example-diagrams/index.html#core-data-model) instead to see a final form of the text.