### PR TITLE
Add RANGE_ERROR to list of potential errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4699,6 +4699,15 @@ name of the [=property=] and the path to the property SHOULD be provided
 in the [=ProblemDetails=] object. See Section
 <a href="#verification"></a>.
           </dd>
+          <dt id="RANGE_ERROR">
+https://www.w3.org/TR/vc-data-model#RANGE_ERROR
+(-67)
+          </dt>
+          <dd>
+A provided value is outside of the expected range of an associated value,
+such as a given index value for an array being larger than the current size
+of the array.
+          </dd>
         </dl>
 
         <p>


### PR DESCRIPTION
This PR is an attempt to address issue https://github.com/w3c/vc-bitstring-status-list/issues/9 by registering a RANGE_ERROR value in the vc-data-model specification, which is used in the vc-bitstring-status-list specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1405.html" title="Last updated on Dec 28, 2023, 4:15 PM UTC (0cb48a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1405/b59c955...0cb48a6.html" title="Last updated on Dec 28, 2023, 4:15 PM UTC (0cb48a6)">Diff</a>