### PR TITLE
Example diagrams multiple credentials

### DIFF
--- a/diagrams/vp-graph-mult-creds.drawio
+++ b/diagrams/vp-graph-mult-creds.drawio
@@ -1,0 +1,635 @@
+<mxfile host="Electron" modified="2024-01-01T10:20:11.462Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.16 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="znCx-WjXOtEsBfixSwPI" version="22.1.16" type="device">
+  <diagram name="Page-1" id="VCU2_7XY7YOSpMuFFgP9">
+    <mxGraphModel dx="3004" dy="2104" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="0" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="p8tfiG4p6Vh0YpFKXhgD-1" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="1" vertex="1">
+          <mxGeometry x="-1361" y="-740" width="880" height="130" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Presentation ABC&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-68">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-979" y="-684.61" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-69">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1330" y="-690" width="180" height="50" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;DoNotArchive&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-70">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-659" y="-684.61" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="80YUNRsU_wij_iDbftCs-71" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;strokeWidth=2;" parent="1" source="80YUNRsU_wij_iDbftCs-68" target="80YUNRsU_wij_iDbftCs-70" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-73" value="&amp;nbsp;termsOfUse&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-71" vertex="1" connectable="0">
+          <mxGeometry x="-0.0295" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-72" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;strokeWidth=2;" parent="1" source="80YUNRsU_wij_iDbftCs-68" target="80YUNRsU_wij_iDbftCs-69" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1064" y="-574.61" as="sourcePoint" />
+            <mxPoint x="-759" y="-574.61" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-74" value="&amp;nbsp;type&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-72" vertex="1" connectable="0">
+          <mxGeometry x="-0.1806" y="-3" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-77" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.526;entryY=0.003;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="80YUNRsU_wij_iDbftCs-68" target="68PoX1-DRDIrpmaT4c05-46" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-880" y="-630" as="sourcePoint" />
+            <mxPoint x="-1170" y="-540" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1050" y="-590" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-78" value="verifiableCredential" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-77" vertex="1" connectable="0">
+          <mxGeometry x="-0.0295" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-79" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;strokeWidth=2;" parent="1" source="80YUNRsU_wij_iDbftCs-68" target="80YUNRsU_wij_iDbftCs-49" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-62.73792094396697" y="-599.9964451771971" as="sourcePoint" />
+            <mxPoint x="-130.0000000000001" y="341.3400000000002" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-390" y="-610" />
+              <mxPoint x="-380" y="-270" />
+              <mxPoint x="-360" y="290" />
+              <mxPoint x="-400" y="520" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="lX6lRBvpDmC6g2FffIeI-1" value="proof" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-79" vertex="1" connectable="0">
+          <mxGeometry x="0.2604" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="p8tfiG4p6Vh0YpFKXhgD-2" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;border-color: var(--border-color); font-size: 13px;&quot;&gt;verifiable presentation graph&lt;br&gt;(the default graph)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rotation=0;" parent="1" vertex="1">
+          <mxGeometry x="-700" y="-745" width="215.5" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-97" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-1370" y="540" width="880" height="328" as="geometry" />
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-49" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="68PoX1-DRDIrpmaT4c05-97" vertex="1">
+          <mxGeometry width="880" height="328" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Signature 8920&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-50">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="68PoX1-DRDIrpmaT4c05-97" vertex="1">
+            <mxGeometry x="377" y="99.88999999999999" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="80YUNRsU_wij_iDbftCs-57" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="68PoX1-DRDIrpmaT4c05-97" source="80YUNRsU_wij_iDbftCs-50" target="80YUNRsU_wij_iDbftCs-52" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="438" y="173.5" as="sourcePoint" />
+            <mxPoint x="316" y="104.5" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-58" value="&amp;nbsp;type&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-57" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-59" value="verificationMethod" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-57" vertex="1" connectable="0">
+          <mxGeometry x="0.1126" y="4" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-60" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="68PoX1-DRDIrpmaT4c05-97" source="80YUNRsU_wij_iDbftCs-50" target="80YUNRsU_wij_iDbftCs-53" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="416" y="112.5" as="sourcePoint" />
+            <mxPoint x="286" y="74.5" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="348" y="173.5" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-61" value="&amp;nbsp;created" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-60" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-62" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="68PoX1-DRDIrpmaT4c05-97" source="80YUNRsU_wij_iDbftCs-50" target="80YUNRsU_wij_iDbftCs-54" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="188" y="-116.5" as="sourcePoint" />
+            <mxPoint x="238" y="-166.5" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="358" y="73.5" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-63" value="&amp;nbsp;type&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-62" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-64" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="68PoX1-DRDIrpmaT4c05-97" source="80YUNRsU_wij_iDbftCs-50" target="80YUNRsU_wij_iDbftCs-55" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="426" y="122.5" as="sourcePoint" />
+            <mxPoint x="638" y="63.5" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="558" y="73.5" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-65" value="nonce&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-64" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-66" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="68PoX1-DRDIrpmaT4c05-97" source="80YUNRsU_wij_iDbftCs-50" target="80YUNRsU_wij_iDbftCs-56" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="436" y="132.5" as="sourcePoint" />
+            <mxPoint x="306" y="94.5" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="558" y="173.5" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-67" value="proofValue" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="80YUNRsU_wij_iDbftCs-66" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-83" value="" style="group" parent="68PoX1-DRDIrpmaT4c05-97" vertex="1" connectable="0">
+          <mxGeometry x="67" y="51.5" width="752" height="243" as="geometry" />
+        </mxCell>
+        <mxCell id="80YUNRsU_wij_iDbftCs-51" value="" style="group" parent="80YUNRsU_wij_iDbftCs-83" vertex="1" connectable="0">
+          <mxGeometry width="752" height="243" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example University Public Key 11&amp;nbsp;&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-52">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="80YUNRsU_wij_iDbftCs-51" vertex="1">
+            <mxGeometry x="302.5" y="183" width="160" height="60" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;2024-01-02T12:43.56Z&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-53">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="80YUNRsU_wij_iDbftCs-51" vertex="1">
+            <mxGeometry y="120" width="190" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Data Integrity Proof&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-54">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;shadow=0;perimeterSpacing=3;" parent="80YUNRsU_wij_iDbftCs-51" vertex="1">
+            <mxGeometry x="5" width="180" height="50" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;hasdkyruod87j&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-55">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="80YUNRsU_wij_iDbftCs-51" vertex="1">
+            <mxGeometry x="602" y="4" width="140" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;zpweJHoan87&lt;/font&gt;&lt;/i&gt;" id="80YUNRsU_wij_iDbftCs-56">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="80YUNRsU_wij_iDbftCs-51" vertex="1">
+            <mxGeometry x="592" y="116" width="160" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="80YUNRsU_wij_iDbftCs-86" value="&lt;i&gt;&lt;font style=&quot;font-size: 13px;&quot;&gt;verifiable presentation proof graph&lt;br&gt;(a named graph)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-97" vertex="1">
+          <mxGeometry x="585.5" y="2" width="280" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-100" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.514;entryY=-0.009;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="80YUNRsU_wij_iDbftCs-68" target="68PoX1-DRDIrpmaT4c05-89" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-553" y="-440" as="sourcePoint" />
+            <mxPoint x="-690" y="-70" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-720" y="-340" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-101" value="verifiableCredential" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-100" vertex="1" connectable="0">
+          <mxGeometry x="-0.0295" relative="1" as="geometry">
+            <mxPoint x="-40" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-90" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="1" vertex="1">
+          <mxGeometry x="-1020" y="291.02446033810145" width="576.7415730337078" height="218.76553966189857" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-89" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="1" vertex="1">
+          <mxGeometry x="-1020" y="3.3146293888166483" width="583.3707865168539" height="256.5523146944083" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Signature 456&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-51">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-770.7415730337079" y="366.8565514954486" width="97.44943820224718" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-52" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-975.5842696629213" y="326.8224577373212" width="498.51685393258424" height="161.09098829648894" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Example University Public Key 7&amp;nbsp;&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" id="68PoX1-DRDIrpmaT4c05-53">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="68PoX1-DRDIrpmaT4c05-52" vertex="1">
+            <mxGeometry x="200.53370786516854" y="121.31543563068921" width="106.06741573033707" height="39.775552665799744" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;2022-06-18T21:19.10Z&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-54">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="68PoX1-DRDIrpmaT4c05-52" vertex="1">
+            <mxGeometry y="79.55110533159949" width="125.95505617977527" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Data Integrity Proof&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-55">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;shadow=0;perimeterSpacing=3;" parent="68PoX1-DRDIrpmaT4c05-52" vertex="1">
+            <mxGeometry x="3.3146067415730336" width="119.32584269662921" height="33.14629388816645" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;34dj239dsj328&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-56">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="68PoX1-DRDIrpmaT4c05-52" vertex="1">
+            <mxGeometry x="399.07865168539325" y="2.651703511053316" width="92.80898876404494" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;zBavE110…3JT2pq&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-57">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="68PoX1-DRDIrpmaT4c05-52" vertex="1">
+            <mxGeometry x="392.44943820224717" y="76.89940182054616" width="106.06741573033707" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-58" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-51" target="68PoX1-DRDIrpmaT4c05-53" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-730.3033707865169" y="415.65452535760727" as="sourcePoint" />
+            <mxPoint x="-811.1797752808989" y="369.9126397919376" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-60" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;verificationMethod&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-58" vertex="1" connectable="0">
+          <mxGeometry x="0.1126" y="4" relative="1" as="geometry">
+            <mxPoint y="-11" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-61" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-51" target="68PoX1-DRDIrpmaT4c05-54" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-744.8876404494382" y="375.2160468140442" as="sourcePoint" />
+            <mxPoint x="-831.0674157303371" y="350.0248634590377" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-789.9662921348315" y="415.65452535760727" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-62" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp;created&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-61" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint y="-4" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-63" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-51" target="68PoX1-DRDIrpmaT4c05-55" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-896.0337078651686" y="223.40602080624188" as="sourcePoint" />
+            <mxPoint x="-862.8876404494382" y="190.25972691807542" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-783.3370786516854" y="349.3619375812744" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-64" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp; type&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-63" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-65" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-51" target="68PoX1-DRDIrpmaT4c05-56" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-738.2584269662922" y="381.8453055916775" as="sourcePoint" />
+            <mxPoint x="-597.7191011235955" y="342.7326788036411" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-650.7528089887641" y="349.3619375812744" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-66" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;nonce&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-65" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-67" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-51" target="68PoX1-DRDIrpmaT4c05-57" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-731.629213483146" y="388.4745643693108" as="sourcePoint" />
+            <mxPoint x="-817.8089887640449" y="363.28338101430427" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-650.7528089887641" y="415.65452535760727" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-68" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;proofValue&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-67" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-69" value="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i style=&quot;font-size: 10px;&quot;&gt;&lt;font style=&quot;font-size: 10px;&quot;&gt;&lt;span style=&quot;&quot;&gt;verifiable credential proof graph&lt;/span&gt;&lt;br&gt;&lt;font style=&quot;font-size: 10px;&quot;&gt;(a named graph)&lt;/font&gt;&lt;br&gt;&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
+          <mxGeometry x="-637.4943820224719" y="297.0076267880364" width="207.49438202247188" height="19.887776332899872" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-70" value="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 10px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;border-color: var(--border-color); font-size: 10px;&quot;&gt;verifiable credential graph&lt;br&gt;(a named graph)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rotation=0;" parent="1" vertex="1">
+          <mxGeometry x="-590" y="-10" width="121.88" height="29.89" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Example University&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-71">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-657.3820224719102" y="200.8665409622887" width="106.06741573033707" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;2010-01-01T10:37.24Z&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-72">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-993.4831460674158" y="127.9446944083225" width="125.95505617977527" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Example Alumni Credential&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" id="68PoX1-DRDIrpmaT4c05-73">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-776.3764044943821" y="28.505812743823142" width="119.32584269662921" height="33.14629388816645" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Credential123&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-74">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-765.438202247191" y="128.20323550065018" width="97.44943820224718" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Pat&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-75">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-547.3370786516855" y="128.20323550065018" width="97.44943820224718" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-76" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="68PoX1-DRDIrpmaT4c05-72" target="68PoX1-DRDIrpmaT4c05-72" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-77" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="68PoX1-DRDIrpmaT4c05-72" target="68PoX1-DRDIrpmaT4c05-72" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-78" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="68PoX1-DRDIrpmaT4c05-74" target="68PoX1-DRDIrpmaT4c05-73" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1429.0224719101125" y="-190.25972691807542" as="sourcePoint" />
+            <mxPoint x="-1395.8764044943819" y="-223.40602080624188" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-79" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;type&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-78" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-80" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="68PoX1-DRDIrpmaT4c05-74" target="68PoX1-DRDIrpmaT4c05-72" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1515.2022471910113" y="-362.36191404421334" as="sourcePoint" />
+            <mxPoint x="-1515.2022471910113" y="-428.6545018205463" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-82" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp;validFrom&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-80" vertex="1" connectable="0">
+          <mxGeometry x="-0.0409" y="-1" relative="1" as="geometry">
+            <mxPoint y="-3" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-83" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=1;exitDx=0;exitDy=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-74" target="68PoX1-DRDIrpmaT4c05-71" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1420.4044943820224" y="-301.8898154746424" as="sourcePoint" />
+            <mxPoint x="-1495.314606741573" y="-251.50744876462937" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-84" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;issuer&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-83" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-85" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-74" target="68PoX1-DRDIrpmaT4c05-75" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1382.6179775280898" y="-309.58638491547464" as="sourcePoint" />
+            <mxPoint x="-1581.4943820224719" y="-342.7326788036411" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-86" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp; credentialSubject&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-85" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint y="-4" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-87" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-75" target="68PoX1-DRDIrpmaT4c05-71" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1223.5168539325844" y="-236.66453836150845" as="sourcePoint" />
+            <mxPoint x="-1096.2359550561798" y="-236.66453836150845" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-88" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;alumniOf&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-87" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-91" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.525;entryY=-0.003;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-74" target="68PoX1-DRDIrpmaT4c05-90" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-723.6741573033707" y="300.305422626788" as="sourcePoint" />
+            <mxPoint x="-690.5280898876405" y="267.1591287386216" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-92" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;proof&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-91" vertex="1" connectable="0">
+          <mxGeometry x="-0.1786" y="-1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-47" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="1" vertex="1">
+          <mxGeometry x="-1465" y="-228.97553966189855" width="576.7415730337078" height="218.76553966189857" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-46" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;dashPattern=12 12;" parent="1" vertex="1">
+          <mxGeometry x="-1465" y="-516.6853706111833" width="583.3707865168539" height="256.5523146944083" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Signature 789&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-8">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1215.741573033708" y="-153.14344850455137" width="97.44943820224718" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-9" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="-1420.5842696629213" y="-193.1775422626788" width="498.51685393258424" height="161.09098829648894" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Example University Public Key 7&amp;nbsp;&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" id="68PoX1-DRDIrpmaT4c05-10">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="68PoX1-DRDIrpmaT4c05-9" vertex="1">
+            <mxGeometry x="200.53370786516854" y="121.31543563068921" width="106.06741573033707" height="39.775552665799744" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;2024-01-01T10:50.10Z&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-11">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="68PoX1-DRDIrpmaT4c05-9" vertex="1">
+            <mxGeometry y="79.55110533159949" width="125.95505617977527" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Data Integrity Proof&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-12">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;shadow=0;perimeterSpacing=3;" parent="68PoX1-DRDIrpmaT4c05-9" vertex="1">
+            <mxGeometry x="3.3146067415730336" width="119.32584269662921" height="33.14629388816645" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;45jhei78j0ei&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-13">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="68PoX1-DRDIrpmaT4c05-9" vertex="1">
+            <mxGeometry x="399.07865168539325" y="2.651703511053316" width="92.80898876404494" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;zHbNml98dnao&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-14">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="68PoX1-DRDIrpmaT4c05-9" vertex="1">
+            <mxGeometry x="392.44943820224717" y="76.89940182054616" width="106.06741573033707" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-15" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-8" target="68PoX1-DRDIrpmaT4c05-10" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1175.303370786517" y="-104.34547464239273" as="sourcePoint" />
+            <mxPoint x="-1256.1797752808989" y="-150.08736020806242" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-17" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;verificationMethod&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-15" vertex="1" connectable="0">
+          <mxGeometry x="0.1126" y="4" relative="1" as="geometry">
+            <mxPoint y="-15" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-8" target="68PoX1-DRDIrpmaT4c05-11" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1189.887640449438" y="-144.7839531859558" as="sourcePoint" />
+            <mxPoint x="-1276.0674157303372" y="-169.9751365409623" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1234.9662921348315" y="-104.34547464239273" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-19" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp;created&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-18" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint y="-4" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-20" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-8" target="68PoX1-DRDIrpmaT4c05-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1341.0337078651685" y="-296.5939791937581" as="sourcePoint" />
+            <mxPoint x="-1307.887640449438" y="-329.74027308192456" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1228.3370786516855" y="-170.6380624187256" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-21" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp; type&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-20" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-22" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-8" target="68PoX1-DRDIrpmaT4c05-13" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1183.258426966292" y="-138.15469440832248" as="sourcePoint" />
+            <mxPoint x="-1042.7191011235955" y="-177.26732119635892" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1095.7528089887642" y="-170.6380624187256" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-23" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;nonce&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-22" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-24" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;fontStyle=2" parent="1" source="68PoX1-DRDIrpmaT4c05-8" target="68PoX1-DRDIrpmaT4c05-14" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1176.629213483146" y="-131.52543563068917" as="sourcePoint" />
+            <mxPoint x="-1262.808988764045" y="-156.71661898569573" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-1095.7528089887642" y="-104.34547464239273" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-25" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;proofValue&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-24" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint y="-9" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-26" value="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i style=&quot;font-size: 11px;&quot;&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;&lt;span style=&quot;&quot;&gt;verifiable credential proof graph&lt;/span&gt;&lt;br&gt;&lt;font style=&quot;font-size: 11px;&quot;&gt;(a named graph)&lt;/font&gt;&lt;br&gt;&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" style="text;html=1;strokeColor=none;fillColor=none;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
+          <mxGeometry x="-1089.124382022472" y="-220.99237321196358" width="207.49438202247188" height="19.887776332899872" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-27" value="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 10px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;border-color: var(--border-color); font-size: 10px;&quot;&gt;verifiable credential graph&lt;br&gt;(a named graph)&lt;br&gt;&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rotation=0;" parent="1" vertex="1">
+          <mxGeometry x="-1035" y="-530" width="121.88" height="29.89" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Example University&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-28">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1102.3820224719102" y="-319.1334590377113" width="106.06741573033707" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;2024-01-01T10:37.24Z&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-29">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-1438.4831460674156" y="-392.0553055916775" width="125.95505617977527" height="26.51703511053316" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;p style=&quot;line-height: 70%;&quot;&gt;&lt;i&gt;&lt;font size=&quot;1&quot; style=&quot;&quot; color=&quot;#000000&quot;&gt;Example Alumni Credent&lt;/font&gt;&lt;font style=&quot;font-size: 11px;&quot; color=&quot;#000000&quot;&gt;ial&lt;/font&gt;&lt;/i&gt;&lt;/p&gt;" id="68PoX1-DRDIrpmaT4c05-30">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1221.376404494382" y="-491.4941872561769" width="119.32584269662921" height="33.14629388816645" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Credential456&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-31">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1210.438202247191" y="-391.7967644993498" width="97.44943820224718" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font style=&quot;font-size: 10px;&quot; color=&quot;#000000&quot;&gt;Ted&lt;/font&gt;&lt;/i&gt;" id="68PoX1-DRDIrpmaT4c05-32">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-992.3370786516855" y="-391.7967644993498" width="97.44943820224718" height="25.999952925877764" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-33" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="68PoX1-DRDIrpmaT4c05-29" target="68PoX1-DRDIrpmaT4c05-29" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-34" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="68PoX1-DRDIrpmaT4c05-29" target="68PoX1-DRDIrpmaT4c05-29" edge="1">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-35" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="68PoX1-DRDIrpmaT4c05-31" target="68PoX1-DRDIrpmaT4c05-30" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1874.0224719101125" y="-710.2597269180754" as="sourcePoint" />
+            <mxPoint x="-1840.8764044943819" y="-743.4060208062419" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-36" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;type&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-35" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-37" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="68PoX1-DRDIrpmaT4c05-31" target="68PoX1-DRDIrpmaT4c05-29" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1960.2022471910113" y="-882.3619140442133" as="sourcePoint" />
+            <mxPoint x="-1960.2022471910113" y="-948.6545018205463" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-38" value="&lt;br&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-37" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-39" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp;validFrom&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-37" vertex="1" connectable="0">
+          <mxGeometry x="-0.0409" y="-1" relative="1" as="geometry">
+            <mxPoint y="-3" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-40" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=1;exitDx=0;exitDy=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-31" target="68PoX1-DRDIrpmaT4c05-28" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1865.4044943820224" y="-821.8898154746423" as="sourcePoint" />
+            <mxPoint x="-1940.314606741573" y="-771.5074487646293" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-41" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;issuer&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-40" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-42" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-31" target="68PoX1-DRDIrpmaT4c05-32" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1827.6179775280898" y="-829.5863849154746" as="sourcePoint" />
+            <mxPoint x="-2026.4943820224719" y="-862.7326788036411" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-43" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;&amp;nbsp; credentialSubject&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-42" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint y="-4" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-44" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;strokeWidth=2;exitX=0;exitY=1;exitDx=0;exitDy=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-32" target="68PoX1-DRDIrpmaT4c05-28" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1668.5168539325844" y="-756.6645383615084" as="sourcePoint" />
+            <mxPoint x="-1541.2359550561798" y="-756.6645383615084" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-45" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;alumniOf&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-44" vertex="1" connectable="0">
+          <mxGeometry x="-0.016" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-48" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.525;entryY=-0.003;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="68PoX1-DRDIrpmaT4c05-31" target="68PoX1-DRDIrpmaT4c05-47" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-1168.6741573033707" y="-219.69457737321198" as="sourcePoint" />
+            <mxPoint x="-1135.5280898876404" y="-252.84087126137842" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="68PoX1-DRDIrpmaT4c05-49" value="&lt;font style=&quot;font-size: 10px;&quot;&gt;proof&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="68PoX1-DRDIrpmaT4c05-48" vertex="1" connectable="0">
+          <mxGeometry x="-0.1786" y="-1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/vp-graph-mult-creds.svg
+++ b/diagrams/vp-graph-mult-creds.svg
@@ -1,0 +1,1197 @@
+<svg xmlns="http://www.w3.org/2000/svg" style="background-color:#fff" viewBox="-0.5 -0.5 1156 1654">
+    <rect width="880" height="130" x="124" y="25" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="19.5" ry="19.5"/>
+    <ellipse cx="579.5" cy="100" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:100px;margin-left:507px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Presentation ABC
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="580" y="105" font-family="Helvetica" font-size="16" text-anchor="middle">Presentation ABC</text>
+    </switch>
+    <ellipse cx="245" cy="100" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="90" ry="25"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:178px;height:1px;padding-top:100px;margin-left:156px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                VerifiablePresentation
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="245" y="105" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiablePresentation</text>
+    </switch>
+    <ellipse cx="899.5" cy="100" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:100px;margin-left:827px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                DoNotArchive
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="900" y="105" font-family="Helvetica" font-size="16" text-anchor="middle">DoNotArchive</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M653 100h163.26" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m823.76 100-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:100px;margin-left:737px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        termsOfUse
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="737" y="105" font-family="Helvetica" font-size="16" text-anchor="middle"> termsOfUse </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M506 100H344.74" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m337.24 100 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:97px;margin-left:437px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="437" y="102" font-family="Helvetica" font-size="16" text-anchor="middle"> type </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M579.5 119.61Q435 175 334.89 243.58" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m328.7 247.82 5.42-9.78.77 5.54 4.88 2.71Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:170px;margin-left:450px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        verifiableCredential
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="450" y="175" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M632.11 113.69Q1095 155 1100 325t15 450q10 280-10 395t-105.72 290.25" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m995.98 1466.99-.1-11.18 3.4 4.44 5.59-.04Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:827px;margin-left:1117px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        proof
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="1117" y="832" font-family="Helvetica" font-size="16" text-anchor="middle">proof</text>
+    </switch>
+    <rect width="215.5" height="30" x="785" y="20" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:214px;height:1px;padding-top:27px;margin-left:786px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
+                            <font style="border-color:var(--border-color);font-size:13px">
+                                verifiable presentation graph
+                                <br/>
+                                (the default graph)
+                                <br/>
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="893" y="43" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable presentation gra...</text>
+    </switch>
+    <rect width="880" height="328" x="115" y="1305" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="49.2" ry="49.2"/>
+    <ellipse cx="565.5" cy="1424.5" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:1425px;margin-left:493px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Signature 8920
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="566" y="1429" font-family="Helvetica" font-size="16" text-anchor="middle">Signature 8920</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m565.5 1444.11-.9 85.65" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m564.52 1537.26-4.89-10.05 4.97 2.55 5.03-2.44Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1499px;margin-left:563px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="563" y="1503" font-family="Helvetica" font-size="16" text-anchor="middle"> type </text>
+    </switch>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1498px;margin-left:569px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        verificationMethod
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="569" y="1502" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M512.89 1438.19q-49.89 40.31-131.34 56.42" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m374.19 1496.07 8.84-6.85-1.48 5.39 3.42 4.42Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1482px;margin-left:439px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        created
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="439" y="1487" font-family="Helvetica" font-size="16" text-anchor="middle"> created</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M512.89 1410.81q-39.89-32.31-133.16-29.59" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m372.24 1381.43 9.85-5.28-2.36 5.07 2.65 4.92Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1378px;margin-left:437px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        type
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="437" y="1383" font-family="Helvetica" font-size="16" text-anchor="middle"> type </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M618.11 1410.81q54.89-32.31 156.16-30.49" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m781.76 1380.46-10.08 4.82 2.59-4.96-2.41-5.04Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1382px;margin-left:709px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        nonce
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="709" y="1386" font-family="Helvetica" font-size="16" text-anchor="middle">nonce </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M618.11 1438.19q54.89 40.31 146.25 52.97" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m771.79 1492.19-10.6 3.58 3.17-4.61-1.79-5.29Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1485px;margin-left:701px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        proofValue
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="701" y="1490" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue</text>
+    </switch>
+    <ellipse cx="564.5" cy="1569.5" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="80" ry="30"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:1570px;margin-left:486px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example University Public Key 11
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="565" y="1574" font-family="Helvetica" font-size="16" text-anchor="middle">Example University P...</text>
+    </switch>
+    <rect width="190" height="40" x="182" y="1476.5" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:188px;height:1px;padding-top:1497px;margin-left:183px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                2024-01-02T12:43.56Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="277" y="1501" font-family="Helvetica" font-size="16" text-anchor="middle">2024-01-02T12:43.56Z</text>
+    </switch>
+    <ellipse cx="277" cy="1381.5" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="90" ry="25"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:178px;height:1px;padding-top:1382px;margin-left:188px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Data Integrity Proof
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="277" y="1386" font-family="Helvetica" font-size="16" text-anchor="middle">Data Integrity Proof</text>
+    </switch>
+    <rect width="140" height="40" x="784" y="1360.5" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:1381px;margin-left:785px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                hasdkyruod87j
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="854" y="1385" font-family="Helvetica" font-size="16" text-anchor="middle">hasdkyruod87j</text>
+    </switch>
+    <rect width="160" height="40" x="774" y="1472.5" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:1493px;margin-left:775px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                zpweJHoan87
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="854" y="1497" font-family="Helvetica" font-size="16" text-anchor="middle">zpweJHoan87</text>
+    </switch>
+    <rect width="280" height="30" x="700.5" y="1307" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:278px;height:1px;padding-top:1322px;margin-left:702px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font style="font-size:13px">
+                                verifiable presentation proof graph
+                                <br/>
+                                (a named graph)
+                                <br/>
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="841" y="1327" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable presentation proof graph...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M579.5 119.61Q765 425 764.86 756.27" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m764.85 763.77-4.99-10 5 2.5 5-2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:410px;margin-left:716px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        verifiableCredential
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="716" y="415" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
+    </switch>
+    <rect width="576.74" height="218.77" x="465" y="1056.02" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="32.81" ry="32.81"/>
+    <rect width="583.37" height="256.55" x="465" y="768.31" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="38.48" ry="38.48"/>
+    <ellipse cx="762.98" cy="1144.86" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="48.725" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:95px;height:1px;padding-top:1145px;margin-left:715px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Signature 456
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="763" y="1150" font-family="Helvetica" font-size="16" text-anchor="middle">Signature 456</text>
+    </switch>
+    <ellipse cx="762.98" cy="1233.03" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="53.034" ry="19.888"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:104px;height:1px;padding-top:1233px;margin-left:711px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i>
+                                <font color="#000" style="font-size:10px">
+                                    Example University Public Key 7
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="763" y="1238" font-family="Helvetica" font-size="16" text-anchor="middle">Example Unive...</text>
+    </switch>
+    <rect width="125.96" height="26.52" x="509.42" y="1171.37" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:124px;height:1px;padding-top:1185px;margin-left:510px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                2022-06-18T21:19.10Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="572" y="1189" font-family="Helvetica" font-size="16" text-anchor="middle">2022-06-18T21:19...</text>
+    </switch>
+    <ellipse cx="572.39" cy="1108.4" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="59.663" ry="16.573"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:117px;height:1px;padding-top:1108px;margin-left:514px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Data Integrity Proof
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="572" y="1113" font-family="Helvetica" font-size="16" text-anchor="middle">Data Integrity...</text>
+    </switch>
+    <rect width="92.81" height="26.52" x="908.49" y="1094.47" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:91px;height:1px;padding-top:1108px;margin-left:909px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                34dj239dsj328
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="955" y="1113" font-family="Helvetica" font-size="16" text-anchor="middle">34dj239dsj328</text>
+    </switch>
+    <rect width="106.07" height="26.52" x="901.87" y="1168.72" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:104px;height:1px;padding-top:1182px;margin-left:903px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                zBavE110…3JT2pq
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="955" y="1187" font-family="Helvetica" font-size="16" text-anchor="middle">zBavE110…3JT2pq</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M762.98 1157.86v45.54" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m762.98 1210.9-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1178px;margin-left:767px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            verificationMethod
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="767" y="1183" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M727.43 1153.75q-32.4 26.9-82.34 30.23" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m637.6 1184.48 9.65-5.65-2.16 5.15 2.82 4.83Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1176px;margin-left:680px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            created
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="680" y="1181" font-family="Helvetica" font-size="16" text-anchor="middle"> created</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M727.43 1135.97q-25.77-21.61-82.68-26.71" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m637.28 1108.6 10.41-4.09-2.94 4.75 2.05 5.21Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1111px;margin-left:679px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            type
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="679" y="1116" font-family="Helvetica" font-size="16" text-anchor="middle">  type  </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M798.54 1135.97q35.71-21.61 100.26-27.37" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m906.27 1107.93-9.52 5.87 2.05-5.2-2.94-4.76Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1115px;margin-left:859px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            nonce
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="859" y="1119" font-family="Helvetica" font-size="16" text-anchor="middle">nonce </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M798.54 1153.75q35.71 26.9 93.59 28.04" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m899.63 1181.94-10.1 4.8 2.6-4.95-2.4-5.05Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:1176px;margin-left:854px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            proofValue
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="854" y="1180" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue </text>
+    </switch>
+    <rect width="207.49" height="19.89" x="847.51" y="1062.01" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:205px;height:1px;padding-top:1072px;margin-left:849px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i style="font-size:10px">
+                                <font style="font-size:10px">
+                                    <span>
+                                        verifiable credential proof graph
+                                    </span>
+                                    <br/>
+                                    <font style="font-size:10px">
+                                        (a named graph)
+                                    </font>
+                                    <br/>
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="951" y="1077" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable credential proo...</text>
+    </switch>
+    <rect width="121.88" height="29.89" x="895" y="755" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:120px;height:1px;padding-top:762px;margin-left:896px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-size:10px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
+                                <font style="border-color:var(--border-color);font-size:10px">
+                                    verifiable credential graph
+                                    <br/>
+                                    (a named graph)
+                                    <br/>
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="956" y="778" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable cred...</text>
+    </switch>
+    <ellipse cx="880.65" cy="978.87" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="53.034" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:104px;height:1px;padding-top:979px;margin-left:829px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Example University
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="881" y="984" font-family="Helvetica" font-size="16" text-anchor="middle">Example Unive...</text>
+    </switch>
+    <rect width="125.96" height="26.52" x="491.52" y="892.94" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:124px;height:1px;padding-top:906px;margin-left:493px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                2010-01-01T10:37.24Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="554" y="911" font-family="Helvetica" font-size="16" text-anchor="middle">2010-01-01T10:37...</text>
+    </switch>
+    <ellipse cx="768.29" cy="810.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="59.663" ry="16.573"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:117px;height:1px;padding-top:810px;margin-left:710px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i>
+                                <font color="#000" style="font-size:10px">
+                                    Example Alumni Credential
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="768" y="815" font-family="Helvetica" font-size="16" text-anchor="middle">Example Alumni...</text>
+    </switch>
+    <ellipse cx="768.29" cy="906.2" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="48.725" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:95px;height:1px;padding-top:906px;margin-left:721px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Credential123
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="768" y="911" font-family="Helvetica" font-size="16" text-anchor="middle">Credential123</text>
+    </switch>
+    <ellipse cx="986.39" cy="906.2" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="48.725" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:95px;height:1px;padding-top:906px;margin-left:939px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Pat
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="986" y="911" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M768.29 893.2v-56.81" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m768.29 828.89 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:861px;margin-left:769px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            type
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="769" y="866" font-family="Helvetica" font-size="16" text-anchor="middle">type</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M719.56 906.2h-92.35" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m619.71 906.2 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:903px;margin-left:671px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            validFrom
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="671" y="908" font-family="Helvetica" font-size="16" text-anchor="middle"> validFrom </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m803.84 915.09 68.69 45.41" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m878.79 964.63-11.1-1.34 4.84-2.79.67-5.55Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:940px;margin-left:842px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            issuer
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="842" y="945" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M817.01 906.2h110.92" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m935.43 906.2-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:903px;margin-left:877px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            credentialSubject
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="877" y="908" font-family="Helvetica" font-size="16" text-anchor="middle">  credentialSubject  </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m950.83 915.09-62.29 45.07" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m882.46 964.56 5.17-9.92.91 5.52 4.96 2.59Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:941px;margin-left:916px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            alumniOf
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="916" y="946" font-family="Helvetica" font-size="16" text-anchor="middle">alumniOf</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m768.29 919.2-.47 126.43" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m767.8 1053.13-4.97-10.02 4.99 2.52 5.01-2.48Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:976px;margin-left:768px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            proof
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="768" y="980" font-family="Helvetica" font-size="16" text-anchor="middle">proof</text>
+    </switch>
+    <rect width="576.74" height="218.77" x="20" y="536.02" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="32.81" ry="32.81"/>
+    <rect width="583.37" height="256.55" x="20" y="248.31" fill="none" stroke="#000" stroke-dasharray="12 12" pointer-events="all" rx="38.48" ry="38.48"/>
+    <ellipse cx="317.98" cy="624.86" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="48.725" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:95px;height:1px;padding-top:625px;margin-left:270px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Signature 789
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="318" y="630" font-family="Helvetica" font-size="16" text-anchor="middle">Signature 789</text>
+    </switch>
+    <ellipse cx="317.98" cy="713.03" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="53.034" ry="19.888"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:104px;height:1px;padding-top:713px;margin-left:266px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i>
+                                <font color="#000" style="font-size:10px">
+                                    Example University Public Key 7
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="318" y="718" font-family="Helvetica" font-size="16" text-anchor="middle">Example Unive...</text>
+    </switch>
+    <rect width="125.96" height="26.52" x="64.42" y="651.37" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:124px;height:1px;padding-top:665px;margin-left:65px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                2024-01-01T10:50.10Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="127" y="669" font-family="Helvetica" font-size="16" text-anchor="middle">2024-01-01T10:50...</text>
+    </switch>
+    <ellipse cx="127.39" cy="588.4" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="59.663" ry="16.573"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:117px;height:1px;padding-top:588px;margin-left:69px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Data Integrity Proof
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="127" y="593" font-family="Helvetica" font-size="16" text-anchor="middle">Data Integrity...</text>
+    </switch>
+    <rect width="92.81" height="26.52" x="463.49" y="574.47" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:91px;height:1px;padding-top:588px;margin-left:464px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                45jhei78j0ei
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="510" y="593" font-family="Helvetica" font-size="16" text-anchor="middle">45jhei78j0ei</text>
+    </switch>
+    <rect width="106.07" height="26.52" x="456.87" y="648.72" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:104px;height:1px;padding-top:662px;margin-left:458px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                zHbNml98dnao
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="510" y="667" font-family="Helvetica" font-size="16" text-anchor="middle">zHbNml98dnao</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M317.98 637.86v45.54" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m317.98 690.9-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:654px;margin-left:322px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            verificationMethod
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="322" y="659" font-family="Helvetica" font-size="16" text-anchor="middle">verificationMethod</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M282.43 633.75q-32.4 26.9-82.34 30.23" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m192.6 664.48 9.65-5.65-2.16 5.15 2.82 4.83Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:656px;margin-left:235px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            created
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="235" y="661" font-family="Helvetica" font-size="16" text-anchor="middle"> created</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M282.43 615.97q-25.77-21.61-82.68-26.71" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m192.28 588.6 10.41-4.09-2.94 4.75 2.05 5.21Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:591px;margin-left:234px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            type
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="234" y="596" font-family="Helvetica" font-size="16" text-anchor="middle">  type  </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M353.54 615.97q35.71-21.61 100.26-27.37" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m461.27 587.93-9.52 5.87 2.05-5.2-2.94-4.76Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:595px;margin-left:414px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            nonce
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="414" y="599" font-family="Helvetica" font-size="16" text-anchor="middle">nonce </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M353.54 633.75q35.71 26.9 93.59 28.04" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m454.63 661.94-10.1 4.8 2.6-4.95-2.4-5.05Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:655px;margin-left:409px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            proofValue
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="409" y="659" font-family="Helvetica" font-size="16" text-anchor="middle">proofValue </text>
+    </switch>
+    <rect width="207.49" height="19.89" x="395.88" y="544.01" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:205px;height:1px;padding-top:554px;margin-left:397px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i style="font-size:11px">
+                                <font style="font-size:11px">
+                                    <span>
+                                        verifiable credential proof graph
+                                    </span>
+                                    <br/>
+                                    <font style="font-size:11px">
+                                        (a named graph)
+                                    </font>
+                                    <br/>
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="500" y="559" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable credential proo...</text>
+    </switch>
+    <rect width="121.88" height="29.89" x="450" y="235" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:120px;height:1px;padding-top:242px;margin-left:451px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-size:10px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
+                                <font style="border-color:var(--border-color);font-size:10px">
+                                    verifiable credential graph
+                                    <br/>
+                                    (a named graph)
+                                    <br/>
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="511" y="258" font-family="Helvetica" font-size="16" text-anchor="middle">verifiable cred...</text>
+    </switch>
+    <ellipse cx="435.65" cy="458.87" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="53.034" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:104px;height:1px;padding-top:459px;margin-left:384px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Example University
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="436" y="464" font-family="Helvetica" font-size="16" text-anchor="middle">Example Unive...</text>
+    </switch>
+    <rect width="125.96" height="26.52" x="46.52" y="372.94" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:124px;height:1px;padding-top:386px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                2024-01-01T10:37.24Z
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="109" y="391" font-family="Helvetica" font-size="16" text-anchor="middle">2024-01-01T10:37...</text>
+    </switch>
+    <ellipse cx="323.29" cy="290.08" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="59.663" ry="16.573"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:117px;height:1px;padding-top:290px;margin-left:265px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <p style="line-height:70%">
+                            <i>
+                                <font color="#000" size="1">
+                                    Example Alumni Credent
+                                </font>
+                                <font color="#000" style="font-size:11px">
+                                    ial
+                                </font>
+                            </i>
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="323" y="295" font-family="Helvetica" font-size="16" text-anchor="middle">Example Alumni...</text>
+    </switch>
+    <ellipse cx="323.29" cy="386.2" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="48.725" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:95px;height:1px;padding-top:386px;margin-left:276px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Credential456
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="323" y="391" font-family="Helvetica" font-size="16" text-anchor="middle">Credential456</text>
+    </switch>
+    <ellipse cx="541.39" cy="386.2" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="48.725" ry="13"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:95px;height:1px;padding-top:386px;margin-left:494px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000" style="font-size:10px">
+                                Ted
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="541" y="391" font-family="Helvetica" font-size="16" text-anchor="middle">Ted</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M323.29 373.2v-56.81" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m323.29 308.89 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:341px;margin-left:324px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            type
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="324" y="346" font-family="Helvetica" font-size="16" text-anchor="middle">type</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M274.56 386.2h-92.35" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m174.71 386.2 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:387px;margin-left:225px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <br/>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+    </switch>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:383px;margin-left:226px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            validFrom
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="226" y="388" font-family="Helvetica" font-size="16" text-anchor="middle"> validFrom  </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m358.84 395.09 68.69 45.41" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m433.79 444.63-11.1-1.34 4.84-2.79.67-5.55Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:420px;margin-left:397px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            issuer
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="397" y="425" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M372.01 386.2h110.92" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m490.43 386.2-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:383px;margin-left:432px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            credentialSubject
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="432" y="388" font-family="Helvetica" font-size="16" text-anchor="middle">  credentialSubject  </text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m505.83 395.09-62.29 45.07" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m437.46 444.56 5.17-9.92.91 5.52 4.96 2.59Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:421px;margin-left:471px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            alumniOf
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="471" y="426" font-family="Helvetica" font-size="16" text-anchor="middle">alumniOf</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m323.29 399.2-.47 126.43" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m322.8 533.13-4.97-10.02 4.99 2.52 5.01-2.48Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:456px;margin-left:323px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:10px">
+                            proof
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="323" y="460" font-family="Helvetica" font-size="16" text-anchor="middle">proof</text>
+    </switch>
+</svg>

--- a/index.html
+++ b/index.html
@@ -892,7 +892,7 @@ Basic components of a verifiable presentation.
 [=verifiable credentials=] are organized into information [=graphs=],
 which are then organized into [=verifiable presentations=].
         </p>
-        <p>
+        <p id="info-graph-vp-explanation">
 <a href="#info-graph-vp"></a> below shows a more complete depiction of a
 [=verifiable presentation=] using an <a>embedded proof</a>
 based on [[?VC-DATA-INTEGRITY]].
@@ -924,11 +924,11 @@ graph is annotated with the parenthetical remark '(the default graph)'. This
 graph is connected, through 'verifiableCredential', to the part of the figure
 which is identical to Figure 6, except that the verifiable credential graph is
 annotated to be a named graph instead of a default graph.
-The verifiable presentation proof graph, has and object with 'Signature 8910'
+The verifiable presentation proof graph has and object with 'Signature 8910'
 with 5 properties: 'type' of DataIntegrityProof, 'verificationMethod' of Example
-Presenter Public Key 11, 'created' of 2018-01-15T12:43:56Z, 'challenge' of
-d28348djsj3239, a 'nonce' of 'd28348djsj3239', and 'proofValue' of
-'p2KaZ...8Fj3K='. This graph is annotated with the parenthetical remark '(a
+Presenter Public Key 11, 'created' of 2018-01-15T12:43:56Z, 
+a 'nonce' of 'd28348djsj3239', and 'proofValue' of
+'zp2KaZ...8Fj3K='. This graph is annotated with the parenthetical remark '(a
 named graph)'">
           <figcaption style="text-align: center;">
 Information [=graphs=] associated with a basic [=verifiable presentation=] that is using an [=embedded proof=]
@@ -976,13 +976,13 @@ based on [[[VC-DATA-INTEGRITY]]] [[?VC-DATA-INTEGRITY]].
 
 
         <p class="note">
-It is possible to have a [=presentation=], such as a business persona, which
+It is possible to have a [=presentation=], such as a collection of university credentials, which
 draws on multiple [=credentials=] about different [=subjects=] that are
 often, but not required to be, related.
 This is achieved by using the <code>verifiableCredential</code> property to
-refer to multiple [=verifiable credentials=]. When using an [=embedded proof=], this means adding one or more [=verifiable credential graphs=],
-each with its own, separate [=proof graph=]; the number of information [=graphs=] thus becomes six, eight, etc.
-When using an [=enveloping proof=], the additional [=verifiable credential graphs=] are added to the same payload.
+refer to multiple [=verifiable credentials=]. 
+See <a href="#info-graph-vp-mult-creds"></a>, a variant of <a href="#info-graph-vp"></a> above,
+for more details.
         </p>
 
       </section>
@@ -7163,6 +7163,45 @@ expected to be a valid
 document</a>.
         </p>
       </section>
+
+    </section>
+
+    <section class="appendix informative">
+      <h2>Additional Diagrams</h2>
+
+      <p id="info-graph-vp-mult-creds-expl">
+        <a href="#info-graph-vp-mult-creds"></a> below is a variant of <a href="#info-graph-vp"></a>:
+        a [=verifiable presentation=] referring to two [=verifiable credentials=], and using <a>embedded proofs</a> based on [[?VC-DATA-INTEGRITY]]. 
+        Each [=verifiable credential graph=] is connected to 
+        its own separate [=proof graph=]; the <code>verifiableCredential</code> property is used
+        to connect the [=verifiable presentation=] to the [=verifiable credential graphs=].
+        The [=presentation=] [=proof graph=] represents the digital signature of the [=verifiable presentation graph=], both [=verifiable credential graphs=], and the [=proof graphs=] linked from the [=verifiable credential graphs=]. The complete [=verifiable presentation=]
+        consists, in this case, of six information [=graphs=].
+      </p>
+
+      <figure id="info-graph-vp-mult-creds">
+        <img style="margin: auto; display: block; width: 100%;" src="diagrams/vp-graph-mult-creds.svg" alt="Diagram with a
+      'verifiable presentation graph' on top connected via a 'proof' to
+      a 'verifiable presentation proof graph on the bottom.  The verifiable
+      presentation graph has and object 'Presentation ABC' with 3 properties: 'type'
+      of value VerifiablePresentation, 'termsOfUse' of value 'Do Not Archive'. The
+      graph is annotated with the parenthetical remark '(the default graph)'. This
+      graph is connected, through 'verifiableCredential', to the part of the figure
+      that consists two variants of Figure 6 (one is identical, the other with
+      minor changes on the labels referring to validity dates, name of the person,
+      and the values for the nonce and the signature values), 
+      except that the verifiable credential graphs are
+      annotated to be nameds graphs instead of a default graph.
+      The verifiable presentation proof graph has and object with 'Signature 8920'
+      with 5 properties: 'type' of DataIntegrityProof, 'verificationMethod' of Example
+      Presenter Public Key 11, 'created' of 2024-01-02T12:43:56Z, a 'nonce' of 'hasdkyruod87j', 
+      and 'proofValue' of 'zpewJHoan87='. This graph is annotated with the parenthetical remark '(a
+      named graph)'">
+        <figcaption style="text-align: center;">
+          A variant of <a href="#info-graph-vp"></a>: information [=graphs=] associated with a [=verifiable presentation=] referring to two 
+          verifiable credentials, using an [=embedded proof=] based on [[[VC-DATA-INTEGRITY]]] [[?VC-DATA-INTEGRITY]].
+        </figcaption>
+      </figure>
 
     </section>
 

--- a/index.html
+++ b/index.html
@@ -910,7 +910,7 @@ the second and third information [=graphs=], respectively, and each is a separat
 The [=presentation=] also refers, via the <code>proof</code> property, to
 the [=presentation=]'s [=proof graph=], which is the fourth information [=graph=] (another [=named graph=]).
 This [=presentation=] [=proof graph=] represents the digital signature of the [=verifiable presentation graph=],
-the [=credential graph=], and the [=proof graph=] linked from the [=credential graph=].
+the [=verifiable credential graph=], and the [=proof graph=] linked from the [=verifiable credential graph=].
         </p>
 
         <figure id="info-graph-vp">


### PR DESCRIPTION
This PR (***which is on top of the `jwt-example-diagrams` branch behind #1404***) is an attempt to close the discussion thread started by @TallTed on https://github.com/w3c/vc-data-model/pull/1404#discussion_r1437891867 for #1404. What it does is:

1. Adds a new diagram for VP-s with two VC-s (based on DI); it is put into a separate, informative appendix at the end of the spec
2. Modifies the editorial note in the original text (which addresses the multiple credentials case for VPs) by referring to the diagram instead of attempting to describe the set of graphs textually. This is also an attempt to answer @andresuribe87 in the separate thread https://github.com/w3c/vc-data-model/pull/1404#discussion_r1437090050.

If merged, this PR would cover the two comments mentioned above.

There is no mention, in the new appendix, to the JWT case because that goes beyond my level of knowledge (see https://github.com/w3c/vc-data-model/pull/1404#issuecomment-1870915997). If that aspect is settled, I am happy to add a JWT variant of the new diagram to the text.

(There are also some minor changes in the alt text of the original diagram; they were errors...)

As before, the automatic preview is not really usable, use [the separate one](https://raw.githack.com/w3c/vc-data-model/jwt-example-diagrams-multiple-creds/index.html#additional-diagrams) instead.