### PR TITLE
Update status list terms to match spec.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -193,12 +193,12 @@
       }
     },
 
-    "StatusList2021Credential":
-      "https://w3id.org/vc/status-list#StatusList2021Credential",
+    "BitstringStatusListCredential":
+      "https://w3id.org/vc/status-list#BitstringStatusListCredential",
 
-    "StatusList2021": {
+    "BitstringStatusList": {
       "@id":
-        "https://w3id.org/vc/status-list#StatusList2021",
+        "https://w3id.org/vc/status-list#BitstringStatusList",
       "@context": {
         "@protected": true,
 
@@ -211,9 +211,9 @@
       }
     },
 
-    "StatusList2021Entry": {
+    "BitstringStatusListEntry": {
       "@id":
-        "https://w3id.org/vc/status-list#StatusList2021Entry",
+        "https://w3id.org/vc/status-list#BitstringStatusListEntry",
       "@context": {
         "@protected": true,
 

--- a/index.html
+++ b/index.html
@@ -1401,7 +1401,7 @@ A valid proof [=type=]. For example,<br>
               </td>
               <td>
 A valid [=credential=] status [=type=]. For example,<br>
-`"type": "StatusList2021Entry"`
+`"type": "BitstringStatusListEntry"`
               </td>
             </tr>
 
@@ -2138,7 +2138,7 @@ could contain a link to an external document which notes whether or not the
   },
   <span class="highlight">"credentialStatus": {
     "id": "https://university.example/credentials/status/3#94567",
-    "type": "StatusList2021Entry",
+    "type": "BitstringStatusListEntry",
     "statusPurpose": "revocation",
     "statusListIndex": "94567",
     "statusListCredential": "https://university.example/credentials/status/3"


### PR DESCRIPTION
StatusList2021 was renamed to BitstringStatusList. This updates the VCDM
term use to match the updated terminology.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/BigBlueHat/vc-data-model/pull/1409.html" title="Last updated on Jan 4, 2024, 9:04 PM UTC (efb45ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1409/b59c955...BigBlueHat:efb45ba.html" title="Last updated on Jan 4, 2024, 9:04 PM UTC (efb45ba)">Diff</a>