### PR TITLE
Adding SHACL as a credential schema language

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -193,6 +193,23 @@
       }
     },
 
+    "ShaclSchemaCredential": "https://w3.org/2018/credentials#ShaclSchemaCredential",
+
+    "ShaclSchema": {
+      "@id": "https://w3.org/2018/credentials#ShaclSchema",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "shaclSchema": {
+           "@id": "https://w3.org/2018/credentials#shaclSchema",
+           "@type": "@id"
+        }
+      }
+    },
+
     "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
 
     "BitstringStatusList": {


### PR DESCRIPTION
With this PR, I am suggesting to implement the proposal suggested by @bmaier in #1411. Just in the context, for now, not yet in the human-readable specification document.

I am affiliated with W3C member Fraunhofer.
