### PR TITLE
Updated section on semantic interoperability (issues #1217 and #1210)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3079,8 +3079,8 @@ these extension points.
           <h4>Semantic Interoperability</h4>
 
           <p>
-            When defining new terms in an application-specific vocabulary, developers MUST use unique [=URLs=] to identify the terms.
-            Whenever possible, it is RECOMMENDED to re-use terms — and their corresponding URLs — defined by well-known, public vocabularies,
+            When defining new terms in an application-specific vocabulary, developers MUST use globally unambiguous [=URLs=] to identify the terms.
+            Whenever possible, it is RECOMMENDED to re-use terms — and their corresponding URLs — defined by well-known, public vocabularies,
             such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]]. 
             If that is not possible, developers MUST <em>define</em> a new URL for each term. 
             When doing so, general [[LINKED-DATA]] principles must be followed, in particular:

--- a/index.html
+++ b/index.html
@@ -3081,9 +3081,9 @@ these extension points.
           <p>
             When defining new terms in an application-specific vocabulary, developers MUST use globally unambiguous [=URLs=] to identify the terms.
             Whenever possible, it is RECOMMENDED to re-use terms — and their corresponding URLs — defined by well-known, public vocabularies,
-            such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]]. 
-            If that is not possible, developers must <em>define</em> a new URL for each term. 
-            When doing so, the general [[LINKED-DATA]] are expected to be followed, in particular:
+            such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]].
+            If that is not possible, authors MUST <em>define</em> a new URL for each term.
+            When doing so, the general guidelines for [[LINKED-DATA]] are expected to be followed, in particular:
           </p>
 
           <ul>
@@ -3092,48 +3092,48 @@ these extension points.
                 the constraints on the use of each term.
               </li>
               <li>
-                  It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary 
+                  It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary
                   using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]].
               </li>
               <li>
-                  It SHOULD be possible to dereference the URL of a term, resulting in its description and/or formal definition.   
-              </li> 
-          </ul>       
-             
+                  It SHOULD be possible to dereference the URL of a term, resulting in its description and/or formal definition.
+              </li>
+          </ul>
+
           <p>
             Developers SHOULD follow the <a data-cite="?LD-BP#vocabulary-checklist">detailed checklist</a> in
             [[[?LD-BP]]] [[?LD-BP]] when defining a new vocabulary.
           </p>
           <p>
-              Furthermore, a machine-readable description (that is, a 
+              Furthermore, a machine-readable description (that is, a
               <a data-cite="JSON-LD11#dfn-context">JSON-LD Context document</a>) MUST be published at the URL specified
-              in the `@context` [=property=] for the vocabulary. 
+              in the `@context` [=property=] for the vocabulary.
               This context MUST map each term to its corresponding URL, possibly accompanied by further
               constraints like the type of the property value. A human-readable document describing the expected order of values for
-              the `@context` [=property=] is also expected to be published by any implementer seeking interoperability.     
+              the `@context` [=property=] is also expected to be published by any implementer seeking interoperability.
           </p>
 
           <p class="note">
               When processing the <a data-cite="JSON-LD11#dfn-active-context">active context</a> defined by the base JSON-LD Context
-              document <a href="#dfn-context">defined in this specification</a>, compliant JSON-LD-based processors produce an error when a JSON-LD context 
+              document <a href="#dfn-context">defined in this specification</a>, compliant JSON-LD-based processors produce an error when a JSON-LD context
               <em>redefines</em> any term.
               The only way to change the definition of existing terms is to introduce a new term that clears the active context within
-              the scope of that new term. 
-              Authors that are interested in this feature should read about the <a data-cite="JSON-LD11#protected-term-definitions">`@protected`</a> 
+              the scope of that new term.
+              Authors that are interested in this feature should read about the <a data-cite="JSON-LD11#protected-term-definitions">`@protected`</a>
               keyword in the JSON-LD 1.1 specification.
           </p>
 
           <p>
-              The base JSON-LD Context file for this specification also includes an extra feature, using the 
+              The base JSON-LD Context file for this specification also includes an extra feature, using the
               <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> keyword, which ensures
               that any undefined term in a [=verifiable credential=] or a [=verifiable presentation=] is automatically mapped to a
-              URL prefixed with `https://www.w3.org/ns/credentials/issuer-dependent#`. 
+              URL prefixed with `https://www.w3.org/ns/credentials/issuer-dependent#`.
               This is to allow early experimentation with terms during the development phase, without
-              requiring a formal definition in every cycle of that experimentation. 
+              requiring a formal definition in every cycle of that experimentation.
               Note that developers SHOULD NOT use this feature in production; this
-              could lead to name clashes, yielding semantic ambiguities with other applications. 
+              could lead to name clashes, yielding semantic ambiguities with other applications.
               Instead, they SHOULD define all the
-              terms, as described earlier in this section, to achieve proper interoperability.  
+              terms, as described earlier in this section, to achieve proper interoperability.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -3082,8 +3082,8 @@ these extension points.
             When defining new terms in an application-specific vocabulary, developers MUST use globally unambiguous [=URLs=] to identify the terms.
             Whenever possible, it is RECOMMENDED to re-use terms — and their corresponding URLs — defined by well-known, public vocabularies,
             such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]]. 
-            If that is not possible, developers MUST <em>define</em> a new URL for each term. 
-            When doing so, general [[LINKED-DATA]] principles must be followed, in particular:
+            If that is not possible, developers must <em>define</em> a new URL for each term. 
+            When doing so, the general [[LINKED-DATA]] are expected to be followed, in particular:
           </p>
 
           <ul>
@@ -3093,7 +3093,7 @@ these extension points.
               </li>
               <li>
                   It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary 
-                  using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]] (and, if necessary, OWL2 [[?OWL2-OVERVIEW]]).
+                  using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]].
               </li>
               <li>
                   It MUST be possible to dereference the URL of a term, resulting in its description and/or formal definition.   

--- a/index.html
+++ b/index.html
@@ -3078,25 +3078,61 @@ these extension points.
         <section>
           <h4>Semantic Interoperability</h4>
 
+          <p>
+            When defining new terms in an application-dependent vocabulary, developers MUST use unique [=URLs=] to identify the terms.
+            It is RECOMMENDED to re-use, whenever possible, terms—and their corresponding URLs—defined by well-known, public vocabularies,
+            such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]]. 
+            If that is not possible, developers MUST <em>define</em> a new URL for each term. 
+            When doing so, general [[LINKED-DATA]] principles must be followed, in particular:
+          </p>
+
           <ul>
-            <li>
-JSON-LD-based processors MUST produce an error when a JSON-LD context redefines
-any term in the
-<a href="https://www.w3.org/TR/json-ld/#dfn-active-context">active context</a>.
-The only way to change the definition of existing terms is to introduce a new
-term that clears the active context within the scope of that new term. Authors
-that are interested in this feature should read about the
-`@protected` feature in the JSON-LD 1.1 specification.
-            </li>
-          </ul>
+              <li>
+                A human-readable documentation MUST be published, describing the semantics and
+                the constraints on the use of each term.</li>
+              <li>
+                  It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary 
+                  using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]] (and, if necessary, OWL2 [[?OWL2-OVERVIEW]]).
+              </li>
+              <li>
+                  It MUST be possible to dereference the URL of a term, resulting in its description and/or formal definition.   
+              </li> 
+          </ul>       
+             
+          <p>
+            Developers SHOULD follow the <a data-cite="?LD-BP#vocabulary-checklist">detailed checklist</a> in
+            [[[?LD-BP]]] [[?LD-BP]] when defining a new vocabulary.
+          </p>
+          <p>
+              Furthermore, a machine-readable description (that is, a 
+              <a data-cite="JSON-LD11#dfn-context">JSON-LD Context document</a>) MUST be published at the URL specified
+              in the `@context` [=property=] for the vocabulary. 
+              This context MUST map each term to its corresponding URL, possibly accompanied by further
+              constraints like the type of the property value. A human-readable document describing the expected order of values for
+              the `@context` [=property=] is also expected to be published by any implementer seeking interoperability.     
+          </p>
+
+          <p class="note">
+              When processing the <a data-cite="JSON-LD11#dfn-active-context">active context</a> defined by the base JSON-LD Context
+              document <a href="#dfn-context">defined in this specification</a>, compliant JSON-LD-based processors produce an error when a JSON-LD context 
+              <em>redefines</em> any term.
+              The only way to change the definition of existing terms is to introduce a new term that clears the active context within
+              the scope of that new term. 
+              Authors that are interested in this feature should read about the <a data-cite="JSON-LD11#protected-term-definitions">`@protected`</a> 
+              keyword in the JSON-LD 1.1 specification.
+          </p>
 
           <p>
-A human-readable document describing the expected order of values for the
-`@context` [=property=] is expected to be published by any
-implementer seeking interoperability. A machine-readable description
-(that is, a normal JSON-LD Context document) is expected to be published
-at the URL specified in the `@context` [=property=] by
-JSON-LD implementers seeking interoperability.
+              The base JSON-LD Context file for this specification also includes an extra feature, using the 
+              <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> keyword, which ensures
+              that any undefined term in a [=verifiable credential=] or a [=verifiable presentation=] is automatically mapped to a
+              URL prefixed with `https://www.w3.org/ns/credentials/issuer-dependent#`. 
+              The purpose is to allow early experimentation with terms during the development phase, without
+              the necessity to provide a formal definition in every cycle of that experimentation. 
+              However, developers SHOULD NOT use this feature in production; this
+              could lead to name clashes, yielding semantic ambiguities with other applications. 
+              Instead, they SHOULD define all the
+              terms, as described earlier in this section, to achieve proper interoperability.  
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -3096,7 +3096,7 @@ these extension points.
                   using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]].
               </li>
               <li>
-                  It MUST be possible to dereference the URL of a term, resulting in its description and/or formal definition.   
+                  It SHOULD be possible to dereference the URL of a term, resulting in its description and/or formal definition.   
               </li> 
           </ul>       
              

--- a/index.html
+++ b/index.html
@@ -3079,8 +3079,8 @@ these extension points.
           <h4>Semantic Interoperability</h4>
 
           <p>
-            When defining new terms in an application-dependent vocabulary, developers MUST use unique [=URLs=] to identify the terms.
-            It is RECOMMENDED to re-use, whenever possible, terms—and their corresponding URLs—defined by well-known, public vocabularies,
+            When defining new terms in an application-specific vocabulary, developers MUST use unique [=URLs=] to identify the terms.
+            Whenever possible, it is RECOMMENDED to re-use terms — and their corresponding URLs — defined by well-known, public vocabularies,
             such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]]. 
             If that is not possible, developers MUST <em>define</em> a new URL for each term. 
             When doing so, general [[LINKED-DATA]] principles must be followed, in particular:
@@ -3088,7 +3088,7 @@ these extension points.
 
           <ul>
               <li>
-                A human-readable documentation MUST be published, describing the semantics and
+                Human-readable documentation MUST be published, describing the semantics of and
                 the constraints on the use of each term.</li>
               <li>
                   It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary 
@@ -3127,9 +3127,9 @@ these extension points.
               <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> keyword, which ensures
               that any undefined term in a [=verifiable credential=] or a [=verifiable presentation=] is automatically mapped to a
               URL prefixed with `https://www.w3.org/ns/credentials/issuer-dependent#`. 
-              The purpose is to allow early experimentation with terms during the development phase, without
-              the necessity to provide a formal definition in every cycle of that experimentation. 
-              However, developers SHOULD NOT use this feature in production; this
+              This is to allow early experimentation with terms during the development phase, without
+              requiring a formal definition in every cycle of that experimentation. 
+              Note that developers SHOULD NOT use this feature in production; this
               could lead to name clashes, yielding semantic ambiguities with other applications. 
               Instead, they SHOULD define all the
               terms, as described earlier in this section, to achieve proper interoperability.  

--- a/index.html
+++ b/index.html
@@ -3079,61 +3079,69 @@ these extension points.
           <h4>Semantic Interoperability</h4>
 
           <p>
-            When defining new terms in an application-specific vocabulary, developers MUST use globally unambiguous [=URLs=] to identify the terms.
-            Whenever possible, it is RECOMMENDED to re-use terms — and their corresponding URLs — defined by well-known, public vocabularies,
-            such as [[[?DCTERMS]]] [[?DCTERMS]] or [[[?schema-org]]] [[?schema-org]].
-            If that is not possible, authors MUST <em>define</em> a new URL for each term.
-            When doing so, the general guidelines for [[LINKED-DATA]] are expected to be followed, in particular:
+When defining new terms in an application-specific vocabulary, developers MUST
+use globally unambiguous [=URLs=] to identify the terms. Whenever possible, it
+is RECOMMENDED to re-use terms — and their corresponding URLs — defined by
+well-known, public vocabularies, such as [[[?DCTERMS]]] [[?DCTERMS]] or
+[[[?schema-org]]] [[?schema-org]]. If that is not possible, authors MUST
+<em>define</em> a new URL for each term. When doing so, the general guidelines
+for [[LINKED-DATA]] are expected to be followed, in particular:
           </p>
 
           <ul>
               <li>
-                Human-readable documentation MUST be published, describing the semantics of and
-                the constraints on the use of each term.
+Human-readable documentation MUST be published, describing the semantics of and
+the constraints on the use of each term.
               </li>
               <li>
-                  It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary
-                  using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]].
+It is RECOMMENDED to also publish the collection of all new terms as a
+machine-readable vocabulary using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]].
               </li>
               <li>
-                  It SHOULD be possible to dereference the URL of a term, resulting in its description and/or formal definition.
+It SHOULD be possible to dereference the URL of a term, resulting in its
+description and/or formal definition.
               </li>
           </ul>
 
           <p>
-            Developers SHOULD follow the <a data-cite="?LD-BP#vocabulary-checklist">detailed checklist</a> in
-            [[[?LD-BP]]] [[?LD-BP]] when defining a new vocabulary.
+Developers SHOULD follow the <a data-cite="?LD-BP#vocabulary-checklist">detailed
+checklist</a> in [[[?LD-BP]]] [[?LD-BP]] when defining a new vocabulary.
           </p>
           <p>
-              Furthermore, a machine-readable description (that is, a
-              <a data-cite="JSON-LD11#dfn-context">JSON-LD Context document</a>) MUST be published at the URL specified
-              in the `@context` [=property=] for the vocabulary.
-              This context MUST map each term to its corresponding URL, possibly accompanied by further
-              constraints like the type of the property value. A human-readable document describing the expected order of values for
-              the `@context` [=property=] is also expected to be published by any implementer seeking interoperability.
+Furthermore, a machine-readable description (that is, a
+<a data-cite="JSON-LD11#dfn-context">JSON-LD Context document</a>) MUST be
+published at the URL specified in the `@context` [=property=] for the
+vocabulary. This context MUST map each term to its corresponding URL, possibly
+accompanied by further constraints like the type of the property value. A
+human-readable document describing the expected order of values for the
+`@context` [=property=] is also expected to be published by any implementer
+seeking interoperability.
           </p>
 
           <p class="note">
-              When processing the <a data-cite="JSON-LD11#dfn-active-context">active context</a> defined by the base JSON-LD Context
-              document <a href="#dfn-context">defined in this specification</a>, compliant JSON-LD-based processors produce an error when a JSON-LD context
-              <em>redefines</em> any term.
-              The only way to change the definition of existing terms is to introduce a new term that clears the active context within
-              the scope of that new term.
-              Authors that are interested in this feature should read about the <a data-cite="JSON-LD11#protected-term-definitions">`@protected`</a>
-              keyword in the JSON-LD 1.1 specification.
+When processing the <a data-cite="JSON-LD11#dfn-active-context">active
+context</a> defined by the base JSON-LD Context document <a
+href="#dfn-context">defined in this specification</a>, compliant JSON-LD-based
+processors produce an error when a JSON-LD context
+<em>redefines</em> any term. The only way to change the definition of existing
+terms is to introduce a new term that clears the active context within the scope
+of that new term. Authors that are interested in this feature should read about
+the <a data-cite="JSON-LD11#protected-term-definitions">`@protected`</a>
+keyword in the JSON-LD 1.1 specification.
           </p>
 
           <p>
-              The base JSON-LD Context file for this specification also includes an extra feature, using the
-              <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> keyword, which ensures
-              that any undefined term in a [=verifiable credential=] or a [=verifiable presentation=] is automatically mapped to a
-              URL prefixed with `https://www.w3.org/ns/credentials/issuer-dependent#`.
-              This is to allow early experimentation with terms during the development phase, without
-              requiring a formal definition in every cycle of that experimentation.
-              Note that developers SHOULD NOT use this feature in production; this
-              could lead to name clashes, yielding semantic ambiguities with other applications.
-              Instead, they SHOULD define all the
-              terms, as described earlier in this section, to achieve proper interoperability.
+The base JSON-LD Context file for this specification also includes an extra
+feature, using the <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a>
+keyword, which ensures that any undefined term in a [=verifiable credential=] or
+a [=verifiable presentation=] is automatically mapped to a URL prefixed with
+`https://www.w3.org/ns/credentials/issuer-dependent#`. This is to allow early
+experimentation with terms during the development phase, without requiring a
+formal definition in every cycle of that experimentation. Note that developers
+SHOULD NOT use this feature in production; this could lead to name clashes,
+yielding semantic ambiguities with other applications. Instead, they SHOULD
+define all the terms, as described earlier in this section, to achieve proper
+interoperability.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -3089,7 +3089,8 @@ these extension points.
           <ul>
               <li>
                 Human-readable documentation MUST be published, describing the semantics of and
-                the constraints on the use of each term.</li>
+                the constraints on the use of each term.
+              </li>
               <li>
                   It is RECOMMENDED to also publish the collection of all new terms as a machine-readable vocabulary 
                   using [[[?RDF-SCHEMA]]] [[?RDF-SCHEMA]] (and, if necessary, OWL2 [[?OWL2-OVERVIEW]]).


### PR DESCRIPTION
This PR is an attempt to jointly cover issues #1217 and #1210, by a thorough re-write of [§5.3.1](https://www.w3.org/TR/vc-data-model-2.0/#semantic-interoperability) on Semantic Interoperability.

This is a normative section, ie, special attention should be given to the usage of the _MUST_, _SHOULD_, etc, keywords. My general approach was to reduce the _MUST_ to the strict minimum, but reviewers might differ.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1420.html" title="Last updated on Feb 10, 2024, 8:35 PM UTC (3f5c4d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1420/8cc968a...3f5c4d6.html" title="Last updated on Feb 10, 2024, 8:35 PM UTC (3f5c4d6)">Diff</a>