### PR TITLE
Unnecessary "`" signs in i18n examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -6171,8 +6171,8 @@ specific base direction.
         <pre class="example nohighlight" title="Design pattern for natural language strings">
 "myProperty": {
   "@value": "<span class="highlight">The string value</span>",
-  "@language": "`LANGUAGE`"
-  "@direction": "`DIRECTION`"
+  "@language": "LANGUAGE"
+  "@direction": "DIRECTION"
 }
         </pre>
 
@@ -6194,7 +6194,7 @@ book in the English language without specifying a text direction.
         <pre class="example nohighlight" title="Expressing natural language text as English">
 "title": {
   "@value": "<span class="highlight">HTML and CSS: Designing and Creating Websites</span>",
-  "@language": "`en`"
+  "@language": "en"
 }
         </pre>
 
@@ -6206,8 +6206,8 @@ base direction of right-to-left.
         <pre class="example nohighlight" title="Arabic text with a base direction of right-to-left">
 "title": {
   "@value": "<span class="highlight" dir="rtl" lang="ar">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
-  "@language": "`ar`",
-  "@direction": "`rtl`"
+  "@language": "ar",
+  "@direction": "rtl"
 }
         </pre>
 
@@ -6226,12 +6226,12 @@ property:
 "title": [
   {
     "@value": "<span class="highlight">HTML and CSS: Designing and Creating Websites</span>",
-    "@language": "`en`"
+    "@language": "en"
   },
   {
     "@value": "<span class="highlight" dir="rtl" lang="ar">HTML و CSS: تصميم و إنشاء مواقع الويب</span>",
-    "@language": "`ar`",
-    "@direction": "`rtl`"
+    "@language": "ar",
+    "@direction": "rtl"
   }
 ]
         </pre>


### PR DESCRIPTION
The "`" characters in the I18N examples seem to be unnecessary and yield erroneous JSON-LD...

Also reported in #1417.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1422.html" title="Last updated on Jan 30, 2024, 2:22 PM UTC (54e9c5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1422/8cc968a...54e9c5a.html" title="Last updated on Jan 30, 2024, 2:22 PM UTC (54e9c5a)">Diff</a>