### PR TITLE
Fix URL prefixes.

### DIFF
--- a/VCDMExplainer.md
+++ b/VCDMExplainer.md
@@ -147,7 +147,7 @@ Decentralized Identifier (DID) scheme.
 ```
 {
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "https://example.com/examples/v1"
   ],
   "id": "http://example.edu/credentials/1872",
@@ -174,7 +174,7 @@ The following is an example verifiable credential that supports ZKPs.
 ```
 {
   "@context": [
-    "https://w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/v1",
     "ctx:sov:anoncred:v1",
     "ctx:sov:GppHbMLLeKNYRhcQiXh3GjP2Yh",
   ],
@@ -229,7 +229,7 @@ and the payload as well as the final JWS compact serialization (base64 encoded).
   "nonce": "660!6345FSer",
   "vc": {
     "@context": [
-      "https://w3.org/2018/credentials/v1",
+      "https://www.w3.org/2018/credentials/v1",
       "https://example.com/examples/v1"
     ],
     "type": ["VerifiableCredential", "UniversityDegreeCredential"],

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -176,10 +176,10 @@
       }
     },
 
-    "JsonSchemaCredential": "https://w3.org/2018/credentials#JsonSchemaCredential",
+    "JsonSchemaCredential": "https://www.w3.org/2018/credentials#JsonSchemaCredential",
 
     "JsonSchema": {
-      "@id": "https://w3.org/2018/credentials#JsonSchema",
+      "@id": "https://www.w3.org/2018/credentials#JsonSchema",
       "@context": {
         "@protected": true,
 
@@ -187,7 +187,7 @@
         "type": "@type",
 
         "jsonSchema": {
-           "@id": "https://w3.org/2018/credentials#jsonSchema",
+           "@id": "https://www.w3.org/2018/credentials#jsonSchema",
            "@type": "@json"
         }
       }

--- a/vocab/credentials/credentials.html
+++ b/vocab/credentials/credentials.html
@@ -21,7 +21,7 @@ var respecConfig = {
     specStatus:  "base",
     shortName:   "vc-vocab",
     publishDate: "2019-05-26",
-    thisVersion: "https://w3.org/2018/credentials",
+    thisVersion: "https://www.w3.org/2018/credentials",
     doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
     // lcEnd: "3000-01-01",
@@ -88,7 +88,7 @@ var respecConfig = {
       .bold {font-weight: bold;}
     </style>
   </head>
-  <body resource="https://w3.org/2018/credentials#" typeof="owl:Ontology" prefix="cred: https://w3.org/2018/credentials#">
+  <body resource="https://www.w3.org/2018/credentials#" typeof="owl:Ontology" prefix="cred: https://www.w3.org/2018/credentials#">
     <section id="abstract">
       <p>This document describes the
         <span property="dc:title">Verifiable Credentials Vocabulary</span>
@@ -140,7 +140,7 @@ report</a>.
       <p>This specification makes use of the following namespaces:</p>
       <dl class="terms">
         <dt><code>cred</code>:</dt>
-        <dd><code>https://w3.org/2018/credentials#</code></dd>
+        <dd><code>https://www.w3.org/2018/credentials#</code></dd>
         <dt><code>dc</code>:</dt>
         <dd><code>http://purl.org/dc/terms/</code></dd>
         <dt><code>sec</code>:</dt>
@@ -362,7 +362,7 @@ report</a>.
         </dd>
         <dt>cred</dt>
         <dd>
-            https://w3.org/2018/credentials#
+            https://www.w3.org/2018/credentials#
         </dd>
         <dt>credentialSchema</dt>
         <dd>

--- a/vocab/credentials/credentials.html
+++ b/vocab/credentials/credentials.html
@@ -144,7 +144,7 @@ report</a>.
         <dt><code>dc</code>:</dt>
         <dd><code>http://purl.org/dc/terms/</code></dd>
         <dt><code>sec</code>:</dt>
-        <dd><code>https://w3.org/2018/security#</code></dd>
+        <dd><code>https://w3id.org/security#</code></dd>
         <dt><code>xsd</code>:</dt>
         <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
       </dl>

--- a/vocab/credentials/credentials.jsonld
+++ b/vocab/credentials/credentials.jsonld
@@ -7,7 +7,7 @@
     {
       "id": "@id",
       "type": "@type",
-      "cred": "https://w3.org/2018/credentials#",
+      "cred": "https://www.w3.org/2018/credentials#",
       "odrl": "http://www.w3.org/ns/odrl/2/",
       "xsd": "http://www.w3.org/2001/XMLSchema#",
       "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018",
@@ -140,7 +140,7 @@
         "@type": "@id"
       }
     },
-    "@id": "https://w3.org/2018/credentials#",
+    "@id": "https://www.w3.org/2018/credentials#",
     "@type": "owl:Ontology",
     "dc:title": {
       "en": "Verifiable Credentials Vocabulary"

--- a/vocab/credentials/credentials.ttl
+++ b/vocab/credentials/credentials.ttl
@@ -2,7 +2,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix cred: <https://w3.org/2018/credentials#> .
+@prefix cred: <https://www.w3.org/2018/credentials#> .
 @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 

--- a/vocab/credentials/template.html
+++ b/vocab/credentials/template.html
@@ -21,7 +21,7 @@ var respecConfig = {
     specStatus:  "base",
     shortName:   "vc-vocab",
     publishDate: "<%=ont["dc:date"]%>",
-    thisVersion: "https://w3.org/2018/credentials",
+    thisVersion: "https://www.w3.org/2018/credentials",
     doJsonLd:    true,
     //edDraftURI: "https://w3c.github.io/vc-vocab/",
     // lcEnd: "3000-01-01",
@@ -148,7 +148,7 @@ report</a>.
       <p>This specification makes use of the following namespaces:</p>
       <dl class="terms">
         <dt><code>cred</code>:</dt>
-        <dd><code>https://w3.org/2018/credentials#</code></dd>
+        <dd><code>https://www.w3.org/2018/credentials#</code></dd>
         <dt><code>dc</code>:</dt>
         <dd><code>http://purl.org/dc/terms/</code></dd>
         <dt><code>sec</code>:</dt>

--- a/vocab/credentials/template.html
+++ b/vocab/credentials/template.html
@@ -152,7 +152,7 @@ report</a>.
         <dt><code>dc</code>:</dt>
         <dd><code>http://purl.org/dc/terms/</code></dd>
         <dt><code>sec</code>:</dt>
-        <dd><code>https://w3.org/2018/security#</code></dd>
+        <dd><code>https://w3id.org/security#</code></dd>
         <dt><code>xsd</code>:</dt>
         <dd><code>http://www.w3.org/2001/XMLSchema#</code></dd>
       </dl>

--- a/vocab/credentials/vocab.csv
+++ b/vocab/credentials/vocab.csv
@@ -1,6 +1,6 @@
 id,type,label,subClassOf,domain,range,@type,@container,comment
 ,@context,,https://w3id.org/security/v2,,,,,
-cred,prefix,,https://w3.org/2018/credentials#,,,,,
+cred,prefix,,https://www.w3.org/2018/credentials#,,,,,
 odrl,prefix,,http://www.w3.org/ns/odrl/2/,,,,,
 xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,
 ,rdfs:seeAlso,,https://www.w3.org/TR/vc-data-model/,,,,,


### PR DESCRIPTION
- It looks like `JsonSchema` and `JsonSchemaCredentials` ids are typos and should use the same id prefix as everything else.
- `VCDMExplainer.md` is old, but might as well use the correct URLs.
- The `vocab/credentials/*` files are older, and now not used at that endpoint in favor of `.../v2/` files (I think).  Seems worth fixing those files too in case people look at them.  Or perhaps they should be removed?
- The `sec` prefix update appears to be a typo.  Also in old files and appears unused.