### PR TITLE
Update refresh service example to use example from CCG spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3389,12 +3389,9 @@ thereby bypassing the [=holder=].
 The value of the `refreshService` [=property=] MUST be one or more
 refresh services that provides enough information to the recipient's software
 such that the recipient can refresh the [=verifiable credential=]. Each
-`refreshService` value MUST specify its `type` (for
-example, `ManualRefreshService2018`) and its `id`, which
-is the [=URL=] of the service. There is an expectation that machine readable
-information needs to be retrievable from the URL. The precise content of
-each refresh service is determined by the specific `refreshService`
-[=type=] definition.
+`refreshService` value MUST specify its `type`. The precise content of each
+refresh service is determined by the specific `refreshService` [=type=]
+definition.
           </dd>
         </dl>
 
@@ -3408,7 +3405,7 @@ each refresh service is determined by the specific `refreshService`
   "id": "http://university.example/credentials/3732",
   "type": ["VerifiableCredential", "ExampleDegreeCredential"],
   "issuer": "https://university.example/issuers/14",
-  "validFrom": "2010-01-01T19:23:24Z",
+  "validFrom": "2020-01-01T19:23:24Z",
   "credentialSubject": {
     "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
     "degree": {
@@ -3417,16 +3414,18 @@ each refresh service is determined by the specific `refreshService`
     }
   },
   <span class="highlight">"refreshService": {
-    "id": "https://university.example/refresh/3732",
-    "type": "ManualRefreshService2018"
+    "type": "VerifiableCredentialRefreshService2021",
+    "url": "https://university.example/flows/refresh-degree",
+    "validFrom": "2021-09-01T19:23:24Z",
+    "validUntil": "2022-02-01T19:23:24Z"
   }</span>
 }
         </pre>
 
         <p>
-In the example above, the [=issuer=] specifies a manual
-`refreshService` that can be used by directing the [=holder=] or
-the [=verifier=] to `https://university.example/refresh/3732`.
+In the example above, the [=issuer=] specifies an automatic
+`refreshService` that can be used by directing the [=holder=] to
+`https://university.example/flows/refresh-degree`.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -3400,7 +3400,8 @@ definition.
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+    "https://www.w3.org/ns/credentials/examples/v2",
+    "https://w3id.org/vc-refresh-service/v1"
   ],
   "id": "http://university.example/credentials/3732",
   "type": ["VerifiableCredential", "ExampleDegreeCredential"],
@@ -3415,7 +3416,7 @@ definition.
   },
   <span class="highlight">"refreshService": {
     "type": "VerifiableCredentialRefreshService2021",
-    "url": "https://university.example/flows/refresh-degree",
+    "url": "https://university.example/workflows/refresh-degree",
     "validFrom": "2021-09-01T19:23:24Z",
     "validUntil": "2022-02-01T19:23:24Z"
   }</span>
@@ -3425,7 +3426,7 @@ definition.
         <p>
 In the example above, the [=issuer=] specifies an automatic
 `refreshService` that can be used by directing the [=holder=] to
-`https://university.example/flows/refresh-degree`.
+`https://university.example/workflows/refresh-degree`.
         </p>
 
       </section>


### PR DESCRIPTION
This PR attempts to address issue #981 by updating the refresh service example to use the one deployed by TruAge (defined by the[ CCG specification](https://w3c-ccg.github.io/vc-refresh-2021/#verifiablecredentialrefreshservice2021-protocol)).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1435.html" title="Last updated on Feb 18, 2024, 7:28 PM UTC (1dff5c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1435/d42fd22...1dff5c2.html" title="Last updated on Feb 18, 2024, 7:28 PM UTC (1dff5c2)">Diff</a>