### PR TITLE
Update vocabulary and template files

### DIFF
--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -112,6 +112,11 @@
           margin: auto;
           height: auto;
       }
+
+      summary {
+        font-weight: normal !important;
+      }
+
     </style>
   </head>
   <body  typeof="owl:Ontology">
@@ -164,15 +169,22 @@
       </dl>
     </section>
 
+    <section>
+      <h2><code>@context</code> files</h2>
+      <p>The following <code>@context</code> files make use of the terms defined in this specification:</p>
+      <ul id="contexts">
+      </ul>
+    </section>
+
     <section id="term_definitions">
       <h1>Regular terms</h1>
 
-      <section id="class_definitions" class="term_definitions">
-        <h2>Class definitions</h2>
-      </section>
-
       <section id="property_definitions" class="term_definitions">
         <h2>Property definitions</h2>
+      </section>
+
+      <section id="class_definitions" class="term_definitions">
+        <h2>Class definitions</h2>
       </section>
 
       <section id="datatype_definitions" class="term_definitions">
@@ -193,12 +205,12 @@
         normatively specify them.
       </p>
 
-      <section id="reserved_class_definitions" class="term_definitions">
-        <h2>Reserved classes</h2>
-      </section>
-
       <section id="reserved_property_definitions" class="term_definitions">
         <h2>Reserved properties</h2>
+      </section>
+
+      <section id="reserved_class_definitions" class="term_definitions">
+        <h2>Reserved classes</h2>
       </section>
 
       <section id="reserved_datatype_definitions" class="term_definitions">
@@ -217,12 +229,12 @@
         <br>New applications should not use them.
       </p>
 
-      <section id="deprecated_class_definitions" class="term_definitions">
-        <h2>Deprecated classes</h2>
-      </section>
-
       <section id="deprecated_property_definitions" class="term_definitions">
         <h2>Deprecated properties</h2>
+      </section>
+
+      <section id="deprecated_class_definitions" class="term_definitions">
+        <h2>Deprecated classes</h2>
       </section>
 
       <section id="deprecated_property_definitions" class="term_definitions">

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -1,7 +1,7 @@
 vocab:
   - id: cred
     value: https://www.w3.org/2018/credentials#
-
+    context: https://www.w3.org/ns/credentials/v2
 # prefix:
 #   - id: odrl
 #     value: http://www.w3.org/ns/odrl/2/
@@ -18,26 +18,26 @@ ontology:
 
 class:
   - id: CredentialEvidence
-    label: Credential Evidence
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-evidence
     status: reserved
+    context: none
 
   - id: CredentialSchema
-    label: Credential schema
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-schema
+    context: none
 
   - id: CredentialStatus
-    label: Credential status
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-status
+    context: none
 
   - id: ConfidenceMethod
     label: Confidence method
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-confidence-method
     status: reserved
+    context: none
 
   - id: EnvelopedVerifiableCredential
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential
-    label: Enveloped verifiable credential
 
   - id: JsonSchema
     label: JSON schema validator
@@ -53,16 +53,19 @@ class:
     label: Refresh service
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-refresh-service
     status: reserved
+    context: none
 
   - id: RenderMethod
     label: Render method
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-render-method
     status: reserved
+    context: none
 
   - id: TermsOfUse
     label: Terms of use
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-terms-of-use
     status: reserved
+    context: none
 
   - id: VerifiableCredential
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#credentials
@@ -72,6 +75,7 @@ class:
     label: Verifiable credential graph
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#dfn-verifiablecredentialgraph
     comment: Instances of this class are <a href="https://www.w3.org/TR/rdf12-concepts/#section-rdf-graph">RDF Graphs</a> [[RDF12-CONCEPTS]].
+    context: none
 
   - id: VerifiablePresentation
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#presentations
@@ -162,6 +166,7 @@ property:
     defined_by: https://w3c-ccg.github.io/vc-render-method/#the-rendermethod-property
     status: reserved
     range: cred:RenderMethod
+    context: none
 
   - id: relatedResource
     label: Related resource


### PR DESCRIPTION
yml2vocab has now the ability of adding information on designated `@context` files that contain individual terms to the output. This change is adapted to this vocabulary.

No changes on the vocabulary content itself.

As usual, the automatic preview is useless for this case, see https://w3c.github.io/yml2vocab/previews/vcdm/ for the new versions of the generated files.