### PR TITLE
Changed the term `mediaType` to `encodingFormat`

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -75,7 +75,7 @@
       "@type": "https://w3id.org/security#multibase"
     },
 
-    "mediaType": {
+    "encodingFormat": {
       "@id": "https://schema.org/encodingFormat"
     },
 

--- a/index.html
+++ b/index.html
@@ -3246,8 +3246,8 @@ There MUST NOT be more than one object in the `relatedResource` per
         </p>
         <p>
 An object in the `relatedResource` array MAY contain a property named
-`mediaType` that indicates the expected media type for the indicated
-`resource`. If a `mediaType` is included, its value
+`encodingFormat` that indicates the expected media type for the indicated
+`resource`. If a `encodingFormat` is included, its value
 SHOULD:
         </p>
         <ul>
@@ -3330,7 +3330,7 @@ integrity protected image.
     "id": "https://university.example.org/images/58473",
     "digestSRI":
       "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
-    "mediaType": "application/svg+xml",
+    "encodingFormat": "application/svg+xml",
   },
   ...
 }


### PR DESCRIPTION
As agreed on the [WG call](https://www.w3.org/2017/vc/WG/Meetings/Minutes/2024-02-14-vcwg#section2-6) to handle issue #1408.

See also related comment in https://github.com/w3c/vc-data-model/pull/1438#pullrequestreview-1882041837.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1440.html" title="Last updated on Feb 15, 2024, 8:26 AM UTC (5a6e4ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1440/d42fd22...5a6e4ce.html" title="Last updated on Feb 15, 2024, 8:26 AM UTC (5a6e4ce)">Diff</a>