### PR TITLE
Added the "Validate" action to the life cycle details diagram (issue 1331)

### DIFF
--- a/diagrams/ecosystemdetail.drawio
+++ b/diagrams/ecosystemdetail.drawio
@@ -1,0 +1,185 @@
+<mxfile host="Electron" modified="2024-02-15T13:15:16.149Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/23.0.2 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="Vc7W3Dx77ieV5szVuuwu" version="23.0.2" type="device">
+  <diagram name="Page-1" id="6gULVhWcurzz5zKnDaAR">
+    <mxGraphModel dx="1653" dy="997" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Issuer&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="r7VOtmBWi9sTdI5Oyx6i-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="1" vertex="1">
+            <mxGeometry x="210" y="403" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Registry&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-11">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="1" vertex="1">
+            <mxGeometry x="530" y="593" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" target="WkVDoU_EPi6P_C-XghKi-3" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="480" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-13" value="&amp;nbsp;Issue&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;exactly once&lt;/font&gt;&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-12" vertex="1" connectable="0">
+          <mxGeometry x="-0.0577" y="4" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-4" target="WkVDoU_EPi6P_C-XghKi-6" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="480" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-15" value="&amp;nbsp;Present&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-14" vertex="1" connectable="0">
+          <mxGeometry x="0.0141" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-6" target="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="800" y="390" as="sourcePoint" />
+            <mxPoint x="480" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-17" value="&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;might NOT preserve privacy&amp;nbsp;&lt;br&gt;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-16" vertex="1" connectable="0">
+          <mxGeometry x="-0.0144" y="2" relative="1" as="geometry">
+            <mxPoint x="1" y="-9" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="480" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-19" value="&amp;nbsp;Revoke&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-18" vertex="1" connectable="0">
+          <mxGeometry x="-0.0007" y="-2" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-20" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-6" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="480" y="440" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="690" y="450" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-21" value="&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;MIGHT preserve privacy&amp;nbsp;&lt;br&gt;repeatable&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-20" vertex="1" connectable="0">
+          <mxGeometry x="0.0976" y="18" relative="1" as="geometry">
+            <mxPoint x="-1" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-23" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-9" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="480" y="440" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="820" y="550" />
+              <mxPoint x="740" y="600" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-24" value="&amp;nbsp;Verify&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-23" vertex="1" connectable="0">
+          <mxGeometry x="-0.0198" y="-16" relative="1" as="geometry">
+            <mxPoint x="6" y="5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-30" value="" style="shape=lineEllipse;perimeter=ellipsePerimeter;whiteSpace=wrap;html=1;backgroundOutline=1;fontSize=16;rotation=-35;strokeWidth=6;strokeColor=#f41010;fillColor=none;" parent="1" vertex="1">
+          <mxGeometry x="320" y="130" width="32.63" height="32.63" as="geometry" />
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-31" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;targetPerimeterSpacing=-6;dashed=1;" parent="1" source="WkVDoU_EPi6P_C-XghKi-1" target="WkVDoU_EPi6P_C-XghKi-30" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="330" y="269" as="sourcePoint" />
+            <mxPoint x="380" y="219" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-32" value="&amp;nbsp;Delete&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once per Holder&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-31" vertex="1" connectable="0">
+          <mxGeometry x="0.0517" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WeRIz-Bh-gNBJ7O2u5bh-2" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="810" y="388" width="155.25" height="88" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-6">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
+            <mxGeometry width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-7">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
+            <mxGeometry x="10" y="10" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-8">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
+            <mxGeometry x="20" y="20" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-9">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
+            <mxGeometry x="30" y="30" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-28" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" source="WkVDoU_EPi6P_C-XghKi-6" target="WkVDoU_EPi6P_C-XghKi-9" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="60" y="-18" as="sourcePoint" />
+            <mxPoint x="260" y="22" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="110" y="-78" />
+              <mxPoint x="170" y="-98" />
+              <mxPoint x="190" y="-28" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-29" value="&amp;nbsp;Validate&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-28" vertex="1" connectable="0">
+          <mxGeometry x="0.3015" y="-2" relative="1" as="geometry">
+            <mxPoint x="2" y="7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WeRIz-Bh-gNBJ7O2u5bh-3" value="" style="group" parent="1" vertex="1" connectable="0">
+          <mxGeometry x="515" y="200" width="155.25" height="88" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
+            <mxGeometry width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-2">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
+            <mxGeometry x="10" y="10" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
+            <mxGeometry x="20" y="20" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-4">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
+            <mxGeometry x="30" y="30" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-25" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" source="WkVDoU_EPi6P_C-XghKi-1" target="WkVDoU_EPi6P_C-XghKi-4" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="35" y="-40" as="sourcePoint" />
+            <mxPoint x="215" y="10" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="105" y="-90" />
+              <mxPoint x="155" y="-100" />
+              <mxPoint x="195" y="-60" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-27" value="&amp;nbsp;Transfer&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-25" vertex="1" connectable="0">
+          <mxGeometry x="0.335" y="-1" relative="1" as="geometry">
+            <mxPoint x="-17" y="1" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/ecosystemdetail.drawio
+++ b/diagrams/ecosystemdetail.drawio
@@ -1,80 +1,80 @@
-<mxfile host="Electron" modified="2024-02-15T13:15:16.149Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/23.0.2 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="Vc7W3Dx77ieV5szVuuwu" version="23.0.2" type="device">
+<mxfile host="Electron" modified="2024-02-22T10:39:37.771Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/23.0.2 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="z_4pgMkUS2etdIXSzCbY" version="23.0.2" type="device">
   <diagram name="Page-1" id="6gULVhWcurzz5zKnDaAR">
-    <mxGraphModel dx="1653" dy="997" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="1365" dy="1311" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Issuer&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="r7VOtmBWi9sTdI5Oyx6i-1">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="1" vertex="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" parent="1" vertex="1">
             <mxGeometry x="210" y="403" width="125.25" height="58" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Registry&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-11">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="1" vertex="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" parent="1" vertex="1">
             <mxGeometry x="530" y="593" width="125.25" height="58" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=1;entryDx=0;entryDy=0;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" target="WkVDoU_EPi6P_C-XghKi-3" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=0;exitDx=0;exitDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="430" y="490" as="sourcePoint" />
-            <mxPoint x="480" y="440" as="targetPoint" />
+            <mxPoint x="530" y="280" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-13" value="&amp;nbsp;Issue&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;exactly once&lt;/font&gt;&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-12" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-13" value="&amp;nbsp;&lt;b&gt;Issue&lt;/b&gt;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;exactly once&lt;/font&gt;&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-12" vertex="1" connectable="0">
           <mxGeometry x="-0.0577" y="4" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.75;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-4" target="WkVDoU_EPi6P_C-XghKi-6" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="4crVNhUSypmRE79kbWuG-14" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="430" y="490" as="sourcePoint" />
-            <mxPoint x="480" y="440" as="targetPoint" />
+            <mxPoint x="670.25" y="273.5" as="sourcePoint" />
+            <mxPoint x="810" y="402.5" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-15" value="&amp;nbsp;Present&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-14" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-15" value="&amp;nbsp;&lt;b&gt;Present&lt;/b&gt;&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-14" vertex="1" connectable="0">
           <mxGeometry x="0.0141" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-6" target="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" target="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="800" y="390" as="sourcePoint" />
+            <mxPoint x="810" y="417" as="sourcePoint" />
             <mxPoint x="480" y="440" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-17" value="&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;might NOT preserve privacy&amp;nbsp;&lt;br&gt;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-16" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-17" value="&lt;b&gt;&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;might NOT preserve privacy, repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-16" vertex="1" connectable="0">
           <mxGeometry x="-0.0144" y="2" relative="1" as="geometry">
-            <mxPoint x="1" y="-9" as="offset" />
+            <mxPoint x="1" y="-5" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;labelBackgroundColor=none;fontColor=default;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="430" y="490" as="sourcePoint" />
             <mxPoint x="480" y="440" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-19" value="&amp;nbsp;Revoke&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-18" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-19" value="&lt;b&gt;&amp;nbsp;Revoke&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-18" vertex="1" connectable="0">
           <mxGeometry x="-0.0007" y="-2" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-20" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-6" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-20" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="810" y="431.5" as="sourcePoint" />
             <mxPoint x="480" y="440" as="targetPoint" />
             <Array as="points">
               <mxPoint x="690" y="450" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-21" value="&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;MIGHT preserve privacy&amp;nbsp;&lt;br&gt;repeatable&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-20" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-21" value="&lt;b&gt;&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;MIGHT preserve privacy, repeatable&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-20" vertex="1" connectable="0">
           <mxGeometry x="0.0976" y="18" relative="1" as="geometry">
             <mxPoint x="-1" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-23" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="WkVDoU_EPi6P_C-XghKi-9" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-23" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="4crVNhUSypmRE79kbWuG-3" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="430" y="490" as="sourcePoint" />
+            <mxPoint x="871.3125" y="476" as="sourcePoint" />
             <mxPoint x="480" y="440" as="targetPoint" />
             <Array as="points">
               <mxPoint x="820" y="550" />
@@ -82,101 +82,161 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-24" value="&amp;nbsp;Verify&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-23" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-24" value="&lt;b&gt;&amp;nbsp;Verify&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-23" vertex="1" connectable="0">
           <mxGeometry x="-0.0198" y="-16" relative="1" as="geometry">
-            <mxPoint x="6" y="5" as="offset" />
+            <mxPoint x="12" y="6" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-30" value="" style="shape=lineEllipse;perimeter=ellipsePerimeter;whiteSpace=wrap;html=1;backgroundOutline=1;fontSize=16;rotation=-35;strokeWidth=6;strokeColor=#f41010;fillColor=none;" parent="1" vertex="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-30" value="" style="shape=lineEllipse;perimeter=ellipsePerimeter;whiteSpace=wrap;html=1;backgroundOutline=1;fontSize=16;rotation=-35;strokeWidth=6;fillColor=none;labelBackgroundColor=none;" parent="1" vertex="1">
           <mxGeometry x="320" y="130" width="32.63" height="32.63" as="geometry" />
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-31" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;targetPerimeterSpacing=-6;dashed=1;" parent="1" source="WkVDoU_EPi6P_C-XghKi-1" target="WkVDoU_EPi6P_C-XghKi-30" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-31" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;targetPerimeterSpacing=-6;dashed=1;labelBackgroundColor=none;fontColor=default;" parent="1" target="WkVDoU_EPi6P_C-XghKi-30" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="330" y="269" as="sourcePoint" />
+            <mxPoint x="515" y="229" as="sourcePoint" />
             <mxPoint x="380" y="219" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-32" value="&amp;nbsp;Delete&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once per Holder&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-31" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-32" value="&amp;nbsp;&lt;b&gt;Delete&lt;/b&gt;&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once per Holder&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-31" vertex="1" connectable="0">
           <mxGeometry x="0.0517" y="1" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WeRIz-Bh-gNBJ7O2u5bh-2" value="" style="group" parent="1" vertex="1" connectable="0">
-          <mxGeometry x="810" y="388" width="155.25" height="88" as="geometry" />
-        </mxCell>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-6">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
-            <mxGeometry width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-7">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
-            <mxGeometry x="10" y="10" width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-8">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
-            <mxGeometry x="20" y="20" width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-9">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" vertex="1">
-            <mxGeometry x="30" y="30" width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-28" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="WeRIz-Bh-gNBJ7O2u5bh-2" source="WkVDoU_EPi6P_C-XghKi-6" target="WkVDoU_EPi6P_C-XghKi-9" edge="1">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-25" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=1;entryY=0;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="60" y="-18" as="sourcePoint" />
-            <mxPoint x="260" y="22" as="targetPoint" />
+            <mxPoint x="590" y="208" as="sourcePoint" />
+            <mxPoint x="670.25" y="228" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="110" y="-78" />
-              <mxPoint x="170" y="-98" />
-              <mxPoint x="190" y="-28" />
+              <mxPoint x="620" y="108" />
+              <mxPoint x="670" y="98" />
+              <mxPoint x="710" y="138" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-29" value="&amp;nbsp;Validate&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-28" vertex="1" connectable="0">
-          <mxGeometry x="0.3015" y="-2" relative="1" as="geometry">
-            <mxPoint x="2" y="7" as="offset" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="WeRIz-Bh-gNBJ7O2u5bh-3" value="" style="group" parent="1" vertex="1" connectable="0">
-          <mxGeometry x="515" y="200" width="155.25" height="88" as="geometry" />
-        </mxCell>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-1">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
-            <mxGeometry width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-2">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
-            <mxGeometry x="10" y="10" width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-3">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
-            <mxGeometry x="20" y="20" width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="WkVDoU_EPi6P_C-XghKi-4">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=#09555B;strokeColor=#FFFFFF;fontColor=#EEEEEE;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" vertex="1">
-            <mxGeometry x="30" y="30" width="125.25" height="58" as="geometry" />
-          </mxCell>
-        </UserObject>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-25" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0;entryDx=0;entryDy=0;" parent="WeRIz-Bh-gNBJ7O2u5bh-3" source="WkVDoU_EPi6P_C-XghKi-1" target="WkVDoU_EPi6P_C-XghKi-4" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="35" y="-40" as="sourcePoint" />
-            <mxPoint x="215" y="10" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="105" y="-90" />
-              <mxPoint x="155" y="-100" />
-              <mxPoint x="195" y="-60" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-27" value="&amp;nbsp;Transfer&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="WkVDoU_EPi6P_C-XghKi-25" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-27" value="&amp;nbsp;&lt;b&gt;Transfer&lt;/b&gt;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-25" vertex="1" connectable="0">
           <mxGeometry x="0.335" y="-1" relative="1" as="geometry">
-            <mxPoint x="-17" y="1" as="offset" />
+            <mxPoint x="-13" y="1" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4crVNhUSypmRE79kbWuG-12" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="810" y="390" width="156.25" height="88" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="4crVNhUSypmRE79kbWuG-3">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" vertex="1" parent="4crVNhUSypmRE79kbWuG-12">
+            <mxGeometry x="31" y="30" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="4crVNhUSypmRE79kbWuG-9" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;exitX=-0.008;exitY=0.845;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="4crVNhUSypmRE79kbWuG-12" source="4crVNhUSypmRE79kbWuG-3">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="30" y="79" as="sourcePoint" />
+            <mxPoint x="150" y="30" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="20" y="80" />
+              <mxPoint x="20" y="69" />
+              <mxPoint x="20" y="40" />
+              <mxPoint x="20" y="20" />
+              <mxPoint x="30" y="20" />
+              <mxPoint x="140" y="20" />
+              <mxPoint x="150" y="20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4crVNhUSypmRE79kbWuG-10" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-12">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="69" as="sourcePoint" />
+            <mxPoint x="140" y="20" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="10" y="70" />
+              <mxPoint x="10" y="59" />
+              <mxPoint x="10" y="30" />
+              <mxPoint x="10" y="10" />
+              <mxPoint x="20" y="10" />
+              <mxPoint x="130" y="10" />
+              <mxPoint x="140" y="10" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4crVNhUSypmRE79kbWuG-11" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-12">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="10" y="59" as="sourcePoint" />
+            <mxPoint x="130" y="10" as="targetPoint" />
+            <Array as="points">
+              <mxPoint y="60" />
+              <mxPoint y="49" />
+              <mxPoint y="20" />
+              <mxPoint />
+              <mxPoint x="10" />
+              <mxPoint x="120" />
+              <mxPoint x="130" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4crVNhUSypmRE79kbWuG-13" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="520" y="210" width="156.25" height="88" as="geometry" />
+        </mxCell>
+        <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="4crVNhUSypmRE79kbWuG-14">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" vertex="1" parent="4crVNhUSypmRE79kbWuG-13">
+            <mxGeometry x="31" y="30" width="125.25" height="58" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="4crVNhUSypmRE79kbWuG-15" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;exitX=-0.008;exitY=0.845;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="4crVNhUSypmRE79kbWuG-13" source="4crVNhUSypmRE79kbWuG-14">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="30" y="79" as="sourcePoint" />
+            <mxPoint x="150" y="30" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="20" y="80" />
+              <mxPoint x="20" y="69" />
+              <mxPoint x="20" y="40" />
+              <mxPoint x="20" y="20" />
+              <mxPoint x="30" y="20" />
+              <mxPoint x="140" y="20" />
+              <mxPoint x="150" y="20" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4crVNhUSypmRE79kbWuG-16" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-13">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="20" y="69" as="sourcePoint" />
+            <mxPoint x="140" y="20" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="10" y="70" />
+              <mxPoint x="10" y="59" />
+              <mxPoint x="10" y="30" />
+              <mxPoint x="10" y="10" />
+              <mxPoint x="20" y="10" />
+              <mxPoint x="130" y="10" />
+              <mxPoint x="140" y="10" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4crVNhUSypmRE79kbWuG-17" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-13">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="10" y="59" as="sourcePoint" />
+            <mxPoint x="130" y="10" as="targetPoint" />
+            <Array as="points">
+              <mxPoint y="60" />
+              <mxPoint y="49" />
+              <mxPoint y="20" />
+              <mxPoint />
+              <mxPoint x="10" />
+              <mxPoint x="120" />
+              <mxPoint x="130" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-28" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=1;entryY=0;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="880" y="388" as="sourcePoint" />
+            <mxPoint x="965.25" y="418" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="920" y="310" />
+              <mxPoint x="980" y="290" />
+              <mxPoint x="1000" y="360" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-29" value="&lt;b&gt;&amp;nbsp;Verify and Validate&amp;nbsp;&lt;br&gt;&lt;/b&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-28" vertex="1" connectable="0">
+          <mxGeometry x="0.3015" y="-2" relative="1" as="geometry">
+            <mxPoint x="8" y="18" as="offset" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/diagrams/ecosystemdetail.svg
+++ b/diagrams/ecosystemdetail.svg
@@ -1,81 +1,340 @@
-<?xml version="1.0" standalone="yes"?>
-<svg version="1.1" viewBox="0 0 960 720" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<defs>
-		<marker id="arrow" viewBox="0 0 6 4" refX="1" refY="2" fill="#000"
-      markerWidth="6" markerHeight="4" orient="auto">
-    <path d="M0 0v4l6 -2z" />
-    </marker>
-		<symbol id="gone" viewBox="-40 -40 960 720">
-			<g transform="rotate(-45)">
-				<circle r="25" fill="red"/>
-				<circle r="15" fill="#fff"/>
-				<rect x="-15" y="-5" width="30" height="10" fill="red"/>
-				<rect class="none" x="-17" y="-4.5" width="34" height="9" fill="red"/>
-			</g>
-    </symbol>
-		<style><![CDATA[
-			path.link {stroke:#000;stroke-width:4;marker-end: url(#arrow)}
-			rect, circle {stroke:#000;stroke-width:1px}
-			rect.none {stroke:none}
-			text {fill:#000;font-size:14px;font-family:sans-serif}
-			text[aria-level ='1']{font-size:2em;font-weight:bold;font-style:italic}
-			text[aria-level = '2']{font-size:1.5em;font-weight:bold}
-			#background {fill:#fff;width:100%;height:100%;stroke:none}
-		]]></style>
-	</defs>
-<rect id="background"/>
-
-<text x="225" y="35" role="heading" aria-level="1">Life of a single Verifiable Credential</text>
-
-<rect fill="#dfd" x="20" y="300" width="115" height="85"/>
-<text role="heading" aria-level="2" x="40" y="345">Issuer</text>
-
-<path class="link" d="m140 320l245 -60"/>
-<text x="200" y="270" role="heading" aria-level="2">Issue</text>
-<text x="190" y="285">exactly once</text>
-
-<path class="link" d="m70 390l320 210" stroke-dasharray="15 3"/>
-<text x="140" y="510" role="heading" aria-level="2">Revoke</text>
-<text x="150" y="525">up to once</text>
-
-<rect fill="#def" x="450" y="220" width="115" height="85"/>
-<rect fill="#def" x="430" y="200" width="115" height="85"/>
-<rect fill="#def" x="410" y="180" width="115" height="85"/>
-<text role="heading" aria-level="2" x="425" y="240">Holders</text>
-
-<path class="link" d="m405 210l-175 -80" stroke-dasharray="15 3"/>
-<text x="270" y="120" role="heading" aria-level="2">Delete</text>
-<text x="250" y="135">up to once per Holder</text>
-<use href="#gone" x="140" y="80"/>
-
-<path class="link" d="m430 175c100 -100 120 -100 125 10"/>
-<text x="550" y="120" role="heading" aria-level="2">Transfer</text>
-<text x="560" y="135">repeatable</text>
-
-<path class="link" d="m550 215c30 0 30 5 145 40"/>
-<text x="610" y="210" role="heading" aria-level="2">Present</text>
-<text x="620" y="225">repeatable</text>
-
-<rect fill="#fe9" x="755" y="285" width="115" height="85"/>
-<rect fill="#fe9" x="735" y="265" width="115" height="85"/>
-<rect fill="#fe9" x="715" y="245" width="115" height="85"/>
-<text role="heading" aria-level="2"  x="720" y="300">Verifiers</text>
-
-<path class="link" d="m855 275c30 -10 45 -40 50 100c-10 200 -200 220 -335 225"/>
-<text x="740" y="620" role="heading" aria-level="2">Verify</text>
-<text x="740" y="635">repeatable</text>
-
-<path class="link" d="m710 318l-550 20"/>
-<text x="390" y="370" role="heading" aria-level="2">Check Status</text>
-<text x="380" y="385" font-weight="bold">might NOT preserve privacy</text>
-<text x="430" y="400">repeatable</text>
-
-<path class="link" d="m730 345c-200 30 -240 140 -250 195"/>
-<text x="540" y="480" role="heading" aria-level="2">Check Status</text>
-<text x="540" y="495" font-weight="bold">MIGHT preserve privacy</text>
-<text x="580" y="510">repeatable</text>
-
-<rect fill="#fcc" x="410" y="570" width="135" height="85"/>
-<text role="heading" aria-level="2" x="430" y="620">Registry</text>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 855 588">
+    <rect width="125.25" height="58" x="20" y="319" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:348px;margin-left:21px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Issuer
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="83" y="353" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Issuer</text>
+    </switch>
+    <rect width="125.25" height="58" x="340" y="509" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:538px;margin-left:341px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Registry
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="403" y="543" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Registry</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m113.94 319 224.14-121.26" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m344.02 194.53-5.78 8.24-.16-5.03-4.12-2.88Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:257px;margin-left:222px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Issue
+                        <br/>
+                        <font style="font-size:12px">
+                            exactly once
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="222" y="262" font-family="Helvetica" font-size="16" text-anchor="middle">Issue...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m480.25 189.5 133.97 123.66" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m619.18 317.74-9.67-2.8 4.71-1.78 1.4-4.83Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:255px;margin-left:551px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Present
+                        <br/>
+                        <font style="font-size:12px">
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="551" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">Present...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m620 333-466.89 14.75" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m146.37 347.96 8.85-4.78-2.11 4.57 2.4 4.43Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:334px;margin-left:388px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Check Status
+                        <br/>
+                        <font style="font-size:12px">
+                            might NOT preserve privacy
+                            <br/>
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="388" y="339" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="m113.94 377 219.65 156.44" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m339.09 537.35-9.94-1.55 4.44-2.36.78-4.97Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:460px;margin-left:226px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Revoke
+                        <br/>
+                        <font style="font-size:12px">
+                            up to once
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="226" y="465" font-family="Helvetica" font-size="16" text-anchor="middle">Revoke...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M620 347.5q-120 18.5-212.95 155" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m403.25 508.08 1.35-9.98 2.45 4.4 4.99.67Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:410px;margin-left:492px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Check Status
+                        <br/>
+                        <font style="font-size:12px">
+                            MIGHT preserve privacy
+                            <br/>
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="492" y="415" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M681.31 392Q630 466 590 491t-117.13 45.02" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m466.33 537.72 7.58-6.62-1.04 4.92 3.3 3.79Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:481px;margin-left:592px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Verify
+                        <br/>
+                        <font style="font-size:12px">
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="592" y="485" font-family="Helvetica" font-size="16" text-anchor="middle">Verify...</text>
+    </switch>
+    <circle cx="146.32" cy="62.32" r="16.315" fill="none" stroke="#f41010" stroke-width="6" pointer-events="all" transform="rotate(-35 146.32 62.32)"/>
+    <path fill="none" stroke="#f41010" stroke-miterlimit="10" stroke-width="6" d="m132.951 71.68 26.73-18.715" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M325 145 169.44 68.62" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m163.39 65.64 10.06-.07-4.01 3.05.04 5.03Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:105px;margin-left:240px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Delete
+                        <br/>
+                        <font style="font-size:12px">
+                            up to once per Holder
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="240" y="109" font-family="Helvetica" font-size="16" text-anchor="middle">Delete...</text>
+    </switch>
+    <rect width="125.25" height="58" x="620" y="304" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:333px;margin-left:621px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Verifiers
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="683" y="338" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
+    </switch>
+    <rect width="125.25" height="58" x="630" y="314" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:343px;margin-left:631px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Verifiers
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="693" y="348" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
+    </switch>
+    <rect width="125.25" height="58" x="640" y="324" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:353px;margin-left:641px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Verifiers
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="703" y="358" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
+    </switch>
+    <rect width="125.25" height="58" x="650" y="334" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:363px;margin-left:651px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Verifiers
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="713" y="368" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M682.63 304Q730 226 760 216q30-10 40 25t-20.71 86.25" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m775.82 333.04.77-10.03 2.7 4.24 5.02.38Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:250px;margin-left:801px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Validate
+                        <br/>
+                        <font style="font-size:12px">
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="801" y="255" font-family="Helvetica" font-size="16" text-anchor="middle">Validate...</text>
+    </switch>
+    <rect width="125.25" height="58" x="325" y="116" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:145px;margin-left:326px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Holders
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="388" y="150" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
+    </switch>
+    <rect width="125.25" height="58" x="335" y="126" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:155px;margin-left:336px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Holders
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="398" y="160" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
+    </switch>
+    <rect width="125.25" height="58" x="345" y="136" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:165px;margin-left:346px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Holders
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="408" y="170" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
+    </switch>
+    <rect width="125.25" height="58" x="355" y="146" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:175px;margin-left:356px">
+                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Holders
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="418" y="180" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M387.63 116Q430 26 455 21q25-5 45 15t-16.57 102.8" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m480.7 144.98-.48-10.05 3.21 3.87 5.02-.24Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:501px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Transfer
+                        <br/>
+                        <font style="font-size:12px">
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="501" y="61" font-family="Helvetica" font-size="16" text-anchor="middle">Transfer...</text>
+    </switch>
 </svg>

--- a/diagrams/ecosystemdetail.svg
+++ b/diagrams/ecosystemdetail.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 855 588">
-    <rect width="125.25" height="58" x="20" y="319" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 903 590">
+    <rect width="125.25" height="58" x="20" y="321" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:348px;margin-left:21px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:350px;margin-left:21px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <font>
                             <span style="font-size:20px">
                                 Issuer
@@ -14,14 +14,14 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="83" y="353" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Issuer</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="83" y="355" font-family="Helvetica" font-size="16" text-anchor="middle">Issuer</text>
     </switch>
-    <rect width="125.25" height="58" x="340" y="509" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
+    <rect width="125.25" height="58" x="340" y="511" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:538px;margin-left:341px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:540px;margin-left:341px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <font>
                             <span style="font-size:20px">
                                 Registry
@@ -31,16 +31,18 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="403" y="543" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Registry</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="403" y="545" font-family="Helvetica" font-size="16" text-anchor="middle">Registry</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m113.94 319 224.14-121.26" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m344.02 194.53-5.78 8.24-.16-5.03-4.12-2.88Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m113.94 321 219.15-119.24" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m339.02 198.53-5.76 8.26-.17-5.03-4.13-2.88Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:257px;margin-left:222px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:260px;margin-left:219px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Issue
+                        <b>
+                            Issue
+                        </b>
                         <br/>
                         <font style="font-size:12px">
                             exactly once
@@ -49,16 +51,18 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="222" y="262" font-family="Helvetica" font-size="16" text-anchor="middle">Issue...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="219" y="265" font-family="Helvetica" font-size="16" text-anchor="middle">Issue...</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m480.25 189.5 133.97 123.66" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m619.18 317.74-9.67-2.8 4.71-1.78 1.4-4.83Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m486.25 187 128.18 127.94" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m619.21 319.71-9.55-3.17 4.77-1.6 1.59-4.77Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:255px;margin-left:551px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:255px;margin-left:555px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Present
+                        <b>
+                            Present
+                        </b>
                         <br/>
                         <font style="font-size:12px">
                             repeatable
@@ -67,37 +71,39 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="551" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">Present...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="555" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">Present...</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m620 333-466.89 14.75" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m146.37 347.96 8.85-4.78-2.11 4.57 2.4 4.43Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m620 335-466.89 14.75" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m146.37 349.96 8.85-4.78-2.11 4.57 2.4 4.43Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:334px;margin-left:388px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:340px;margin-left:388px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Check Status
-                        <br/>
-                        <font style="font-size:12px">
-                            might NOT preserve privacy
+                        <b>
+                            Check Status
                             <br/>
-                            repeatable
+                        </b>
+                        <font style="font-size:12px">
+                            might NOT preserve privacy, repeatable
                         </font>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="388" y="339" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="388" y="345" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="m113.94 377 219.65 156.44" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m339.09 537.35-9.94-1.55 4.44-2.36.78-4.97Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="m113.94 379 219.65 156.44" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m339.09 539.35-9.94-1.55 4.44-2.36.78-4.97Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:460px;margin-left:226px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:462px;margin-left:226px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Revoke
-                        <br/>
+                        <b>
+                            Revoke
+                            <br/>
+                        </b>
                         <font style="font-size:12px">
                             up to once
                         </font>
@@ -105,37 +111,39 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="226" y="465" font-family="Helvetica" font-size="16" text-anchor="middle">Revoke...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="226" y="467" font-family="Helvetica" font-size="16" text-anchor="middle">Revoke...</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M620 347.5q-120 18.5-212.95 155" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m403.25 508.08 1.35-9.98 2.45 4.4 4.99.67Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M620 349.5q-120 18.5-212.95 155" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m403.25 510.08 1.35-9.98 2.45 4.4 4.99.67Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:410px;margin-left:492px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:412px;margin-left:492px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Check Status
-                        <br/>
-                        <font style="font-size:12px">
-                            MIGHT preserve privacy
+                        <b>
+                            Check Status
                             <br/>
-                            repeatable
+                        </b>
+                        <font style="font-size:12px">
+                            MIGHT preserve privacy, repeatable
                         </font>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="492" y="415" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="492" y="417" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M681.31 392Q630 466 590 491t-117.13 45.02" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m466.33 537.72 7.58-6.62-1.04 4.92 3.3 3.79Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M682.31 396Q630 468 590 493t-117.13 45.02" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m466.33 539.72 7.58-6.62-1.04 4.92 3.3 3.79Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:481px;margin-left:592px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:484px;margin-left:597px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Verify
-                        <br/>
+                        <b>
+                            Verify
+                            <br/>
+                        </b>
                         <font style="font-size:12px">
                             repeatable
                         </font>
@@ -143,18 +151,20 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="592" y="485" font-family="Helvetica" font-size="16" text-anchor="middle">Verify...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="597" y="489" font-family="Helvetica" font-size="16" text-anchor="middle">Verify...</text>
     </switch>
-    <circle cx="146.32" cy="62.32" r="16.315" fill="none" stroke="#f41010" stroke-width="6" pointer-events="all" transform="rotate(-35 146.32 62.32)"/>
-    <path fill="none" stroke="#f41010" stroke-miterlimit="10" stroke-width="6" d="m132.951 71.68 26.73-18.715" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M325 145 169.44 68.62" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m163.39 65.64 10.06-.07-4.01 3.05.04 5.03Z" pointer-events="all"/>
+    <circle cx="146.32" cy="64.32" r="16.315" fill="none" stroke="#000" stroke-width="6" pointer-events="all" transform="rotate(-35 146.32 64.32)"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="6" d="m132.951 73.68 26.73-18.715" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M325 147 169.44 70.62" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m163.39 67.64 10.06-.07-4.01 3.05.04 5.03Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:105px;margin-left:240px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:107px;margin-left:240px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Delete
+                        <b>
+                            Delete
+                        </b>
                         <br/>
                         <font style="font-size:12px">
                             up to once per Holder
@@ -163,170 +173,18 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="240" y="109" font-family="Helvetica" font-size="16" text-anchor="middle">Delete...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="240" y="111" font-family="Helvetica" font-size="16" text-anchor="middle">Delete...</text>
     </switch>
-    <rect width="125.25" height="58" x="620" y="304" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:333px;margin-left:621px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Verifiers
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="683" y="338" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
-    </switch>
-    <rect width="125.25" height="58" x="630" y="314" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:343px;margin-left:631px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Verifiers
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="693" y="348" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
-    </switch>
-    <rect width="125.25" height="58" x="640" y="324" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:353px;margin-left:641px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Verifiers
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="703" y="358" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
-    </switch>
-    <rect width="125.25" height="58" x="650" y="334" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:363px;margin-left:651px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Verifiers
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="713" y="368" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M682.63 304Q730 226 760 216q30-10 40 25t-20.71 86.25" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m775.82 333.04.77-10.03 2.7 4.24 5.02.38Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:250px;margin-left:801px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Validate
-                        <br/>
-                        <font style="font-size:12px">
-                            repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="801" y="255" font-family="Helvetica" font-size="16" text-anchor="middle">Validate...</text>
-    </switch>
-    <rect width="125.25" height="58" x="325" y="116" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:145px;margin-left:326px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Holders
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="388" y="150" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
-    </switch>
-    <rect width="125.25" height="58" x="335" y="126" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:155px;margin-left:336px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Holders
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="398" y="160" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
-    </switch>
-    <rect width="125.25" height="58" x="345" y="136" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:165px;margin-left:346px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Holders
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="408" y="170" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
-    </switch>
-    <rect width="125.25" height="58" x="355" y="146" fill="#09555b" stroke="#fff" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:175px;margin-left:356px">
-                <div data-drawio-colors="color: #EEEEEE;" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#eee;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Holders
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="418" y="180" fill="#EEE" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M387.63 116Q430 26 455 21q25-5 45 15t-16.57 102.8" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M400 126q30-100 55-105t45 15q20 20-16.57 102.8" pointer-events="stroke"/>
     <path stroke="#000" stroke-miterlimit="10" d="m480.7 144.98-.48-10.05 3.21 3.87 5.02-.24Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:501px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:55px;margin-left:503px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Transfer
+                        <b>
+                            Transfer
+                        </b>
                         <br/>
                         <font style="font-size:12px">
                             repeatable
@@ -335,6 +193,65 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="501" y="61" font-family="Helvetica" font-size="16" text-anchor="middle">Transfer...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="503" y="59" font-family="Helvetica" font-size="16" text-anchor="middle">Transfer...</text>
+    </switch>
+    <rect width="125.25" height="58" x="651" y="338" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:367px;margin-left:652px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Verifiers
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="714" y="372" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M650 387.01q-10 .99-10-4.51V338q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M640 377q-10 1-10-4.5V328q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M630 367q-10 1-10-4.5V318q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
+    <rect width="125.25" height="58" x="361" y="158" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:187px;margin-left:362px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font>
+                            <span style="font-size:20px">
+                                Holders
+                            </span>
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="424" y="192" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M360 207.01q-10 .99-10-4.51V158q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M350 197q-10 1-10-4.5V148q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M340 187q-10 1-10-4.5V138q0-10 5-10h120q5 0 5 10M690 306q40-78 70-88t40 25q10 35-20.71 86.25" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" d="m775.82 335.04.77-10.03 2.7 4.24 5.02.38Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:265px;margin-left:807px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <b>
+                            Verify and Validate
+                            <br/>
+                        </b>
+                        <font style="font-size:12px">
+                            repeatable
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="807" y="269" font-family="Helvetica" font-size="16" text-anchor="middle">Verify and Validate...</text>
     </switch>
 </svg>

--- a/diagrams/vc-graph.drawio
+++ b/diagrams/vc-graph.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2023-10-24T09:12:50.957Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.0.3 Chrome/114.0.5735.289 Electron/25.8.4 Safari/537.36" etag="esilLBypGqtj8wdToedX" version="22.0.3" type="device">
+<mxfile host="Electron" modified="2024-02-22T10:05:47.306Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/23.0.2 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="ANofyeOICTgo2w3kkl61" version="23.0.2" type="device">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="2372" dy="2129" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="2534" dy="2138" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />

--- a/index.html
+++ b/index.html
@@ -2754,9 +2754,10 @@ how the ecosystem is envisaged to operate.
          src="diagrams/ecosystemdetail.svg" alt="diagram showing how
          credentials flow from issuer to holder, and optionally
          from one holder to another; and how
-         presentations flow from holder to verifier, where
-         all parties can use information from a logical
-         verifiable data registry">
+         presentations flow from holder to verifier, 
+         optionally from one verifier to another through verification and validation.
+         All parties can use information from a logical
+         verifiable data registry. Holder may also delete credential.">
           <figcaption style="text-align: center;">
             Life of a single Verifiable Credential: the roles and information flows for this specification.
           </figcaption>

--- a/index.html
+++ b/index.html
@@ -2759,7 +2759,7 @@ how the ecosystem is envisaged to operate.
          All parties can use information from a logical
          verifiable data registry. Holder may also delete credential.">
           <figcaption style="text-align: center;">
-            Life of a single Verifiable Credential: the roles and information flows for this specification.
+            Lifecycle of a single Verifiable Credential: the roles and information flows for this specification.
           </figcaption>
         </figure>
 

--- a/index.html
+++ b/index.html
@@ -2758,7 +2758,7 @@ how the ecosystem is envisaged to operate.
          all parties can use information from a logical
          verifiable data registry">
           <figcaption style="text-align: center;">
-            The roles and information flows for this specification.
+            Life of a single Verifiable Credential: the roles and information flows for this specification.
           </figcaption>
         </figure>
 


### PR DESCRIPTION
This is to handle #1331.

The usual preview is useless in this case; to review, you should look at the SVG file directly, see [svg link](https://raw.githack.com/w3c/vc-data-model/validation-on-diagram/diagrams/ecosystemdetail.svg).

- I completely re-did the diagram from scratch, because I do not know where the old source is (and I did not want to mess around with the SVG file itself). Also, the old diagram did not work with dark mode; hopefully this does (I tested it with Brave with Dark Mode switched on, and it looks o.k. there. @dlongley, you should have a look). This is also the reason why the diagram is less "colorful".
- Also, I removed the big title ("Life of a single Verifiable Credential") and I put this into the caption instead.

I am not sure what the 'semantics' of dotted lines is, so the new loop on Validate is just a continuous line.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1441.html" title="Last updated on Mar 3, 2024, 7:44 PM UTC (5fc78ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1441/d42fd22...5fc78ef.html" title="Last updated on Mar 3, 2024, 7:44 PM UTC (5fc78ef)">Diff</a>