### PR TITLE
Proper rendering of sha-512 values

### DIFF
--- a/index.html
+++ b/index.html
@@ -6848,8 +6848,8 @@ https://www.w3.org/2018/credentials#<br>
               <td>
 https://www.w3.org/2018/credentials/index.jsonld<br><br>
 sha256: `z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=`<br><br>
-sha3-512: `m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH
-h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==`
+sha3-512: <code>m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
+h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==</code>
               </td>
             </tr>
             <tr>
@@ -6860,8 +6860,8 @@ https://w3id.org/security#<br>
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
 sha256: `LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=`<br><br>
-sha3-512: `f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw
-e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==`
+sha3-512: <code>f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
+e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
               </td>
             </tr>
           </tbody>

--- a/index.html
+++ b/index.html
@@ -6848,7 +6848,7 @@ https://www.w3.org/2018/credentials#<br>
               <td>
 https://www.w3.org/2018/credentials/index.jsonld<br><br>
 sha256: `z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=`<br><br>
-sha3-512: `m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
+sha3-512: `m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH
 h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==`
               </td>
             </tr>
@@ -6860,7 +6860,7 @@ https://w3id.org/security#<br>
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
 sha256: `LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=`<br><br>
-sha3-512: `f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
+sha3-512: `f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw
 e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==`
               </td>
             </tr>


### PR DESCRIPTION
In [§B.2](Implementations that depend on RDF vocabulary processing) the SHA3-512 values did not display correctly; the values were not rendered as a `<code>`. This PR removes the `<wbr>` tag which seems to have created problems in the respec->html conversion.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1443.html" title="Last updated on Feb 22, 2024, 8:51 AM UTC (e56dfaa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1443/d42fd22...e56dfaa.html" title="Last updated on Feb 22, 2024, 8:51 AM UTC (e56dfaa)">Diff</a>