### PR TITLE
Removing unnecessary direction attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1716,7 +1716,7 @@ respectively. See
       "@value": "Une université publique axée sur l'enseignement d'exemples.",
       "@language": "fr"
     }, {
-      "@value": "جامعة عامة تركز على أمثلة التدريس.",
+      "@value": ".جامعة عامة تركز على أمثلة التدريس",
       "@language": "ar"
     }]
   },

--- a/index.html
+++ b/index.html
@@ -1707,8 +1707,7 @@ respectively. See
       "@language": "fr"
     }, {
       "@value": "جامعة المثال",
-      "@language": "ar",
-      "@direction": "rtl"
+      "@language": "ar"
     }],
     "description": [{
       "@value": "A public university focusing on teaching examples.",
@@ -1718,8 +1717,7 @@ respectively. See
       "@language": "fr"
     }, {
       "@value": "جامعة عامة تركز على أمثلة التدريس.",
-      "@language": "ar",
-      "@direction": "rtl"
+      "@language": "ar"
     }]
   },
   "validFrom": "2015-05-10T12:30:00Z",
@@ -1731,8 +1729,7 @@ respectively. See
     "@language": "fr"
   }, {
     "@value": "مثال الشهادة الجامعية",
-    "@language": "ar",
-    "@direction": "rtl"
+    "@language": "ar"
   }],
   "description": [{
     "@value": "2015 Bachelor of Science and Arts Degree",
@@ -1757,8 +1754,7 @@ respectively. See
         "@language": "fr"
       }, {
         "@value": "بكالوريوس العلوم والآداب",
-        "@language": "ar",
-        "@direction": "rtl"
+        "@language": "ar"
       }]
     }
   }


### PR DESCRIPTION
Referring to #1424, the edit removes the `@direction` key, except for the example that begins with numerals. (I am not 100% sure it is necessary for that example either, but keeping it there gives at least one example of the key's usage).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1446.html" title="Last updated on Mar 3, 2024, 7:48 PM UTC (acc8ea2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1446/3a0007b...acc8ea2.html" title="Last updated on Mar 3, 2024, 7:48 PM UTC (acc8ea2)">Diff</a>