### PR TITLE
extension point clarification

### DIFF
--- a/index.html
+++ b/index.html
@@ -3854,11 +3854,11 @@ on top of this specification.
         <p>
 This specification reserves a number of [=properties=] to serve as possible
 extension points. While some implementers signalled interest in these properties,
-their inclusion in this specification was considered to be premature. Some of these
-extension points were originally defined in previous versions of this
-specification, whilst others were not. It is important to note that none of these properties
-are defined by this specification. Consequently, implementers are cautioned that usage of these 
-properties is considered experimental.
+their inclusion in this specification was considered to be premature. Some of 
+these extension points were originally defined in previous versions of this
+specification, whilst others were not. It is important to note that none of these
+properties are defined by this specification. Consequently, implementers are 
+cautioned that use of these properties is considered experimental.
         </p>
         <p>
 Implementers MAY use these properties, but SHOULD expect them and/or

--- a/index.html
+++ b/index.html
@@ -3853,16 +3853,16 @@ on top of this specification.
 
         <p>
 This specification reserves a number of [=properties=] to serve as possible
-extension points. While some implementers signaled interest in these properties,
-their inclusion in this specification was considered to be premature; these
-extension points might be more formally defined in future versions of this
-specification. It is important to note that these properties are not defined by
-this specification and implementers are cautioned that usage of these properties
-is considered experimental.
+extension points. While some implementers signalled interest in these properties,
+their inclusion in this specification was considered to be premature. Some of these
+extension points were originally defined in previous versions of this
+specification, whilst others were not. It is important to note that none of these properties
+are defined by this specification. Consequently, implementers are cautioned that usage of these 
+properties is considered experimental.
         </p>
         <p>
 Implementers MAY use these properties, but SHOULD expect them and/or
-their meanings to change during the process to normatively specify them.
+their meanings to change during the process of normatively specifying them.
 Implementers SHOULD NOT use these properties without a publicly disclosed
 specification describing their implementation.
         </p>

--- a/index.html
+++ b/index.html
@@ -3853,10 +3853,10 @@ on top of this specification.
 
         <p>
 This specification reserves a number of [=properties=] to serve as possible
-extension points. While some implementers signalled interest in these properties,
+extension points. While some implementers signaled interest in these properties,
 their inclusion in this specification was considered to be premature. Some of 
 these extension points were originally defined in previous versions of this
-specification, whilst others were not. It is important to note that none of these
+specification, while others were not. It is important to note that none of these
 properties are defined by this specification. Consequently, implementers are 
 cautioned that use of these properties is considered experimental.
         </p>


### PR DESCRIPTION
removed "more formally defined"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/David-Chadwick/vc-data-model/pull/1447.html" title="Last updated on Mar 3, 2024, 7:57 PM UTC (7ab710d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1447/3a0007b...David-Chadwick:7ab710d.html" title="Last updated on Mar 3, 2024, 7:57 PM UTC (7ab710d)">Diff</a>