### PR TITLE
Add warning about English descriptions being illustrative.

### DIFF
--- a/index.html
+++ b/index.html
@@ -475,6 +475,14 @@ Implementers are cautioned to remove this content if they desire to use the
 information as a valid document.
         </p>
 
+        <p class="note" title="Human-readable text in English is illustrative">
+Examples provided throughout this document include descriptive fields, such as
+`name` and `description`, in English to simplify the concepts in each example of
+the specification. These examples do not necessarily reflect the data structures
+needed for international use, which is described in more detail in Section
+[[[#internationalization-considerations]]].
+        </p>
+
       </section>
 
     </section>

--- a/index.html
+++ b/index.html
@@ -475,12 +475,12 @@ Implementers are cautioned to remove this content if they desire to use the
 information as a valid document.
         </p>
 
-        <p class="note" title="Human-readable text in English is illustrative">
+        <p class="note" title="Human-readable texts in English are illustrative">
 Examples provided throughout this document include descriptive fields, such as
-`name` and `description`, in English to simplify the concepts in each example of
-the specification. These examples do not necessarily reflect the data structures
-needed for international use, which is described in more detail in Section
-[[[#internationalization-considerations]]].
+`name` and `description`, with values in English to simplify the concepts in each
+example of the specification. These examples do not necessarily reflect the data
+structures needed for international use, which is described in more detail in
+Section [[[#internationalization-considerations]]].
         </p>
 
       </section>


### PR DESCRIPTION
This PR is an attempt to address issue #1192 by adding text warning that the use of English in descriptions is illustrative.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1449.html" title="Last updated on Mar 3, 2024, 9:18 PM UTC (77190d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1449/64cf5b1...77190d3.html" title="Last updated on Mar 3, 2024, 9:18 PM UTC (77190d3)">Diff</a>