### PR TITLE
Add language related to validation expectations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6494,27 +6494,28 @@ data fields in this specification by [=verifiers=].
 When a [=verifier=] requests one or more [=verifiable credentials=] from a
 [=holder=], they can specify the <a href="#types">type</a> of credential(s)
 that they would like to receive. Credential types, as well as validation schemas
-for the type and each of its [=claims=], are defined by specification authors
+for each type and each of their [=claims=], are defined by specification authors
 and are published in places like the [[[VC-SPECS]]].
         </p>
 
         <p>
 The type of a credential is expressed via the <a href="#types">type</a>
 property. A [=verifiable credential=] of a specific type is expected to contain
-specific [=properties=] that can be used to determine whether or not the
-[=presentation=] meets a set of processing rules that the [=verifier=] is
-executing. By requesting [=verifiable credentials=] of a particular `type`, the
+specific [=properties=] (which might be deeply nested) that can be used to determine whether or not the
+[=presentation=] satisfies a set of processing rules that the [=verifier=]
+executes. By requesting [=verifiable credentials=] of a particular `type`, the
 [=verifier=] is able to gather specific information from the [=holder=], which
-originated  with the [=issuer=] of each [=verifiable credential=], that will
-enable it to determine the next stage of an interaction with a [=holder=].
+originated with the [=issuer=] of each [=verifiable credential=], that will
+enable the [=verifier=] to determine the next stage of an interaction with a [=holder=].
         </p>
 
         <p>
 When a [=verifier=] requests a [=verifiable credential=] of a specific type,
 there will be a set of mandatory and optional [=claims=] that are associated
-with that type. It is expected that a [=verifier=] will fail to validate
-[=claims=] that are mandatory that are not included and will ignore any
-[=claim=] that is not associated with the specific type. In other words, a
+with that type. It is expected that a [=verifier=]'s validation of a
+[=verifiable credential=] will fail when mandatory [=claims=] are not
+included, and that any [=claim=] that is not associated with the specific
+type will be ignored. In other words, a
 [=verifier=] will perform input validation on the [=verifiable credential=] it
 receives and will reject malformed input based on the credential type
 specification.

--- a/index.html
+++ b/index.html
@@ -6491,19 +6491,35 @@ data fields in this specification by [=verifiers=].
         <h3>Credential Type</h3>
 
         <p>
-When a [=verifier=] requests one or more [=verifiable credentials=]
-from a [=holder=], they can specify the type of credential(s) that they would
-like to receive. The type of a credential is expressed via the
-<a href="#types">type</a> property. A [=verifiable credential=] of a specific
-type is expected to contain specific [=properties=] that can be used to
-determine whether or not the [=presentation=] meets a set of processing rules
-that the [=verifier=] is executing. By requesting
-[=verifiable credentials=] of a particular `type`, the
-[=verifier=] is able to gather specific information from the [=holder=],
-which originated  with the [=issuer=] of each [=verifiable credential=],
-that will enable it to determine the next stage of an interaction with a
-[=holder=].
+When a [=verifier=] requests one or more [=verifiable credentials=] from a
+[=holder=], they can specify the <a href="#types">type</a> of credential(s)
+that they would like to receive. Credential types, as well as validation schemas
+for the type and each of its [=claims=], are defined by specification authors
+and are published in places like the [[[VC-SPECS]]].
         </p>
+
+        <p>
+The type of a credential is expressed via the <a href="#types">type</a>
+property. A [=verifiable credential=] of a specific type is expected to contain
+specific [=properties=] that can be used to determine whether or not the
+[=presentation=] meets a set of processing rules that the [=verifier=] is
+executing. By requesting [=verifiable credentials=] of a particular `type`, the
+[=verifier=] is able to gather specific information from the [=holder=], which
+originated  with the [=issuer=] of each [=verifiable credential=], that will
+enable it to determine the next stage of an interaction with a [=holder=].
+        </p>
+
+        <p>
+When a [=verifier=] requests a [=verifiable credential=] of a specific type,
+there will be a set of mandatory and optional [=claims=] that are associated
+with that type. It is expected that a [=verifier=] will fail to validate
+[=claims=] that are mandatory that are not included and will ignore any
+[=claim=] that is not associated with the specific type. In other words, a
+[=verifier=] will perform input validation on the [=verifiable credential=] it
+receives and will reject malformed input based on the credential type
+specification.
+        </p>
+
       </section>
 
       <section class="informative">


### PR DESCRIPTION
This PR is an attempt to address issue #1388 by documenting that a verifier is expected to perform input validation based on the requirements of a specific type of credential and might ignore claims that it does not understand.

/cc @jyasskin


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1451.html" title="Last updated on Mar 9, 2024, 4:09 PM UTC (5cf1016)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1451/64cf5b1...5cf1016.html" title="Last updated on Mar 9, 2024, 4:09 PM UTC (5cf1016)">Diff</a>