### PR TITLE
Remove note on verification methods; refactor proof validation section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6642,14 +6642,14 @@ ensure:
 
         <ul>
           <li>
-The proof is available in a form defined by a known cryptographic suite.
+The cryptographic proof is available in a form defined by a known cryptographic suite.
           </li>
           <li>
-All required proof [=properties=] are present.
+All required cryptographic proof [=properties=] are present.
           </li>
           <li>
-The proof [=verification=] algorithm, when applied to the data, results in an
-acceptable proof.
+The cryptographic proof [=verification=] algorithm, when applied to the data, results in an
+accepted cryptographic proof.
           </li>
         </ul>
 
@@ -6660,11 +6660,12 @@ ensure:
 
         <ul>
           <li>
-Acceptably recent metadata regarding the [=verification material=], such as a
-public key, associated with the signature is available. For example, the
-metadata might include [=properties=] related to public key validity periods,
-the controller of the public key, or the public key purpose, such as
-authentication or encryption, for which it is authorized.
+Acceptably recent metadata regarding the [=verification material=]
+associated with the signature is available. For example, if the
+[=verification material=] is a public key, the
+metadata might include [=properties=] related to the validity period,
+the controller, or the authorized purpose, such as
+authentication or encryption, of the public key.
           </li>
           <li>
 The public key is not suspended, revoked, or expired.

--- a/index.html
+++ b/index.html
@@ -6632,39 +6632,42 @@ the validity period for a [=verifiable credential=] is not in the future.
         <h3>Proofs (Signatures)</h3>
 
         <p>
-The cryptographic mechanism used to prove that the information in a
+The securing mechanism used to prove that the information in a
 [=verifiable credential=] or [=verifiable presentation=] was not tampered
 with is called a <em>proof</em>. There are many types of cryptographic proofs
 including, but not limited to, digital signatures and zero-knowledge proofs. In
-general, when verifying proofs, implementations are expected to ensure:
+general, when verifying cryptographic proofs, implementations are expected to
+ensure:
         </p>
 
         <ul>
           <li>
-The proof is available in the form of a known proof suite.
+The proof is available in a form defined by a known cryptographic suite.
           </li>
           <li>
-All required proof suite [=properties=] are present.
+All required proof [=properties=] are present.
           </li>
           <li>
-The proof suite [=verification=] algorithm, when applied to the data, results
-in an acceptable proof.
+The proof [=verification=] algorithm, when applied to the data, results in an
+acceptable proof.
           </li>
         </ul>
 
         <p>
-Some proofs are digital signatures. In general, when verifying digital
-signatures, implementations are expected to ensure:
+In general, when verifying digital signatures, implementations are expected to
+ensure:
         </p>
 
         <ul>
           <li>
-Acceptably recent metadata regarding the [=verification material=] associated
-with the signature is available. For example, the metadata might include
-[=properties=] related to validity periods, key owner, or key purpose.
+Acceptably recent metadata regarding the [=verification material=], such as a
+public key, associated with the signature is available. For example, the
+metadata might include [=properties=] related to public key validity periods,
+the controller of the public key, or the public key purpose, such as
+authentication or encryption, for which it is authorized.
           </li>
           <li>
-The key is not suspended, revoked, or expired.
+The public key is not suspended, revoked, or expired.
           </li>
           <li>
 The cryptographic signature is expected to verify.

--- a/index.html
+++ b/index.html
@@ -6634,7 +6634,7 @@ the validity period for a [=verifiable credential=] is not in the future.
         <p>
 The securing mechanism used to prove that the information in a
 [=verifiable credential=] or [=verifiable presentation=] was not tampered
-with is called a <em>proof</em>. There are many types of cryptographic proofs
+with is called a <em>cryptographic proof</em>. There are many types of cryptographic proofs
 including, but not limited to, digital signatures and zero-knowledge proofs. In
 general, when verifying cryptographic proofs, implementations are expected to
 ensure:

--- a/index.html
+++ b/index.html
@@ -6632,9 +6632,9 @@ the validity period for a [=verifiable credential=] is not in the future.
         <h3>Proofs (Signatures)</h3>
 
         <p>
-The securing mechanism used to prove that the information in a
-[=verifiable credential=] or [=verifiable presentation=] was not tampered
-with is called a <em>cryptographic proof</em>. There are many types of cryptographic proofs
+The securing mechanism used to prove that the information in a [=verifiable
+credential=] or [=verifiable presentation=] was not tampered with is called a
+<em>cryptographic proof</em>. There are many types of cryptographic proofs
 including, but not limited to, digital signatures and zero-knowledge proofs. In
 general, when verifying cryptographic proofs, implementations are expected to
 ensure:
@@ -6642,14 +6642,15 @@ ensure:
 
         <ul>
           <li>
-The cryptographic proof is available in a form defined by a known cryptographic suite.
+The cryptographic proof is available in a form defined by a known cryptographic
+suite.
           </li>
           <li>
 All required cryptographic proof [=properties=] are present.
           </li>
           <li>
-The cryptographic proof [=verification=] algorithm, when applied to the data, results in an
-accepted cryptographic proof.
+The cryptographic proof [=verification=] algorithm, when applied to the data,
+results in an accepted cryptographic proof.
           </li>
         </ul>
 
@@ -6660,18 +6661,17 @@ ensure:
 
         <ul>
           <li>
-Acceptably recent metadata regarding the [=verification material=]
-associated with the signature is available. For example, if the
-[=verification material=] is a public key, the
-metadata might include [=properties=] related to the validity period,
-the controller, or the authorized purpose, such as
+Acceptably recent metadata regarding the [=verification material=] associated
+with the signature is available. For example, if the [=verification material=]
+is a public key, the metadata might include [=properties=] related to the
+validity period, the controller, or the authorized purpose, such as
 authentication or encryption, of the public key.
           </li>
           <li>
 The public key is not suspended, revoked, or expired.
           </li>
           <li>
-The cryptographic signature is expected to verify.
+The digital signature is expected to verify.
           </li>
           <li>
 Any additional requirements defined by the securing mechanism are satisfied.

--- a/index.html
+++ b/index.html
@@ -6674,24 +6674,6 @@ Any additional requirements defined by the securing mechanism are satisfied.
           </li>
         </ul>
 
-        <p class="note">
-The digital signature provides a number of protections, other than tamper
-resistance, which are not immediately obvious. For example, a Linked Data
-Signature `created` [=property=] establishes a date and time
-before which the [=credential=] should not be considered [=verified=],
-distinct from the validity period of the credential. This property describes the
-validity of the proof, not of the credential.
-The JWT `iat` claim likewise provides the time that the signature was made.
-<br/><br/>
-The `verificationMethod` [=property=] specifies, for example, the
-public key that can be used to verify the digital signature. Dereferencing a
-public key URL reveals information about the controller of the key, which can
-be checked against the issuer of the [=credential=]. The
-`proofPurpose` [=property=] clearly expresses the purpose for
-the proof and ensures this information is protected by the signature. A proof is
-typically attached to a [=verifiable presentation=] for authentication
-purposes and to a [=verifiable credential=] as a method of assertion.
-        </p>
       </section>
 
       <section class="informative">


### PR DESCRIPTION
This PR is an attempt to address issue #1274 by removing the note on verification methods (since we now have a spec that defines those) and refactors the validation section to use more modern language.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1452.html" title="Last updated on Mar 9, 2024, 4:23 PM UTC (286ce7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1452/64cf5b1...286ce7c.html" title="Last updated on Mar 9, 2024, 4:23 PM UTC (286ce7c)">Diff</a>