### PR TITLE
Add section on enveloped verifiable presentations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2455,7 +2455,7 @@ enveloped [=verifiable credential=]:
 
           <p>
 It is possible to express a [=verifiable presentation=] that has been secured
-using a securing mechanism that "envelopes" the payload, such as
+using a mechanism that "envelops" the payload, such as
 [[[?VC-JOSE-COSE]]] [[?VC-JOSE-COSE]]. This can be accomplished by using an
 object that has a `type` of `EnvelopedVerifiablePresentation`.
           </p>
@@ -2470,23 +2470,23 @@ that defines at least the `id`, `type`, and `EnvelopedVerifiablePresentation`
 terms as defined by the base context provided by this specification. The `id`
 value of the object MUST be a `data:` URL [[RFC2397]] that expresses a secured
 [=verifiable presentation=] using an
-<a href="#dfn-enveloping-proof">enveloping</a> security scheme, such as
+<a href="#dfn-enveloping-proof">enveloping</a> securing mechanism, such as
 [[[VC-JOSE-COSE]]] [[VC-JOSE-COSE]]. The `type` value of the object MUST be
 `EnvelopedVerifiablePresentation`.
             </dd>
           </dl>
 
-        <p>
+          <p>
 The example below shows an enveloped [=verifiable presentation=]:
-        </p>
+          </p>
 
-        <pre class="example nohighlight" title="Basic structure of an enveloped verifiable presentation">
+          <pre class="example nohighlight" title="Basic structure of an enveloped verifiable presentation">
 {
   "@context": "https://www.w3.org/ns/credentials/v2",
   <span class="highlight">"id": "data:application/vp+ld+json+jwt;eyJraWQiO...zhwGfQ",
   "type": "EnvelopedVerifiablePresentation"</span>
 }
-        </pre>
+          </pre>
 
         </section>
 

--- a/index.html
+++ b/index.html
@@ -2451,6 +2451,46 @@ enveloped [=verifiable credential=]:
         </section>
 
         <section>
+          <h4>Enveloped Verifiable Presentations</h4>
+
+          <p>
+It is possible to express a [=verifiable presentation=] that has been secured
+using a securing mechanism that "envelopes" the payload, such as
+[[[?VC-JOSE-COSE]]] [[?VC-JOSE-COSE]]. This can be accomplished by using an
+object that has a `type` of `EnvelopedVerifiablePresentation`.
+          </p>
+
+          <dl>
+            <dt id="defn-EnvelopedVerifiablePresentation">EnvelopedVerifiablePresentation</dt>
+            <dd>
+Used to express an enveloped [=verifiable presentation=].
+The `@context` property of the object MUST be present and include a context,
+such as the <a href="#base-context">base context for this specification</a>,
+that defines at least the `id`, `type`, and `EnvelopedVerifiablePresentation`
+terms as defined by the base context provided by this specification. The `id`
+value of the object MUST be a `data:` URL [[RFC2397]] that expresses a secured
+[=verifiable presentation=] using an
+<a href="#dfn-enveloping-proof">enveloping</a> security scheme, such as
+[[[VC-JOSE-COSE]]] [[VC-JOSE-COSE]]. The `type` value of the object MUST be
+`EnvelopedVerifiablePresentation`.
+            </dd>
+          </dl>
+
+        <p>
+The example below shows an enveloped [=verifiable presentation=]:
+        </p>
+
+        <pre class="example nohighlight" title="Basic structure of an enveloped verifiable presentation">
+{
+  "@context": "https://www.w3.org/ns/credentials/v2",
+  <span class="highlight">"id": "data:application/vp+ld+json+jwt;eyJraWQiO...zhwGfQ",
+  "type": "EnvelopedVerifiablePresentation"</span>
+}
+        </pre>
+
+        </section>
+
+        <section>
           <h4>Presentations Using Derived Credentials</h4>
 
           <p>

--- a/index.html
+++ b/index.html
@@ -2428,12 +2428,13 @@ value of the object MUST be a `data:` URL [[RFC2397]] that expresses a secured
             </dd>
           </dl>
 
-        <p>
+          <p>
 The example below shows a [=verifiable presentation=] that contains an
 enveloped [=verifiable credential=]:
-        </p>
+          </p>
 
-        <pre class="example nohighlight" title="Basic structure of a presentation">
+          <pre class="example nohighlight"
+               title="Basic structure of a presentation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2446,7 +2447,15 @@ enveloped [=verifiable credential=]:
     "type": "EnvelopedVerifiableCredential"
   }]</span>
 }
-        </pre>
+          </pre>
+
+          <p class="note" title="Processing enveloped content as RDF">
+It is possible that an implementer might want to process the object described in
+this section, and the enveloped presentation expressed by the `id` value, in an
+RDF environment and create linkages between the objects that are relevant to
+RDF. The desire and mechanisms for doing so are use case dependent and will,
+thus, be implementation dependent.
+          </p>
 
         </section>
 

--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -1,42 +1,42 @@
-<mxfile host="Electron" modified="2023-12-10T15:07:48.508Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/22.1.2 Chrome/114.0.5735.289 Electron/25.9.4 Safari/537.36" etag="pWKSvkn9tbMr6_T2Y-XU" version="22.1.2" type="device">
+<mxfile host="Electron" modified="2024-03-04T08:03:30.936Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/23.0.2 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="Vi-e1ZbyFz_zjhMOGs0x" version="23.0.2" type="device">
   <diagram name="Page-1" id="5wcF2D67hh1iBqyEtvuE">
-    <mxGraphModel dx="3282" dy="2106" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
+    <mxGraphModel dx="3435" dy="2149" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="900" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;verifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#verifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-1451" y="-305.2954554812147" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-1446" y="-305.2954554812147" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredential" id="1oUjKqBKF74gJ-cnWfdO-5">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-1281" y="-889" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-1276" y="-889" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchemaCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#JsonSchemaCredential" id="1oUjKqBKF74gJ-cnWfdO-6">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-1561" y="-768.9536798764797" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-1556" y="-768.9536798764797" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiablePresentation" id="1oUjKqBKF74gJ-cnWfdO-7">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-1285" y="-150.71513124034982" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-1280" y="-150.717565620175" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="1oUjKqBKF74gJ-cnWfdO-9" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-6" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1535" y="-563.2743180648482" as="sourcePoint" />
-            <mxPoint x="-1485" y="-603.2897581060216" as="targetPoint" />
+            <mxPoint x="-1530" y="-563.2743180648482" as="sourcePoint" />
+            <mxPoint x="-1480" y="-603.2897581060216" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1411" y="-832.9783839423571" />
+              <mxPoint x="-1406" y="-832.9783839423571" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="1oUjKqBKF74gJ-cnWfdO-12" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-3" target="1oUjKqBKF74gJ-cnWfdO-15" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1314" y="-492.0468347915595" as="sourcePoint" />
-            <mxPoint x="-1291" y="-552.8703036541431" as="targetPoint" />
+            <mxPoint x="-1309" y="-492.0468347915595" as="sourcePoint" />
+            <mxPoint x="-1286" y="-552.8703036541431" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="1oUjKqBKF74gJ-cnWfdO-13" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-3" target="1oUjKqBKF74gJ-cnWfdO-3" edge="1">
@@ -44,409 +44,409 @@
         </mxCell>
         <mxCell id="1oUjKqBKF74gJ-cnWfdO-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-7" target="1oUjKqBKF74gJ-cnWfdO-3" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-987" y="-436.0252187339167" as="sourcePoint" />
-            <mxPoint x="-937" y="-476.04065877509004" as="targetPoint" />
+            <mxPoint x="-982" y="-436.0252187339167" as="sourcePoint" />
+            <mxPoint x="-932" y="-476.04065877509004" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1361" y="-216.74060730828626" />
+              <mxPoint x="-1356" y="-216.74060730828626" />
             </Array>
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;VerifiableCredentialGraph&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#VerifiableCredentialGraph" id="1oUjKqBKF74gJ-cnWfdO-15">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-1474.5" y="-449.9957436953165" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-1469.5" y="-449.9957436953165" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="1oUjKqBKF74gJ-cnWfdO-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=classicThin;endFill=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="-1251" y="-640.9042717447246" as="sourcePoint" />
+            <mxPoint x="-1246" y="-640.9042717447246" as="sourcePoint" />
             <Array as="points">
-              <mxPoint x="-1290" y="-650" />
+              <mxPoint x="-1285" y="-650" />
             </Array>
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSchema" id="lZdwYr-LXM3OhQDUA7XR-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-824.9752959341225" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-824.9752959341225" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialStatus" id="lZdwYr-LXM3OhQDUA7XR-2">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-768" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-768" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;credentialSubject&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSubject" id="lZdwYr-LXM3OhQDUA7XR-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-712" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-712" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;issuer&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#issuer" id="lZdwYr-LXM3OhQDUA7XR-4">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-655" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-655" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-542" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-542" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-485" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-485" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;renderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#renderMethod" id="lZdwYr-LXM3OhQDUA7XR-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-428" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-428" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;confidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#confidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-8">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-371" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-371" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;termsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#termsOfUse" id="lZdwYr-LXM3OhQDUA7XR-9">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-315" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-315" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validFrom&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#validFrom" id="lZdwYr-LXM3OhQDUA7XR-10">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-258" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-258" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;validUntil&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#validUntil" id="lZdwYr-LXM3OhQDUA7XR-11">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-201" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-201" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;holder&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#holder" id="lZdwYr-LXM3OhQDUA7XR-12">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-144.71281523417395" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-144.71281523417395" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-13" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-12" target="1oUjKqBKF74gJ-cnWfdO-7" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1039" y="-161.51930005146687" as="sourcePoint" />
-            <mxPoint x="-1105" y="-336.7869274318065" as="targetPoint" />
+            <mxPoint x="-1034" y="-161.51930005146687" as="sourcePoint" />
+            <mxPoint x="-1100" y="-336.7869274318065" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-14" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-1" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1029" y="-601.6891405043747" as="sourcePoint" />
-            <mxPoint x="-1095" y="-776.9567678847144" as="targetPoint" />
+            <mxPoint x="-1024" y="-601.6891405043747" as="sourcePoint" />
+            <mxPoint x="-1090" y="-776.9567678847144" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-990" y="-811" />
-              <mxPoint x="-1111" y="-808.9691199176531" />
+              <mxPoint x="-985" y="-811" />
+              <mxPoint x="-1106" y="-808.9691199176531" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-15" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=0;startArrow=classic;startFill=1;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-2" target="1oUjKqBKF74gJ-cnWfdO-5" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-988" y="-754.5481214616573" as="sourcePoint" />
-            <mxPoint x="-1201" y="-792.9629439011837" as="targetPoint" />
+            <mxPoint x="-983" y="-754.5481214616573" as="sourcePoint" />
+            <mxPoint x="-1196" y="-792.9629439011837" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1147" y="-752.1471950591869" />
+              <mxPoint x="-1142" y="-752.1471950591869" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-3" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1149" y="-497.6489963973238" as="sourcePoint" />
-            <mxPoint x="-1215" y="-672.9166237776634" as="targetPoint" />
+            <mxPoint x="-1144" y="-497.6489963973238" as="sourcePoint" />
+            <mxPoint x="-1210" y="-672.9166237776634" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1121" y="-704.9289758106022" />
+              <mxPoint x="-1116" y="-704.9289758106022" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-17" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-4" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1162" y="-841.7817807514153" as="sourcePoint" />
-            <mxPoint x="-942" y="-691.3237261966032" as="targetPoint" />
+            <mxPoint x="-1157" y="-841.7817807514153" as="sourcePoint" />
+            <mxPoint x="-937" y="-691.3237261966032" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1131" y="-680.9197117858981" />
+              <mxPoint x="-1126" y="-680.9197117858981" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-5" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1152" y="-833.7786927431806" as="sourcePoint" />
-            <mxPoint x="-961" y="-592.8857436953165" as="targetPoint" />
+            <mxPoint x="-1147" y="-833.7786927431806" as="sourcePoint" />
+            <mxPoint x="-956" y="-592.8857436953165" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1151" y="-656.9104477611941" />
+              <mxPoint x="-1146" y="-656.9104477611941" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-19" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-6" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1142" y="-825.775604734946" as="sourcePoint" />
-            <mxPoint x="-922" y="-675.3175501801338" as="targetPoint" />
+            <mxPoint x="-1137" y="-825.775604734946" as="sourcePoint" />
+            <mxPoint x="-917" y="-675.3175501801338" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1161" y="-624.8980957282554" />
+              <mxPoint x="-1156" y="-624.8980957282554" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-20" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-7" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1132" y="-817.7725167267113" as="sourcePoint" />
-            <mxPoint x="-912" y="-667.3144621718991" as="targetPoint" />
+            <mxPoint x="-1127" y="-817.7725167267113" as="sourcePoint" />
+            <mxPoint x="-907" y="-667.3144621718991" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1181" y="-592.8857436953165" />
+              <mxPoint x="-1176" y="-592.8857436953165" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-21" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-8" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1122" y="-809.7694287184765" as="sourcePoint" />
-            <mxPoint x="-902" y="-659.3113741636645" as="targetPoint" />
+            <mxPoint x="-1117" y="-809.7694287184765" as="sourcePoint" />
+            <mxPoint x="-897" y="-659.3113741636645" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1201" y="-592.8857436953165" />
+              <mxPoint x="-1196" y="-592.8857436953165" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-22" value="" style="ellipse;whiteSpace=wrap;html=1;aspect=fixed;fontSize=16;fillColor=#cc0000;strokeColor=none;" parent="1" vertex="1">
-          <mxGeometry x="-1071" y="-253" width="10" height="10" as="geometry" />
+          <mxGeometry x="-1066" y="-253" width="10" height="10" as="geometry" />
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-23" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-7" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-871" y="-123.10447761194041" as="sourcePoint" />
-            <mxPoint x="-1053" y="-123.10447761194041" as="targetPoint" />
+            <mxPoint x="-866" y="-123.10447761194041" as="sourcePoint" />
+            <mxPoint x="-1048" y="-123.10447761194041" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1130" y="-220" />
+              <mxPoint x="-1125" y="-220" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-24" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="lZdwYr-LXM3OhQDUA7XR-22" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-861" y="-115.10138960370568" as="sourcePoint" />
-            <mxPoint x="-1060" y="-307" as="targetPoint" />
+            <mxPoint x="-856" y="-115.10138960370568" as="sourcePoint" />
+            <mxPoint x="-1055" y="-307" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1210" y="-560" />
+              <mxPoint x="-1205" y="-560" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-25" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-10" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-929" y="-307.57565620175" as="sourcePoint" />
-            <mxPoint x="-1111" y="-307.57565620175" as="targetPoint" />
+            <mxPoint x="-924" y="-307.57565620175" as="sourcePoint" />
+            <mxPoint x="-1106" y="-307.57565620175" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-26" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-9" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1142" y="-299.1724137931036" as="sourcePoint" />
-            <mxPoint x="-901" y="-360.79619145651066" as="targetPoint" />
+            <mxPoint x="-1137" y="-299.1724137931036" as="sourcePoint" />
+            <mxPoint x="-896" y="-360.79619145651066" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-970" y="-300" />
+              <mxPoint x="-965" y="-300" />
             </Array>
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;dashPattern=5 2 2 2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-22" target="lZdwYr-LXM3OhQDUA7XR-11" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1141" y="-280.76531137416373" as="sourcePoint" />
-            <mxPoint x="-921" y="-232.7467833247556" as="targetPoint" />
+            <mxPoint x="-1136" y="-280.76531137416373" as="sourcePoint" />
+            <mxPoint x="-916" y="-232.7467833247556" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-980" y="-200" />
+              <mxPoint x="-975" y="-200" />
             </Array>
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RenderMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RenderMethod" id="lZdwYr-LXM3OhQDUA7XR-28">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-434.002316006176" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-434.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-548.0023160061761" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-548.0023160061761" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-491.002316006176" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-491.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;ConfidenceMethod&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#ConfidenceMethod" id="lZdwYr-LXM3OhQDUA7XR-31">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-377.002316006176" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-377.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;TermsOfUse&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#TermsOfUse" id="lZdwYr-LXM3OhQDUA7XR-32">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-321.002316006176" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-321.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialSchema" id="lZdwYr-LXM3OhQDUA7XR-33">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-830.9776119402986" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-830.9776119402986" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialStatus&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialStatus" id="lZdwYr-LXM3OhQDUA7XR-34">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-591" y="-774.0023160061761" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-586" y="-774.0023160061761" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-35" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-1" target="lZdwYr-LXM3OhQDUA7XR-33" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-621" y="-604.0900669068451" as="sourcePoint" />
-            <mxPoint x="-621" y="-712.9320638188369" as="targetPoint" />
+            <mxPoint x="-616" y="-604.0900669068451" as="sourcePoint" />
+            <mxPoint x="-616" y="-712.9320638188369" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-36" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-2" target="lZdwYr-LXM3OhQDUA7XR-34" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-681" y="-736.9413278435409" as="sourcePoint" />
-            <mxPoint x="-601" y="-720.9351518270715" as="targetPoint" />
+            <mxPoint x="-676" y="-736.9413278435409" as="sourcePoint" />
+            <mxPoint x="-596" y="-720.9351518270715" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-37" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-5" target="lZdwYr-LXM3OhQDUA7XR-29" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-701" y="-522.8826556870819" as="sourcePoint" />
-            <mxPoint x="-542" y="-568.5002573340196" as="targetPoint" />
+            <mxPoint x="-696" y="-522.8826556870819" as="sourcePoint" />
+            <mxPoint x="-537" y="-568.5002573340196" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-38" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-6" target="lZdwYr-LXM3OhQDUA7XR-30" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-671" y="-610.9166237776634" as="sourcePoint" />
-            <mxPoint x="-552" y="-610.9166237776634" as="targetPoint" />
+            <mxPoint x="-666" y="-610.9166237776634" as="sourcePoint" />
+            <mxPoint x="-547" y="-610.9166237776634" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-39" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-7" target="lZdwYr-LXM3OhQDUA7XR-28" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-561" y="-611.7169325784869" as="sourcePoint" />
-            <mxPoint x="-442" y="-611.7169325784869" as="targetPoint" />
+            <mxPoint x="-556" y="-611.7169325784869" as="sourcePoint" />
+            <mxPoint x="-437" y="-611.7169325784869" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-40" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-8" target="lZdwYr-LXM3OhQDUA7XR-31" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-671" y="-322.80545548121466" as="sourcePoint" />
-            <mxPoint x="-552" y="-322.80545548121466" as="targetPoint" />
+            <mxPoint x="-666" y="-322.80545548121466" as="sourcePoint" />
+            <mxPoint x="-547" y="-322.80545548121466" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-41" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-9" target="lZdwYr-LXM3OhQDUA7XR-32" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-691" y="-274.7869274318065" as="sourcePoint" />
-            <mxPoint x="-572" y="-274.7869274318065" as="targetPoint" />
+            <mxPoint x="-686" y="-274.7869274318065" as="sourcePoint" />
+            <mxPoint x="-567" y="-274.7869274318065" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;JsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#JsonSchema" id="lZdwYr-LXM3OhQDUA7XR-42">
           <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
-            <mxGeometry x="-231" y="-752.1471950591869" width="218" height="39.215131240349976" as="geometry" />
+            <mxGeometry x="-226" y="-752.1471950591869" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="lZdwYr-LXM3OhQDUA7XR-43" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="1" source="lZdwYr-LXM3OhQDUA7XR-42" target="lZdwYr-LXM3OhQDUA7XR-33" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-241" y="-484.44390118373656" as="sourcePoint" />
-            <mxPoint x="-70" y="-584.4825012866701" as="targetPoint" />
+            <mxPoint x="-236" y="-484.44390118373656" as="sourcePoint" />
+            <mxPoint x="-65" y="-584.4825012866701" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-211" y="-816.9722079258878" />
+              <mxPoint x="-206" y="-816.9722079258878" />
             </Array>
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;jsonSchema&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#credentialSubject" id="usrDyYZYH79wCYu34c_K-7">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-207.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-202.5" y="-640.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="usrDyYZYH79wCYu34c_K-8" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" target="usrDyYZYH79wCYu34c_K-7" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-120" y="-710" as="sourcePoint" />
-            <mxPoint x="-90" y="-310" as="targetPoint" />
+            <mxPoint x="-115" y="-710" as="sourcePoint" />
+            <mxPoint x="-85" y="-310" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;font color=&quot;#000000&quot;&gt;rdf:JSON&lt;/font&gt;" id="usrDyYZYH79wCYu34c_K-9">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-195.99999999999994" y="-545.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
+            <mxGeometry x="-190.99999999999994" y="-545.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="usrDyYZYH79wCYu34c_K-10" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="usrDyYZYH79wCYu34c_K-7" target="usrDyYZYH79wCYu34c_K-9" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-310" y="-389.8028821410189" as="sourcePoint" />
-            <mxPoint x="-191" y="-389.8028821410189" as="targetPoint" />
+            <mxPoint x="-305" y="-389.8028821410189" as="sourcePoint" />
+            <mxPoint x="-186" y="-389.8028821410189" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;relatedResource&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#relatedResource" id="NdHKz3nYJsEpI_Vai11b-1">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-881" y="-598" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-876" y="-598" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="NdHKz3nYJsEpI_Vai11b-2" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;strokeWidth=2;strokeColor=#CC0000;endFill=1;startArrow=none;startFill=0;dashPattern=5 2 2 2;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-5" target="NdHKz3nYJsEpI_Vai11b-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-1162" y="-840" as="sourcePoint" />
-            <mxPoint x="-871" y="-631" as="targetPoint" />
+            <mxPoint x="-1157" y="-840" as="sourcePoint" />
+            <mxPoint x="-866" y="-631" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1121" y="-670.9197117858981" />
+              <mxPoint x="-1116" y="-670.9197117858981" />
             </Array>
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;digestSRI&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#digestSRI" id="NdHKz3nYJsEpI_Vai11b-3">
           <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-207.5" y="-429.002063818837" width="171" height="27.21049922799794" as="geometry" />
+            <mxGeometry x="-202.5" y="-429.002063818837" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;font color=&quot;#000000&quot;&gt;sriString&lt;/font&gt;" link="https://www.w3.org/2018/credentials#sriString" id="NdHKz3nYJsEpI_Vai11b-4">
           <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
-            <mxGeometry x="-195.99999999999994" y="-334.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
+            <mxGeometry x="-190.99999999999994" y="-334.0000000000001" width="149.3690176322418" height="28.708676470588237" as="geometry" />
           </mxCell>
         </UserObject>
         <mxCell id="NdHKz3nYJsEpI_Vai11b-5" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeColor=#000099;dashed=1;strokeWidth=2;" parent="1" source="NdHKz3nYJsEpI_Vai11b-3" target="NdHKz3nYJsEpI_Vai11b-4" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-310" y="-178.80288214101893" as="sourcePoint" />
-            <mxPoint x="-191" y="-178.80288214101893" as="targetPoint" />
+            <mxPoint x="-305" y="-178.80288214101893" as="sourcePoint" />
+            <mxPoint x="-186" y="-178.80288214101893" as="targetPoint" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;EnvelopedVerifiableCredential&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential" id="jcIRoWpeUHbpSJrjuQO4-1">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" vertex="1" parent="1">
-            <mxGeometry x="-1577" y="-638.22" width="250" height="39.22" as="geometry" />
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-1572" y="-638.22" width="250" height="39.22" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-2" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=classicThin;endFill=0;" edge="1" parent="1" target="jcIRoWpeUHbpSJrjuQO4-1" source="1oUjKqBKF74gJ-cnWfdO-15">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-2" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;exitX=0.5;exitY=0;exitDx=0;exitDy=0;endArrow=classicThin;endFill=0;" parent="1" source="1oUjKqBKF74gJ-cnWfdO-15" target="jcIRoWpeUHbpSJrjuQO4-1" edge="1">
           <mxGeometry relative="1" as="geometry">
-            <mxPoint x="-1361" y="-458" as="sourcePoint" />
-            <mxPoint x="-1189" y="-752.15" as="targetPoint" />
+            <mxPoint x="-1356" y="-458" as="sourcePoint" />
+            <mxPoint x="-1184" y="-752.15" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-1420" y="-520" />
+              <mxPoint x="-1415" y="-520" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-4" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-4" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="-1598" y="-62" width="1595" height="54.5" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-5" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-5" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=none;dashed=1;" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1">
           <mxGeometry width="1595" height="54.5" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-6" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-6" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="725" y="7.639812500000005" width="163.39999999999998" height="40" as="geometry" />
         </mxCell>
         <UserObject label="" id="jcIRoWpeUHbpSJrjuQO4-7">
-          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-6">
+          <mxCell style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-6" vertex="1">
             <mxGeometry x="75" y="11.5" width="88.4" height="17" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-8" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-6">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-8" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: center; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Datatype&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;" parent="jcIRoWpeUHbpSJrjuQO4-6" vertex="1">
           <mxGeometry x="13" width="90" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-9" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-9" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="182" y="9.077312500000005" width="170" height="37.125" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-9">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#330000;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-9" vertex="1">
           <mxGeometry x="83" y="4.95" width="80" height="23.685750000000002" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-11" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-9">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-11" value="Property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-9" vertex="1">
           <mxGeometry width="70" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-12" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-12" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="901" y="9.077312500000005" width="170" height="37.125" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-13" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-12">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-13" value="" style="endArrow=classic;html=1;rounded=0;endFill=1;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-12" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="87" y="17.94375" as="sourcePoint" />
             <mxPoint x="167" y="18.5625" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-14" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-12">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-14" value="Superclass" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-12" vertex="1">
           <mxGeometry x="-5" width="80" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-15" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-15" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="1098" y="9.077312500000005" width="136" height="37.125" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=5 2 2 2;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-15">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-16" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;startArrow=none;startFill=0;endArrow=classic;endFill=1;strokeColor=#FF3333;dashed=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;dashPattern=5 2 2 2;" parent="jcIRoWpeUHbpSJrjuQO4-15" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="74" y="18.5625" as="sourcePoint" />
             <mxPoint x="154" y="18.5625" as="targetPoint" />
@@ -456,59 +456,64 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-17" value="Domain&lt;br&gt;of" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-15">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-17" value="Domain&lt;br&gt;of" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-15" vertex="1">
           <mxGeometry y="-5" width="60" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-18" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-18" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="1266" y="9.077312500000005" width="160" height="37.125" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-18">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-19" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;dashed=1;strokeColor=#0000CC;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-18" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="67" y="18.5625" as="sourcePoint" />
             <mxPoint x="147" y="18.5625" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-20" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-18">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-20" value="Range" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-18" vertex="1">
           <mxGeometry width="60" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-21" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-21" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="367" y="5.983562500000005" width="160" height="43.3125" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-22" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-21">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-22" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="jcIRoWpeUHbpSJrjuQO4-21" vertex="1">
           <mxGeometry x="65" y="4.95" width="100" height="28.004625" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-23" value="Reserved&lt;br&gt;class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-21">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-23" value="Reserved&lt;br&gt;class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-21" vertex="1">
           <mxGeometry x="-10" y="1.8125" width="70" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-24" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-24" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="539" y="2.889812500000005" width="176" height="49.5" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-25" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-24">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-25" value="Reserved&lt;br&gt;property" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-24" vertex="1">
           <mxGeometry y="7" width="70" height="40" as="geometry" />
         </mxCell>
         <UserObject label="" link="https://www.w3.org/2018/credentials#evidence" id="jcIRoWpeUHbpSJrjuQO4-26">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-24">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="jcIRoWpeUHbpSJrjuQO4-24" vertex="1">
             <mxGeometry x="81.75" y="14.231250000000001" width="91.25" height="24.75" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-27" value="" style="group" vertex="1" connectable="0" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-27" value="" style="group" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1" connectable="0">
           <mxGeometry x="7" y="12.639812500000005" width="160" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-28" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-27">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-28" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#82b366;strokeWidth=2;" parent="jcIRoWpeUHbpSJrjuQO4-27" vertex="1">
           <mxGeometry x="60" y="0.9976874999999978" width="100" height="28.004625" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-29" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-27">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-29" value="Class" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;" parent="jcIRoWpeUHbpSJrjuQO4-27" vertex="1">
           <mxGeometry width="50" height="30" as="geometry" />
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-30" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" edge="1" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-30" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;fontSize=12;startSize=8;endSize=8;dashed=1;dashPattern=1 4;strokeWidth=2;endArrow=classic;endFill=0;" parent="jcIRoWpeUHbpSJrjuQO4-4" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="1515" y="27.139812500000005" as="sourcePoint" />
             <mxPoint x="1588" y="27.359812500000004" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="jcIRoWpeUHbpSJrjuQO4-31" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" vertex="1" parent="jcIRoWpeUHbpSJrjuQO4-4">
+        <mxCell id="jcIRoWpeUHbpSJrjuQO4-31" value="&lt;span style=&quot;color: rgb(0, 0, 0); font-family: Helvetica; font-size: 12px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; float: none; display: inline !important;&quot;&gt;Graph containment&lt;/span&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;" parent="jcIRoWpeUHbpSJrjuQO4-4" vertex="1">
           <mxGeometry x="1431" width="70" height="25.64" as="geometry" />
         </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;EnvelopedVerifiablePresentation&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#EnvelopedVerifiablePresentation" id="jI3qBF4UIzf47FgSKy2m-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" vertex="1" parent="1">
+            <mxGeometry x="-1583" y="-150.72000000000003" width="257" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
       </root>
     </mxGraphModel>
   </diagram>

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -1,9 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background-color:#fff" viewBox="-0.5 -0.5 1636 923">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-0.5 -0.5 1636 923">
     <a xlink:href="https://www.w3.org/2018/credentials#verifiableCredential">
-        <rect width="171" height="27.21" x="167" y="604.7" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="172" y="604.7" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:618px;margin-left:168px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:618px;margin-left:173px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -15,14 +15,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="253" y="623" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="258" y="623" font-family="Helvetica" font-size="16" text-anchor="middle">verifiableCredential</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredential">
-        <ellipse cx="446" cy="40.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="451" cy="40.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:41px;margin-left:338px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:41px;margin-left:343px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -34,14 +34,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="446" y="45" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredential</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="451" y="45" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredential</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#JsonSchemaCredential">
-        <ellipse cx="166" cy="160.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="171" cy="160.65" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:161px;margin-left:58px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:161px;margin-left:63px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -53,14 +53,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="166" y="165" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchemaCredential</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="171" y="165" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchemaCredential</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#VerifiablePresentation">
-        <ellipse cx="442" cy="778.89" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="447" cy="778.89" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:779px;margin-left:334px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:779px;margin-left:339px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -72,20 +72,20 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="442" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiablePresentation</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="447" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiablePresentation</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M166 141.05q41-64.03 161.62-97.82" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m334.85 41.21-8.28 7.51 1.05-5.49-3.75-4.14Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M252.5 604.7v-95.74" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m252.5 501.46 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M333 778.89q-76-85.63-79.79-137.27" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m252.66 634.15 5.72 9.6-5.17-2.13-4.8 2.86Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M171 141.05q41-64.03 161.62-97.82" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m339.85 41.21-8.28 7.51 1.05-5.49-3.75-4.14Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M257.5 604.7v-95.74" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m257.5 501.46 5 10-5-2.5-5 2.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M338 778.89q-76-85.63-79.79-137.27" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m257.66 634.15 5.72 9.6-5.17-2.13-4.8 2.86Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#VerifiableCredentialGraph">
-        <ellipse cx="252.5" cy="479.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="257.5" cy="479.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:480px;margin-left:145px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:480px;margin-left:150px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -97,16 +97,16 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="253" y="484" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredentialGraph</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="258" y="484" font-family="Helvetica" font-size="16" text-anchor="middle">VerifiableCredentialGraph</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 460Q328 260 365.88 63.81" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m367.3 56.45 1.38 10.45-2.8-3.09-3.75 1.82Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M257.5 460Q333 260 370.88 63.81" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m372.3 56.45 1.38 10.45-2.8-3.09-3.75 1.82Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#credentialSchema">
-        <rect width="171" height="27.21" x="737" y="85.02" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="85.02" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:99px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:99px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -118,14 +118,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSchema</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSchema</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#credentialStatus">
-        <rect width="171" height="27.21" x="737" y="142" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="142" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:156px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:156px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -137,14 +137,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">credentialStatus</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#credentialSubject">
-        <rect width="171" height="27.21" x="737" y="198" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="198" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:212px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:212px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -156,14 +156,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="216" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="216" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#issuer">
-        <rect width="171" height="27.21" x="737" y="255" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="255" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:269px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:269px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -175,14 +175,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="273" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="273" font-family="Helvetica" font-size="16" text-anchor="middle">issuer</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#evidence">
-        <rect width="171" height="27.21" x="737" y="368" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="368" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:382px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:382px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -194,14 +194,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">evidence</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#refreshService">
-        <rect width="171" height="27.21" x="737" y="425" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="425" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:439px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:439px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -213,14 +213,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="443" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="443" font-family="Helvetica" font-size="16" text-anchor="middle">refreshService</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#renderMethod">
-        <rect width="171" height="27.21" x="737" y="482" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="482" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:496px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:496px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -232,14 +232,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="500" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="500" font-family="Helvetica" font-size="16" text-anchor="middle">renderMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#confidenceMethod">
-        <rect width="171" height="27.21" x="737" y="539" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="539" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:553px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:553px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -251,14 +251,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">confidenceMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#termsOfUse">
-        <rect width="171" height="27.21" x="737" y="595" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="595" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:609px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:609px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -270,14 +270,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">termsOfUse</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#validFrom">
-        <rect width="171" height="27.21" x="737" y="652" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="652" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:666px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:666px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -289,14 +289,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="670" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="670" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#validUntil">
-        <rect width="171" height="27.21" x="737" y="709" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="709" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:723px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:723px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -308,14 +308,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="727" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="727" font-family="Helvetica" font-size="16" text-anchor="middle">validUntil</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#holder">
-        <rect width="171" height="27.21" x="737" y="765.29" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="765.29" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:779px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:779px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -327,43 +327,43 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">holder</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">holder</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 778.89H551" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 778.89-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 98.66Q628 99 567.5 100.02 507 101.03 446 60.22" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 98.64-9.98 5.03 2.48-5.01-2.51-4.99Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M727.26 155.69Q471 157.85 446 60.22" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 155.62-9.95 5.09 2.45-5.02-2.54-4.98Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 144.85 281.27 151.12" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 211.54-10.13 4.73 2.64-4.93-2.37-5.07Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q41 168.86 281.38 206.86" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.79 268.26-10.66 3.37 3.25-4.55-1.69-5.32Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q21 192.87 282.21 317.2" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.98 380.64-11.18.22 4.41-3.44-.11-5.59Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q11 224.88 282.46 373.7" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.04 437.53-11.17-.42 4.59-3.19.21-5.58Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-9 256.89 282.63 430.41" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.08 494.46-11.15-.81 4.7-3.02.41-5.58Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q-29 256.89 283.16 486.61" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m735.2 551.28-11.02-1.9 4.98-2.55.95-5.5Z" pointer-events="all"/>
-    <circle cx="552" cy="662" r="5" fill="#c00" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M442 759.28q46-69.28 100.84-88.99" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m549.9 667.76-7.72 8.08.66-5.55-4.05-3.86Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22Q408 350 547.87 648.19" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m551.05 654.98-8.77-6.93 5.59.14 3.46-4.39Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m557 662 170.27 3.41" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 665.56-10.09 4.8 2.6-4.95-2.4-5.05Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q91-52 170.27-53.24" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.76 608.64-9.92 5.16 2.43-5.04-2.58-4.96Z" pointer-events="all"/>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M557 662q81 48 170.34 59.38" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.78 722.32-10.55 3.7 3.11-4.64-1.85-5.28Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M732.26 778.89H556" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.76 778.89-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M732.26 98.66Q633 99 572.5 100.02 512 101.03 451 60.22" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.76 98.64-9.98 5.03 2.48-5.01-2.51-4.99Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M732.26 155.69Q476 157.85 451 60.22" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.76 155.62-9.95 5.09 2.45-5.02-2.54-4.98Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q51 144.85 281.27 151.12" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.76 211.54-10.13 4.73 2.64-4.93-2.37-5.07Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q41 168.86 281.38 206.86" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.79 268.26-10.66 3.37 3.25-4.55-1.69-5.32Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q21 192.87 282.21 317.2" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.98 380.64-11.18.22 4.41-3.44-.11-5.59Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q11 224.88 282.46 373.7" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m740.04 437.53-11.17-.42 4.59-3.19.21-5.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q-9 256.89 282.63 430.41" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m740.08 494.46-11.15-.81 4.7-3.02.41-5.58Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q-29 256.89 283.16 486.61" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m740.2 551.28-11.02-1.9 4.98-2.55.95-5.5Z" pointer-events="all"/>
+    <circle cx="557" cy="662" r="5" fill="#c00" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M447 759.28q46-69.28 100.84-88.99" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m554.9 667.76-7.72 8.08.66-5.55-4.05-3.86Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22Q413 350 552.87 648.19" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m556.05 654.98-8.77-6.93 5.59.14 3.46-4.39Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m562 662 170.27 3.41" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.76 665.56-10.09 4.8 2.6-4.95-2.4-5.05Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M562 662q91-52 170.27-53.24" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.76 608.64-9.92 5.16 2.43-5.04-2.58-4.96Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M562 662q81 48 170.34 59.38" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.78 722.32-10.55 3.7 3.11-4.64-1.85-5.28Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#RenderMethod">
-        <ellipse cx="1136" cy="495.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="495.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:496px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:496px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -375,14 +375,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="500" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="500" font-family="Helvetica" font-size="16" text-anchor="middle">RenderMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#CredentialEvidence">
-        <ellipse cx="1136" cy="381.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="381.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:382px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:382px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -394,14 +394,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="386" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialEvidence</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#RefreshService">
-        <ellipse cx="1136" cy="438.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="438.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:439px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:439px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -413,14 +413,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="443" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="443" font-family="Helvetica" font-size="16" text-anchor="middle">RefreshService</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#ConfidenceMethod">
-        <ellipse cx="1136" cy="552.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="552.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:553px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:553px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -432,14 +432,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="557" font-family="Helvetica" font-size="16" text-anchor="middle">ConfidenceMethod</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#TermsOfUse">
-        <ellipse cx="1136" cy="608.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="608.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:609px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:609px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -451,14 +451,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="613" font-family="Helvetica" font-size="16" text-anchor="middle">TermsOfUse</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#CredentialSchema">
-        <ellipse cx="1136" cy="98.63" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="98.63" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:99px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:99px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -470,14 +470,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialSchema</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="103" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialSchema</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#CredentialStatus">
-        <ellipse cx="1136" cy="155.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1141" cy="155.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:156px;margin-left:1028px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:156px;margin-left:1033px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -489,28 +489,28 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1136" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialStatus</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1141" y="160" font-family="Helvetica" font-size="16" text-anchor="middle">CredentialStatus</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 98.63h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 98.63-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 155.61h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 155.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 381.61h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 381.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 438.61h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 438.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 495.61h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 495.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 552.61h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 552.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M908 608.61h109.26" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1024.76 608.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 98.63h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 98.63-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 155.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 155.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 381.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 381.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 438.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 438.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 495.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 495.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 552.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 552.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="M913 608.61h109.26" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1029.76 608.61-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#JsonSchema">
-        <ellipse cx="1496" cy="177.46" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+        <ellipse cx="1501" cy="177.46" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:177px;margin-left:1388px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:177px;margin-left:1393px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -522,16 +522,16 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1496" y="182" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchema</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1501" y="182" font-family="Helvetica" font-size="16" text-anchor="middle">JsonSchema</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1496 157.85q-89-64.82-241.27-59.56" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1247.23 98.55 9.83-5.34-2.33 5.08 2.67 4.91Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1501 157.85q-89-64.82-241.27-59.56" pointer-events="stroke"/>
+    <path stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m1252.23 98.55 9.83-5.34-2.33 5.08 2.67 4.91Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#credentialSubject">
-        <rect width="171" height="27.21" x="1410.5" y="270" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="1415.5" y="270" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:284px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:284px;margin-left:1417px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -543,15 +543,15 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1496" y="288" font-family="Helvetica" font-size="16" text-anchor="middle">jsonSchema</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1501" y="288" font-family="Helvetica" font-size="16" text-anchor="middle">jsonSchema</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1498 200-1.72 60.27" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1496.06 267.76-4.71-10.14 4.93 2.65 5.07-2.36Z" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 365h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="m1503 200-1.72 60.27" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m1501.06 267.76-4.71-10.14 4.93 2.65 5.07-2.36Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1447 365h109.37l20 14.35-20 14.36H1447l-20-14.36Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:379px;margin-left:1423px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:379px;margin-left:1428px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <font color="#000">
@@ -561,15 +561,15 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="1497" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="1502" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">rdf:JSON</text>
     </switch>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 297.21.59 58.05" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1501 297.21.59 58.05" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1501.66 362.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#relatedResource">
-        <rect width="171" height="27.21" x="737" y="312" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="742" y="312" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:326px;margin-left:738px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:326px;margin-left:743px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -581,16 +581,16 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="823" y="330" font-family="Helvetica" font-size="16" text-anchor="middle">relatedResource</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="828" y="330" font-family="Helvetica" font-size="16" text-anchor="middle">relatedResource</text>
         </switch>
     </a>
-    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M446 60.22q51 178.86 281.84 262.08" pointer-events="stroke"/>
-    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m734.9 324.85-11.11 1.31 4.05-3.86-.66-5.55Z" pointer-events="all"/>
+    <path fill="none" stroke="#c00" stroke-dasharray="10 4 4 4" stroke-miterlimit="10" stroke-width="2" d="M451 60.22q51 178.86 281.84 262.08" pointer-events="stroke"/>
+    <path fill="#c00" stroke="#c00" stroke-miterlimit="10" stroke-width="2" d="m739.9 324.85-11.11 1.31 4.05-3.86-.66-5.55Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#digestSRI">
-        <rect width="171" height="27.21" x="1410.5" y="481" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+        <rect width="171" height="27.21" x="1415.5" y="481" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:495px;margin-left:1412px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:495px;margin-left:1417px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -602,14 +602,14 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1496" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">digestSRI</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1501" y="499" font-family="Helvetica" font-size="16" text-anchor="middle">digestSRI</text>
         </switch>
     </a>
     <a xlink:href="https://www.w3.org/2018/credentials#sriString">
-        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1442 576h109.37l20 14.35-20 14.36H1442l-20-14.36Z" pointer-events="all"/>
+        <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="M1447 576h109.37l20 14.35-20 14.36H1447l-20-14.36Z" pointer-events="all"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:590px;margin-left:1423px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:147px;height:1px;padding-top:590px;margin-left:1428px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <font color="#000">
@@ -619,16 +619,16 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="1497" y="595" font-family="Helvetica" font-size="16" text-anchor="middle">sriString</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="1502" y="595" font-family="Helvetica" font-size="16" text-anchor="middle">sriString</text>
         </switch>
     </a>
-    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1496 508.21.59 58.05" pointer-events="stroke"/>
-    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1496.66 573.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
+    <path fill="none" stroke="#009" stroke-dasharray="6 6" stroke-miterlimit="10" stroke-width="2" d="m1501 508.21.59 58.05" pointer-events="stroke"/>
+    <path fill="#009" stroke="#009" stroke-miterlimit="10" stroke-width="2" d="m1501.66 573.76-5.1-9.94 5.03 2.44 4.97-2.55Z" pointer-events="all"/>
     <a xlink:href="https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential">
-        <ellipse cx="166" cy="291.39" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="125" ry="19.61"/>
+        <ellipse cx="171" cy="291.39" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="125" ry="19.61"/>
         <switch transform="translate(-.5 -.5)">
             <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:248px;height:1px;padding-top:291px;margin-left:42px">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:248px;height:1px;padding-top:291px;margin-left:47px">
                     <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                         <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                             <i>
@@ -640,11 +640,11 @@
                     </div>
                 </div>
             </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="166" y="296" font-family="Helvetica" font-size="16" text-anchor="middle">EnvelopedVerifiableCredential</text>
+            <text xmlns="http://www.w3.org/2000/svg" x="171" y="296" font-family="Helvetica" font-size="16" text-anchor="middle">EnvelopedVerifiableCredential</text>
         </switch>
     </a>
-    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M252.5 460q-54.5-70-82.84-139.98" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m166.84 313.07 6.84 8.02-4.02-1.07-2.16 3.57Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-dasharray="2 8" stroke-miterlimit="10" stroke-width="2" d="M257.5 460q-54.5-70-82.84-139.98" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="2" d="m171.84 313.07 6.84 8.02-4.02-1.07-2.16 3.57Z" pointer-events="all"/>
     <rect width="1595" height="54.5" x="20" y="848" fill="none"/>
     <rect width="1595" height="54.5" x="20" y="848" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all"/>
     <rect width="163.4" height="40" x="745" y="855.64" fill="none"/>
@@ -797,4 +797,23 @@
         </foreignObject>
         <text xmlns="http://www.w3.org/2000/svg" x="1486" y="871" font-family="Helvetica" font-size="16" text-anchor="middle">Graph con...</text>
     </switch>
+    <a xlink:href="https://www.w3.org/2018/credentials#EnvelopedVerifiablePresentation">
+        <ellipse cx="163.5" cy="778.89" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="128.5" ry="19.61"/>
+        <switch transform="translate(-.5 -.5)">
+            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:255px;height:1px;padding-top:779px;margin-left:36px">
+                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                            <i>
+                                <font color="#000">
+                                    EnvelopedVerifiablePresentation
+                                </font>
+                            </i>
+                        </div>
+                    </div>
+                </div>
+            </foreignObject>
+            <text xmlns="http://www.w3.org/2000/svg" x="164" y="784" font-family="Helvetica" font-size="16" text-anchor="middle">EnvelopedVerifiablePresentation</text>
+        </switch>
+    </a>
 </svg>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -39,6 +39,9 @@ class:
   - id: EnvelopedVerifiableCredential
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiableCredential
 
+  - id: EnvelopedVerifiablePresentation
+    defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-EnvelopedVerifiablePresentation
+
   - id: JsonSchema
     label: JSON schema validator
     defined_by: https://www.w3.org/TR/vc-json-schema/#jsonschema


### PR DESCRIPTION
This PR is an attempt to address issue #1431 by adding a way of expressing an enveloped verifiable presentation.

/cc @christophera


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1453.html" title="Last updated on Mar 9, 2024, 4:40 PM UTC (2cf9040)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1453/64cf5b1...2cf9040.html" title="Last updated on Mar 9, 2024, 4:40 PM UTC (2cf9040)">Diff</a>