### PR TITLE
Updating the text on vocabulary hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6872,7 +6872,7 @@ following vocabulary URLs used in the base context ultimately resolve to the
 following files when loading the JSON-LD serializations, which are normative. Other semantically equivalent
 serializations of the vocabulary files MAY be used by implementations.
 Cryptographic hashes are provided for all the JSON-LD content to ensure that developers can
-verify that the contents of each file are correct.
+verify that the content of each file is correct.
         </p>
 
         <table class="simple">

--- a/index.html
+++ b/index.html
@@ -6910,9 +6910,9 @@ e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
 
         <p>
 It is possible to confirm the cryptographic digests listed above by running 
-a command like the following (replacing `<DOCUMENT_URL>` and `<DIGEST_ALGORITHM>`
+a command like the following (replacing `&lt;DOCUMENT_URL>` and `&lt;DIGEST_ALGORITHM>`
 with appropriate values) through a modern UNIX-like OS command line interface:
-`curl -sL -H "Accept: application/ld+json" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
+`curl -sL -H "Accept: application/ld+json" &lt;DOCUMENT_URL> | openssl dgst -&lt;DIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
         </p>
 
         <p class="note"

--- a/index.html
+++ b/index.html
@@ -6869,24 +6869,23 @@ implementer feedback that requires the referenced URLs to be modified.
         <p>
 Implementations that depend on RDF vocabulary processing MUST ensure that the
 following vocabulary URLs used in the base context ultimately resolve to the
-following files, which are normative. Other semantically equivalent
+following files when loading the JSON-LD serializations, which are normative. Other semantically equivalent
 serializations of the vocabulary files MAY be used by implementations.
-Cryptographic hashes are provided for all content to ensure that developers can
+Cryptographic hashes are provided for all the JSON-LD contents to ensure that developers can
 verify that the contents of each file are correct.
         </p>
 
         <table class="simple">
           <thead>
             <tr>
-              <th>URL and Media Type</th>
-              <th>Content and Hashes</th>
+              <th>URL</th>
+              <th>JSON-LD Content and Hashes</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td>
-https://www.w3.org/2018/credentials#<br>
-`application/ld+json`
+https://www.w3.org/2018/credentials#
               </td>
               <td>
 https://www.w3.org/2018/credentials/index.jsonld<br><br>
@@ -6897,8 +6896,7 @@ h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==</code>
             </tr>
             <tr>
               <td>
-https://w3id.org/security#<br>
-`application/ld+json`
+https://w3id.org/security#
               </td>
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
@@ -6913,7 +6911,7 @@ e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
         <p>
 It is possible to confirm the cryptographic digests listed above by running the
 following command from a modern Unix command interface line:
-`curl -sL -H "Accept: &lt;MEDIA_TYPE>" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
+`curl -sL -H "Accept: application/ld+json" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
         </p>
 
         <p class="note"

--- a/index.html
+++ b/index.html
@@ -6871,7 +6871,7 @@ Implementations that depend on RDF vocabulary processing MUST ensure that the
 following vocabulary URLs used in the base context ultimately resolve to the
 following files when loading the JSON-LD serializations, which are normative. Other semantically equivalent
 serializations of the vocabulary files MAY be used by implementations.
-Cryptographic hashes are provided for all the JSON-LD contents to ensure that developers can
+Cryptographic hashes are provided for all the JSON-LD content to ensure that developers can
 verify that the contents of each file are correct.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -6909,8 +6909,9 @@ e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
         </table>
 
         <p>
-It is possible to confirm the cryptographic digests listed above by running the
-following command from a modern Unix command interface line:
+It is possible to confirm the cryptographic digests listed above by running 
+a command like the following (replacing `<DOCUMENT_URL>` and `<DIGEST_ALGORITHM>`
+with appropriate values) through a modern UNIX-like OS command line interface:
 `curl -sL -H "Accept: application/ld+json" &lt;DOCUMENT_URL> | openssl dgst -&ltDIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
         </p>
 


### PR DESCRIPTION
This is to handle #1442. It makes it clearer that all references are on JSON-LD.

Two notes for the future:

- If this PR is accepted and merged, a similar change should be done for the [DI spec's corresponding tables](https://www.w3.org/TR/vc-data-integrity/#contexts-and-vocabularies) for consistency (including the typesetting style for the hash values).
- _When going to Proposed REC_, the URL for the JSON-LD versions _must_ be changed in the text to use the final URL on W3C Date Space.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1454.html" title="Last updated on Mar 13, 2024, 7:21 AM UTC (3912181)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1454/64cf5b1...3912181.html" title="Last updated on Mar 13, 2024, 7:21 AM UTC (3912181)">Diff</a>