### PR TITLE
(Editorial) Created a new version for several diagrams 

### DIFF
--- a/diagrams/claim-example-2.drawio
+++ b/diagrams/claim-example-2.drawio
@@ -1,0 +1,31 @@
+<mxfile host="Electron" modified="2024-03-12T16:09:23.578Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="mi4guVrgRldrTKaDrCUm" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Pat&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-4">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-930" y="-449.61" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;21&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-12">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-510" y="-450" width="70" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="I-3xDNqU13IutiKupr62-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" source="I-3xDNqU13IutiKupr62-4" target="I-3xDNqU13IutiKupr62-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-694" y="-134.61" as="sourcePoint" />
+            <mxPoint x="-681.5" y="-85.61" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-28" value="&amp;nbsp;overAge&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-27" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint x="-22" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/claim-example-2.svg
+++ b/diagrams/claim-example-2.svg
@@ -1,29 +1,52 @@
-<svg version="1.1" fill="none" viewBox="0 0 225 50"
-    xmlns="http://www.w3.org/2000/svg">
-    <title>A simple example claim</title>
-    <desc>
-A subject, called "Pat", has a property "ageOver", with the value
-"21". The intended meaning is that Pat is over the age of 21.
-    </desc>
-    <defs>
-      <style><![CDATA[
-          rect, ellipse {stroke-width: 1;stroke: #000}
-          .literal {font-family: serif}
-          line {stroke: #000;stroke-width: 2;marker-end: url(#arrow)}
-          text {fill: #000;font-size: 10px;font-family: sans-serif}
-          #background {stroke: none;fill: #fff;width:100%;height:100%}
-      ]]></style>
-      <marker id="arrow" viewBox="0 0 6 4" refX="4" refY="2" fill="#000"
-          markerWidth="6" markerHeight="4" orient="auto">
-          <path d="M0 0v4l6 -2z" />
-      </marker>
-    </defs>
-<rect id="background"/>
-
-    <ellipse fill="#acf" rx="44" ry="20" cx="60" cy="25" />
-    <text x="40" y="24" transform="scale(1.25)">Pat</text>
-    <line x1="104" y1="25" x2="180" y2="25" />
-    <text x="120" y="20">overAge</text>
-    <rect x="185" y="12" width="25" height="25" fill="#fe9" />
-    <text class="literal" x="192" y="28">21</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 532 82">
+    <ellipse cx="94.5" cy="41" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:41px;margin-left:22px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Pat
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="95" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
+    </switch>
+    <rect width="70" height="40" x="441" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:68px;height:1px;padding-top:41px;margin-left:442px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                21
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="476" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">21</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M168 41h263.26" pointer-events="stroke"/>
+        <path d="m438.76 41-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:39px;margin-left:302px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        overAge
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="302" y="43" font-family="Helvetica" font-size="16" text-anchor="middle"> overAge </text>
+    </switch>
 </svg>

--- a/diagrams/claim-example.drawio
+++ b/diagrams/claim-example.drawio
@@ -1,0 +1,31 @@
+<mxfile host="Electron" modified="2024-03-12T16:07:40.629Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="MytOyN8ivGb5ZmKrL98e" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Pat&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-4">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-930" y="-449.61" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example University&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-12">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-510" y="-450" width="150" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="I-3xDNqU13IutiKupr62-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" source="I-3xDNqU13IutiKupr62-4" target="I-3xDNqU13IutiKupr62-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-694" y="-134.61" as="sourcePoint" />
+            <mxPoint x="-681.5" y="-85.61" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-28" value="&amp;nbsp;alumniOf&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-27" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint x="-10" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/claim-example.svg
+++ b/diagrams/claim-example.svg
@@ -1,29 +1,52 @@
-<svg version="1.1" fill="none" viewBox="0 0 300 50"
-    xmlns="http://www.w3.org/2000/svg">
-    <title>A simple example claim</title>
-    <desc>
-A subject, called "Pat", has a property "alumniOf", with the value "Example
-University". The claim expressed is that Pat attended the famous "Example U".
-    </desc>
-    <defs>
-      <style><![CDATA[
-          rect, ellipse {stroke-width: 1;stroke: #000}
-          .literal {font-family: serif}
-          line {stroke: #000;stroke-width: 2;marker-end: url(#arrow)}
-          text {fill: #000;font-size: 10px;font-family: sans-serif}
-          #background {stroke: none;fill: #fff;width:100%;height:100%}
-      ]]></style>
-        <marker id="arrow" viewBox="0 0 6 4" refX="4" refY="2" fill="#000"
-            markerWidth="6" markerHeight="4" orient="auto">
-            <path d="M0 0v4l6 -2z" />
-        </marker>
-    </defs>
-    <rect id="background"/>
-
-    <ellipse fill="#acf" rx="44" ry="20" cx="60" cy="25" />
-    <text x="40" y="24" transform="scale(1.25)">Pat</text>
-    <line x1="105" y1="25" x2="180" y2="25" />
-    <text x="110" y="20">alumniOf</text>
-    <rect x="185" y="15" width="110" height="25" fill="#fe9" />
-    <text class="literal" x="200" y="30">Example University</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 612 82">
+    <ellipse cx="94.5" cy="41" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:41px;margin-left:22px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Pat
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="95" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
+    </switch>
+    <rect width="150" height="40" x="441" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:41px;margin-left:442px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example University
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="516" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Example University</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M168 41h263.26" pointer-events="stroke"/>
+        <path d="m438.76 41-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:39px;margin-left:314px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        alumniOf
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="314" y="43" font-family="Helvetica" font-size="16" text-anchor="middle"> alumniOf </text>
+    </switch>
 </svg>

--- a/diagrams/claim-extended.drawio
+++ b/diagrams/claim-extended.drawio
@@ -1,0 +1,63 @@
+<mxfile host="Electron" modified="2024-03-12T16:16:00.307Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="YDH9rix6KHnz6TjrjhUz" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Pat&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-4">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-930" y="-449.61" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Example University&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-12">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-510" y="-450" width="150" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="I-3xDNqU13IutiKupr62-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-782.9999999999995" y="-430.0000000000002" as="sourcePoint" />
+            <mxPoint x="-510" y="-430" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-28" value="&amp;nbsp; alumniOf&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-27" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint x="-10" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Sam&lt;/font&gt;&lt;/i&gt;" id="0RvG0JXg9gKrVT7jjSYo-1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" vertex="1" parent="1">
+            <mxGeometry x="-750" y="-340" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Professor&lt;/font&gt;&lt;/i&gt;" id="0RvG0JXg9gKrVT7jjSYo-2">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+            <mxGeometry x="-440" y="-340.78" width="150" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="0RvG0JXg9gKrVT7jjSYo-3" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1" source="0RvG0JXg9gKrVT7jjSYo-1" target="0RvG0JXg9gKrVT7jjSYo-2">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-584" y="-310" as="sourcePoint" />
+            <mxPoint x="-460" y="-330" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0RvG0JXg9gKrVT7jjSYo-4" value="&amp;nbsp; jobTitle&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" vertex="1" connectable="0" parent="0RvG0JXg9gKrVT7jjSYo-3">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint x="-9" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0RvG0JXg9gKrVT7jjSYo-5" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" edge="1" parent="1" source="I-3xDNqU13IutiKupr62-4" target="0RvG0JXg9gKrVT7jjSYo-1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-830" y="-250" as="sourcePoint" />
+            <mxPoint x="-557" y="-250" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="0RvG0JXg9gKrVT7jjSYo-6" value="&amp;nbsp;knows&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" vertex="1" connectable="0" parent="0RvG0JXg9gKrVT7jjSYo-5">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint x="-1" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/claim-extended.svg
+++ b/diagrams/claim-extended.svg
@@ -1,46 +1,118 @@
-<svg version="1.1" fill="none" viewBox="0 0 400 100" xmlns="http://www.w3.org/2000/svg">
-<title>An extended example claim</title>
-<desc>
-A subject, called "Pat", has a property "alumniOf", with the value
-"Example University", and a property "knows" whose value is the subject "Sam".
-"Sam" has a property "jobTitle", whose value is "Professor".
-The claim expressed is that Pat attended the famous "Example U",
-and that he knows "Sam", whose title is "Professor".
-</desc>
-    <defs>
-      <style><![CDATA[
-          rect, ellipse {stroke-width: 1;stroke: #000}
-          .literal {font-family: serif}
-          line {stroke: #000;stroke-width: 2;marker-end: url(#arrow)}
-          text {fill: #000;font-size: 10px;font-family: sans-serif}
-          #background {stroke: none;fill: #fff;width:100%;height:100%}
-      ]]></style>
-        <marker id="arrow" viewBox="0 0 6 4" refX="4" refY="2" fill="#000"
-            markerWidth="6" markerHeight="4" orient="auto">
-            <path d="M0 0v4l6 -2z" />
-        </marker>
-        <path id="knowsPath" d="M95 40l60 25" />
-    </defs>
-    <rect id="background"/>
-
-    <ellipse fill="#acf" rx="44" ry="20" cx="60" cy="25" />
-    <text x="40" y="24" transform="scale(1.25)">Pat</text>
-    <line x1="105" y1="25" x2="180" y2="25" />
-    <text x="110" y="20">alumniOf</text>
-    <rect x="185" y="15" width="110" height="25" fill="#fe9" />
-    <text class="literal" x="200" y="30">Example University</text>
-    <line x1="90" y1="40" x2="150" y2="65" />
-    <text>
-        <textPath href="#knowsPath">
-            <tspan dx="10">knows</tspan>
-        </textPath>
-    </text>
-    <g>
-        <ellipse fill="#acf" rx="45" ry="20" cx="200" cy="70" />
-        <text x="150" y="60" transform="scale(1.25)">Sam</text>
-        <line x1="247" y1="70" x2="290" y2="70" />
-        <text x="250" y="65">jobTitle</text>
-        <rect x="295" y="55" width="50" height="25" fill="#fe9" />
-        <text class="literal" x="300" y="70">Professor</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 682 192">
+    <ellipse cx="94.5" cy="41" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:41px;margin-left:22px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Pat
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="95" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
+    </switch>
+    <rect width="150" height="40" x="441" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:41px;margin-left:442px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Example University
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="516" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Example University</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M168 41h263.26" pointer-events="stroke"/>
+        <path d="m438.76 41-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
     </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:39px;margin-left:314px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        alumniOf
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="314" y="43" font-family="Helvetica" font-size="16" text-anchor="middle">  alumniOf  </text>
+    </switch>
+    <ellipse cx="274.5" cy="150.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:151px;margin-left:202px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Sam
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="275" y="155" font-family="Helvetica" font-size="16" text-anchor="middle">Sam</text>
+    </switch>
+    <rect width="150" height="40" x="511" y="130.22" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:150px;margin-left:512px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Professor
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="586" y="155" font-family="Helvetica" font-size="16" text-anchor="middle">Professor</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m348 150.61 153.26-.37" pointer-events="stroke"/>
+        <path d="m508.76 150.23-9.98 5.02 2.48-5.01-2.51-4.99Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:148px;margin-left:432px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        jobTitle
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="432" y="153" font-family="Helvetica" font-size="16" text-anchor="middle">  jobTitle  </text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m94.5 60.61 99.06 83.72" pointer-events="stroke"/>
+        <path d="m199.29 149.17-10.86-2.64 5.13-2.2 1.32-5.44Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:109px;margin-left:153px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        knows
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="153" y="113" font-family="Helvetica" font-size="16" text-anchor="middle"> knows </text>
+    </switch>
 </svg>

--- a/diagrams/claim.drawio
+++ b/diagrams/claim.drawio
@@ -1,0 +1,31 @@
+<mxfile host="Electron" modified="2024-03-12T16:02:46.288Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="UftCXAJBqIPXLlsHPOsS" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Subject&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-4">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
+            <mxGeometry x="-930" y="-449.61" width="147" height="39.22" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;Value&lt;/font&gt;&lt;/i&gt;" id="I-3xDNqU13IutiKupr62-12">
+          <mxCell style="rounded=0;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
+            <mxGeometry x="-510" y="-450" width="140" height="40" as="geometry" />
+          </mxCell>
+        </UserObject>
+        <mxCell id="I-3xDNqU13IutiKupr62-27" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" source="I-3xDNqU13IutiKupr62-4" target="I-3xDNqU13IutiKupr62-12" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-694" y="-134.61" as="sourcePoint" />
+            <mxPoint x="-681.5" y="-85.61" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-28" value="&amp;nbsp;Property&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-27" vertex="1" connectable="0">
+          <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
+            <mxPoint x="-10" y="-5" as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/claim.svg
+++ b/diagrams/claim.svg
@@ -1,26 +1,3 @@
-<svg version="1.1" fill="none" viewBox="0 0 300 50"
-    xmlns="http://www.w3.org/2000/svg">
-    <title>The structure of a claim</title>
-    <desc>A "Subject" has a "Property", with a "Value".</desc>
-    <defs>
-        <style><![CDATA[
-            rect, ellipse {stroke-width: 1;stroke: #000}
-            .literal {font-family: serif}
-            line {stroke: #000;stroke-width: 2;marker-end: url(#arrow)}
-            text {fill: #000;font-size: 10px;font-family: sans-serif}
-            #background {stroke: none;fill: #fff;width:100%;height:100%}
-        ]]></style>
-        <marker id="arrow" viewBox="0 0 6 4" refX="4" refY="2" fill="#000"
-            markerWidth="6" markerHeight="4" orient="auto">
-            <path d="M0 0v4l6 -2z" />
-        </marker>
-    </defs>
-<rect id="background"/>
-
-    <ellipse fill="#acf" rx="44" ry="20" cx="60" cy="25" />
-    <text x="32" y="24" transform="scale(1.25)">Subject</text>
-    <line x1="105" y1="25" x2="180" y2="25" />
-    <text x="120" y="20">Property</text>
-    <rect x="185" y="15" width="110" height="25" fill="#fe9" />
-    <text class="literal" x="220" y="30">Value</text>
-</svg>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="602px" height="82px" viewBox="-0.5 -0.5 602 82"><defs/><g><g><ellipse cx="94.5" cy="41" rx="73.5" ry="19.61" fill="none" stroke="#336600" stroke-width="2" pointer-events="all"/></g><g><g transform="translate(-0.5 -0.5)"><switch><foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 145px; height: 1px; padding-top: 41px; margin-left: 22px;"><div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;"><div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><i><font color="#000000">Subject</font></i></div></div></div></foreignObject><text x="95" y="46" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">Subject</text></switch></g></g><g><rect x="441" y="21" width="140" height="40" fill="none" stroke="rgb(0, 0, 0)" stroke-width="2" pointer-events="all"/></g><g><g transform="translate(-0.5 -0.5)"><switch><foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 41px; margin-left: 442px;"><div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;"><div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><i><font color="#000000">Value</font></i></div></div></div></foreignObject><text x="511" y="46" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">Value</text></switch></g></g><g><path d="M 168 41 Q 168 41 431.26 41" fill="none" stroke="rgb(0, 0, 0)" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/><path d="M 438.76 41 L 428.76 46 L 431.26 41 L 428.76 36 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/></g><g><g transform="translate(-0.5 -0.5)"><switch><foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 39px; margin-left: 314px;"><div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;"><div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;"> Property </div></div></div></foreignObject><text x="314" y="43" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle"> Property </text></switch></g></g></g></svg>

--- a/diagrams/claim.svg
+++ b/diagrams/claim.svg
@@ -1,3 +1,52 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="602px" height="82px" viewBox="-0.5 -0.5 602 82"><defs/><g><g><ellipse cx="94.5" cy="41" rx="73.5" ry="19.61" fill="none" stroke="#336600" stroke-width="2" pointer-events="all"/></g><g><g transform="translate(-0.5 -0.5)"><switch><foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 145px; height: 1px; padding-top: 41px; margin-left: 22px;"><div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;"><div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><i><font color="#000000">Subject</font></i></div></div></div></foreignObject><text x="95" y="46" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">Subject</text></switch></g></g><g><rect x="441" y="21" width="140" height="40" fill="none" stroke="rgb(0, 0, 0)" stroke-width="2" pointer-events="all"/></g><g><g transform="translate(-0.5 -0.5)"><switch><foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 41px; margin-left: 442px;"><div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;"><div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;"><i><font color="#000000">Value</font></i></div></div></div></foreignObject><text x="511" y="46" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle">Value</text></switch></g></g><g><path d="M 168 41 Q 168 41 431.26 41" fill="none" stroke="rgb(0, 0, 0)" stroke-width="2" stroke-miterlimit="10" pointer-events="stroke"/><path d="M 438.76 41 L 428.76 46 L 431.26 41 L 428.76 36 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/></g><g><g transform="translate(-0.5 -0.5)"><switch><foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;"><div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 39px; margin-left: 314px;"><div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;"><div style="display: inline-block; font-size: 16px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;"> Property </div></div></div></foreignObject><text x="314" y="43" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="16px" text-anchor="middle"> Property </text></switch></g></g></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 602 82">
+    <ellipse cx="94.5" cy="41" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:41px;margin-left:22px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Subject
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="95" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Subject</text>
+    </switch>
+    <rect width="140" height="40" x="441" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:41px;margin-left:442px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <font color="#000">
+                                Value
+                            </font>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="511" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Value</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M168 41h263.26" pointer-events="stroke"/>
+        <path d="m438.76 41-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:39px;margin-left:314px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Property
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="314" y="43" font-family="Helvetica" font-size="16" text-anchor="middle"> Property </text>
+    </switch>
+</svg>

--- a/diagrams/ecosystem.drawio
+++ b/diagrams/ecosystem.drawio
@@ -1,0 +1,89 @@
+<mxfile host="Electron" modified="2024-03-12T15:55:35.963Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="g-GSf0Bf5x1TNweZP27z" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="I-3xDNqU13IutiKupr62-62" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="CqYlGcgU1QHX9f7NfkNa-4" target="CqYlGcgU1QHX9f7NfkNa-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-810" y="-819.39" as="sourcePoint" />
+            <mxPoint x="-655.5" y="-679.39" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-63" value="Register Identifiers&lt;div&gt;and use Schemas&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-62" vertex="1" connectable="0">
+          <mxGeometry x="-0.1786" y="-1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1060" y="-519" as="sourcePoint" />
+            <mxPoint x="-1060" y="-519" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;&lt;b&gt;Verifiable Data Registry&lt;/b&gt;&lt;/i&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Maintains identifiers and schemas&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="-723.5" y="-440" width="354" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-4" value="&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;&lt;b&gt;Holder&lt;/b&gt;&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Acquired, stores, presents VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="-622" y="-620" width="151" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-5" value="&lt;div&gt;&lt;span style=&quot;font-size: 16px;&quot;&gt;&lt;b&gt;&lt;i&gt;Verifier&lt;/i&gt;&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Verifies VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="-301" y="-620" width="151" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-6" value="&lt;div&gt;&lt;span style=&quot;font-size: 16px;&quot;&gt;&lt;b&gt;&lt;i&gt;Issuer&lt;/i&gt;&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Issues VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
+          <mxGeometry x="-943" y="-620" width="151" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-7" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=classic;html=1;curved=0;rounded=0;endSize=8;startSize=8;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="CqYlGcgU1QHX9f7NfkNa-6" target="CqYlGcgU1QHX9f7NfkNa-2">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-890" y="-410" as="sourcePoint" />
+            <mxPoint x="-840" y="-460" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-867" y="-480" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-8" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Verify Identifiers&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and use Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-7">
+          <mxGeometry x="-0.6027" y="-1" relative="1" as="geometry">
+            <mxPoint y="-6" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-9" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=classic;html=1;curved=0;rounded=0;endSize=8;startSize=8;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="CqYlGcgU1QHX9f7NfkNa-5" target="CqYlGcgU1QHX9f7NfkNa-2">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-240" y="-510" as="sourcePoint" />
+            <mxPoint x="-86" y="-370" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="-225" y="-470" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-10" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Verify Identifiers&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-9">
+          <mxGeometry x="-0.6027" y="-1" relative="1" as="geometry">
+            <mxPoint y="-7" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-11" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="CqYlGcgU1QHX9f7NfkNa-6" target="CqYlGcgU1QHX9f7NfkNa-4">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-769" y="-580.5" as="sourcePoint" />
+            <mxPoint x="-630" y="-580" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-12" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Issue Credentials&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-11">
+          <mxGeometry x="-0.1789" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-13" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-471" y="-580" as="sourcePoint" />
+            <mxPoint x="-301" y="-580.5" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-14" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Send Presentation&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-13">
+          <mxGeometry x="-0.1789" y="1" relative="1" as="geometry">
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/ecosystem.drawio
+++ b/diagrams/ecosystem.drawio
@@ -1,84 +1,87 @@
-<mxfile host="Electron" modified="2024-03-12T15:55:35.963Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="g-GSf0Bf5x1TNweZP27z" version="24.0.4" type="device">
+<mxfile host="Electron" modified="2024-03-14T08:01:44.817Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="ttzc8Ggs5sIMR0JceH18" version="24.0.4" type="device">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="2584" dy="2099" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="I-3xDNqU13IutiKupr62-62" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="CqYlGcgU1QHX9f7NfkNa-4" target="CqYlGcgU1QHX9f7NfkNa-2" edge="1">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-810" y="-819.39" as="sourcePoint" />
-            <mxPoint x="-655.5" y="-679.39" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="I-3xDNqU13IutiKupr62-63" value="Register Identifiers&lt;div&gt;and use Schemas&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-62" vertex="1" connectable="0">
-          <mxGeometry x="-0.1786" y="-1" relative="1" as="geometry">
-            <mxPoint as="offset" />
-          </mxGeometry>
-        </mxCell>
         <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="-1060" y="-519" as="sourcePoint" />
             <mxPoint x="-1060" y="-519" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;&lt;b&gt;Verifiable Data Registry&lt;/b&gt;&lt;/i&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Maintains identifiers and schemas&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="-723.5" y="-440" width="354" height="60" as="geometry" />
+        <mxCell id="Km3G5aqWlyfif2j-xYPQ-1" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1040" y="-590" width="793" height="240" as="geometry" />
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-4" value="&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;&lt;b&gt;Holder&lt;/b&gt;&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Acquired, stores, presents VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="-622" y="-620" width="151" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-5" value="&lt;div&gt;&lt;span style=&quot;font-size: 16px;&quot;&gt;&lt;b&gt;&lt;i&gt;Verifier&lt;/i&gt;&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Verifies VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="-301" y="-620" width="151" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-6" value="&lt;div&gt;&lt;span style=&quot;font-size: 16px;&quot;&gt;&lt;b&gt;&lt;i&gt;Issuer&lt;/i&gt;&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Issues VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" vertex="1" parent="1">
-          <mxGeometry x="-943" y="-620" width="151" height="70" as="geometry" />
-        </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-7" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=classic;html=1;curved=0;rounded=0;endSize=8;startSize=8;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="CqYlGcgU1QHX9f7NfkNa-6" target="CqYlGcgU1QHX9f7NfkNa-2">
+        <mxCell id="I-3xDNqU13IutiKupr62-62" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;strokeWidth=2;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="Km3G5aqWlyfif2j-xYPQ-1" source="CqYlGcgU1QHX9f7NfkNa-4" target="CqYlGcgU1QHX9f7NfkNa-2" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-890" y="-410" as="sourcePoint" />
-            <mxPoint x="-840" y="-460" as="targetPoint" />
+            <mxPoint x="133" y="-199.39" as="sourcePoint" />
+            <mxPoint x="287.5" y="-59.389999999999986" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-63" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Register Identifiers&lt;/font&gt;&lt;div style=&quot;font-size: 17px;&quot;&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and use Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-62" vertex="1" connectable="0">
+          <mxGeometry x="-0.1786" y="-1" relative="1" as="geometry">
+            <mxPoint y="4" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;&lt;b&gt;Verifiable Data Registry&lt;/b&gt;&lt;/i&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Maintains identifiers and schemas&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" parent="Km3G5aqWlyfif2j-xYPQ-1" vertex="1">
+          <mxGeometry x="219.5" y="180" width="354" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-4" value="&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;&lt;b&gt;Holder&lt;/b&gt;&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Acquired, stores, presents VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" parent="Km3G5aqWlyfif2j-xYPQ-1" vertex="1">
+          <mxGeometry x="321" width="151" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-5" value="&lt;div&gt;&lt;span style=&quot;font-size: 16px;&quot;&gt;&lt;b&gt;&lt;i&gt;Verifier&lt;/i&gt;&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Verifies VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" parent="Km3G5aqWlyfif2j-xYPQ-1" vertex="1">
+          <mxGeometry x="642" width="151" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-6" value="&lt;div&gt;&lt;span style=&quot;font-size: 16px;&quot;&gt;&lt;b&gt;&lt;i&gt;Issuer&lt;/i&gt;&lt;/b&gt;&lt;/span&gt;&lt;/div&gt;&lt;div&gt;&lt;font style=&quot;font-size: 16px;&quot;&gt;&lt;i&gt;Issues VCs&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=2;" parent="Km3G5aqWlyfif2j-xYPQ-1" vertex="1">
+          <mxGeometry width="151" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-7" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=classic;html=1;curved=0;rounded=0;endSize=8;startSize=8;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="Km3G5aqWlyfif2j-xYPQ-1" source="CqYlGcgU1QHX9f7NfkNa-6" target="CqYlGcgU1QHX9f7NfkNa-2" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="53" y="210" as="sourcePoint" />
+            <mxPoint x="103" y="160" as="targetPoint" />
             <Array as="points">
-              <mxPoint x="-867" y="-480" />
+              <mxPoint x="76" y="140" />
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-8" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Verify Identifiers&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and use Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-7">
-          <mxGeometry x="-0.6027" y="-1" relative="1" as="geometry">
-            <mxPoint y="-6" as="offset" />
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-9" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=classic;html=1;curved=0;rounded=0;endSize=8;startSize=8;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" edge="1" parent="1" source="CqYlGcgU1QHX9f7NfkNa-5" target="CqYlGcgU1QHX9f7NfkNa-2">
-          <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-240" y="-510" as="sourcePoint" />
-            <mxPoint x="-86" y="-370" as="targetPoint" />
-            <Array as="points">
-              <mxPoint x="-225" y="-470" />
-            </Array>
-          </mxGeometry>
-        </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-10" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Verify Identifiers&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-9">
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-8" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Verify Identifiers&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and use Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" parent="CqYlGcgU1QHX9f7NfkNa-7" vertex="1" connectable="0">
           <mxGeometry x="-0.6027" y="-1" relative="1" as="geometry">
             <mxPoint y="-7" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-11" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="1" source="CqYlGcgU1QHX9f7NfkNa-6" target="CqYlGcgU1QHX9f7NfkNa-4">
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-9" value="" style="edgeStyle=elbowEdgeStyle;elbow=horizontal;endArrow=classic;html=1;curved=0;rounded=0;endSize=8;startSize=8;fontSize=12;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;strokeWidth=2;" parent="Km3G5aqWlyfif2j-xYPQ-1" source="CqYlGcgU1QHX9f7NfkNa-5" target="CqYlGcgU1QHX9f7NfkNa-2" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-769" y="-580.5" as="sourcePoint" />
-            <mxPoint x="-630" y="-580" as="targetPoint" />
+            <mxPoint x="703" y="110" as="sourcePoint" />
+            <mxPoint x="857" y="250" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="718" y="150" />
+            </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-12" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Issue Credentials&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-11">
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-10" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Verify Identifiers&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 17px;&quot;&gt;and Schemas&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" parent="CqYlGcgU1QHX9f7NfkNa-9" vertex="1" connectable="0">
+          <mxGeometry x="-0.6027" y="-1" relative="1" as="geometry">
+            <mxPoint y="-8" as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-11" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="Km3G5aqWlyfif2j-xYPQ-1" source="CqYlGcgU1QHX9f7NfkNa-6" target="CqYlGcgU1QHX9f7NfkNa-4" edge="1">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="174" y="39.5" as="sourcePoint" />
+            <mxPoint x="313" y="40" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-12" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Issue Credentials&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" parent="CqYlGcgU1QHX9f7NfkNa-11" vertex="1" connectable="0">
           <mxGeometry x="-0.1789" y="1" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-13" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="1">
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-13" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="Km3G5aqWlyfif2j-xYPQ-1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-471" y="-580" as="sourcePoint" />
-            <mxPoint x="-301" y="-580.5" as="targetPoint" />
+            <mxPoint x="472" y="36" as="sourcePoint" />
+            <mxPoint x="642" y="35.5" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-14" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Send Presentation&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-13">
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-14" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Send Presentation&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" parent="CqYlGcgU1QHX9f7NfkNa-13" vertex="1" connectable="0">
           <mxGeometry x="-0.1789" y="1" relative="1" as="geometry">
             <mxPoint as="offset" />
           </mxGeometry>

--- a/diagrams/ecosystem.svg
+++ b/diagrams/ecosystem.svg
@@ -1,27 +1,31 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 961 282">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 864 282">
     <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="M542.5 91v100.26" pointer-events="stroke"/>
-        <path d="m542.5 198.76-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
+        <path fill="none" d="M445.5 91v100.26" pointer-events="stroke"/>
+        <path d="m445.5 198.76-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
     </g>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:137px;margin-left:542px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:141px;margin-left:445px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Register Identifiers
-                        <div>
-                            and use Schemas
+                        <font style="font-size:17px">
+                            Register Identifiers
+                        </font>
+                        <div style="font-size:17px">
+                            <font style="font-size:17px">
+                                and use Schemas
+                            </font>
                         </div>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="542" y="141" font-family="Helvetica" font-size="16" text-anchor="middle">Register Identifiers...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="445" y="145" font-family="Helvetica" font-size="16" text-anchor="middle">Register Identifiers...</text>
     </switch>
-    <rect width="354" height="60" x="365.5" y="201" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="9" ry="9"/>
+    <rect width="354" height="60" x="268.5" y="201" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="9" ry="9"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:352px;height:1px;padding-top:231px;margin-left:367px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:352px;height:1px;padding-top:231px;margin-left:270px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <font style="font-size:16px">
@@ -42,12 +46,12 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="543" y="235" font-family="Helvetica" font-size="12" text-anchor="middle">Verifiable Data Registry...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="446" y="235" font-family="Helvetica" font-size="12" text-anchor="middle">Verifiable Data Registry...</text>
     </switch>
-    <rect width="151" height="70" x="467" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
+    <rect width="151" height="70" x="370" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:468px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:371px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div>
@@ -70,12 +74,12 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="543" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Holder...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="446" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Holder...</text>
     </switch>
-    <rect width="151" height="70" x="788" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
+    <rect width="151" height="70" x="691" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:789px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:692px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div>
@@ -98,12 +102,12 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="864" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Verifier...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="767" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Verifier...</text>
     </switch>
-    <rect width="151" height="70" x="146" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
+    <rect width="151" height="70" x="49" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:147px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:50px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div>
@@ -126,15 +130,15 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="222" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Issuer...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="125" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Issuer...</text>
     </switch>
     <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="m221.5 91 .5 140h133.76" pointer-events="stroke"/>
-        <path d="m363.26 231-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+        <path fill="none" d="m124.5 91 .5 140h133.76" pointer-events="stroke"/>
+        <path d="m266.26 231-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
     </g>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:141px;margin-left:222px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:140px;margin-left:125px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
                         <font style="font-size:17px">
@@ -149,15 +153,15 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="222" y="145" font-family="Helvetica" font-size="12" text-anchor="middle">Verify Identifiers...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="125" y="144" font-family="Helvetica" font-size="12" text-anchor="middle">Verify Identifiers...</text>
     </switch>
     <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="m863.5 91 .5 140H729.24" pointer-events="stroke"/>
-        <path d="m721.74 231 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+        <path fill="none" d="m766.5 91 .5 140H632.24" pointer-events="stroke"/>
+        <path d="m624.74 231 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
     </g>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:141px;margin-left:864px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:140px;margin-left:767px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
                         <font style="font-size:17px">
@@ -172,12 +176,12 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="864" y="145" font-family="Helvetica" font-size="12" text-anchor="middle">Verify Identifiers...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="767" y="144" font-family="Helvetica" font-size="12" text-anchor="middle">Verify Identifiers...</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M297.5 69V43h138.99V32.5L466.5 56l-30.01 23.5V69Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M200.5 69V43h138.99V32.5L369.5 56l-30.01 23.5V69Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:368px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:271px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
                         <font style="font-size:15px">
@@ -187,12 +191,12 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="368" y="59" font-family="Helvetica" font-size="12" text-anchor="middle">Issue Credentials</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="271" y="59" font-family="Helvetica" font-size="12" text-anchor="middle">Issue Credentials</text>
     </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m618.54 74-.08-26 138.99-.41-.03-10.5L787.5 60.5l-29.94 23.59-.03-10.5Z" pointer-events="all"/>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m521.54 70-.08-26 138.99-.41-.03-10.5L690.5 56.5l-29.94 23.59-.03-10.5Z" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:60px;margin-left:688px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:591px">
                 <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
                         <font style="font-size:15px">
@@ -202,6 +206,6 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="688" y="64" font-family="Helvetica" font-size="12" text-anchor="middle">Send Presentation</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="591" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Send Presentation</text>
     </switch>
 </svg>

--- a/diagrams/ecosystem.svg
+++ b/diagrams/ecosystem.svg
@@ -1,53 +1,207 @@
-<?xml version="1.0" standalone="yes"?>
-<svg version="1.1" viewBox="0 -5 735 325" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<defs>
-		<marker id="arrow" viewBox="0 0 6 4" refX="1" refY="2" fill="#000"
-      markerWidth="6" markerHeight="4" orient="auto">
-    <path d="M0 0v4l6 -2z" />
-    </marker>
-		<style><![CDATA[
-			path.register {marker-end: url(#arrow);stroke:#000;stroke-width:3}
-			path.myJob {marker-end: url(#coreArrow);stroke:#000;stroke-width:.5;fill:#def}
-			rect {stroke:#000;stroke-width:2px}
-			rect {fill: #bda}
-			text {fill:#000;font-size:14px;font-family:sans-serif}
-			*[role=heading]{font-size:1.5em;font-weight:bold}
-			.myRole {font-style:italic}
-			#background {width: 100%;height:100%;stroke:none;fill:#fff}
-		]]></style>
-	</defs>
-<rect id="background" y="-5"/>
-
-<rect x="15" width="120" height="90" rx="10"/>
-<text x="41" y="45" role="heading">Issuer</text>
-<text x="40" y="60" class="myRole">Issues VCs</text>
-<path class="myJob" d="m136 35h130v-3l9 13 -9 13v-3h-130z"/>
-  <text x="145" y="50">Issue Credentials</text>
-<path class="register" d="m75 90v160h55"/>
-	<text x="85" y="150">Verify Identifiers
-		<tspan x="85" y="165">and use Schemas</tspan>
-</text>
-
-<rect x="275" width="130" height="90" rx="10"/>
-<text x="305" y="45" role="heading">Holder</text>
-<text x="290" y="60" class="myRole">Acquires, stores,</text>
-<text x="300" y="75" class="myRole">presents VCs</text>
-<path class="myJob" d="m406 35h145v-3l9 13 -9 13v-3h-145z"/>
-  <text x="415" y="50">Send Presentation</text>
-<path class="register" d="m340 90v90"/>
-	<text x="350" y="150">Register Identifiers
-		<tspan x="350" y="165">and use Schemas</tspan>
-</text>
-
-<rect x="560" width="130" height="90" rx="10"/>
-<text x="582" y="45" role="heading">Verifier</text>
-<text x="585" y="60" class="myRole">Verifies VCs</text>
-<path class="register" d="m640 90v160h-70"/>
-	<text x="630" y="150" text-anchor="end">Verify Identifiers<tspan x="630" y="165">and Schemas</tspan>
-</text>
-
-<rect x="150" y="200" width="400" height="90" rx="10"/>
-<text x="210" y="245" role="heading">Verifiable Data Registry</text>
-<text x="235" y="260" class="myRole">Maintains identifiers and schemas</text>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 961 282">
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="M542.5 91v100.26" pointer-events="stroke"/>
+        <path d="m542.5 198.76-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:137px;margin-left:542px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        Register Identifiers
+                        <div>
+                            and use Schemas
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="542" y="141" font-family="Helvetica" font-size="16" text-anchor="middle">Register Identifiers...</text>
+    </switch>
+    <rect width="354" height="60" x="365.5" y="201" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="9" ry="9"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:352px;height:1px;padding-top:231px;margin-left:367px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:16px">
+                            <i>
+                                <b>
+                                    Verifiable Data Registry
+                                </b>
+                            </i>
+                        </font>
+                        <div>
+                            <font style="font-size:16px">
+                                <i>
+                                    Maintains identifiers and schemas
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="543" y="235" font-family="Helvetica" font-size="12" text-anchor="middle">Verifiable Data Registry...</text>
+    </switch>
+    <rect width="151" height="70" x="467" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:468px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font style="font-size:16px">
+                                <i>
+                                    <b>
+                                        Holder
+                                    </b>
+                                </i>
+                            </font>
+                        </div>
+                        <div>
+                            <font style="font-size:16px">
+                                <i>
+                                    Acquired, stores, presents VCs
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="543" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Holder...</text>
+    </switch>
+    <rect width="151" height="70" x="788" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:789px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <span style="font-size:16px">
+                                <b>
+                                    <i>
+                                        Verifier
+                                    </i>
+                                </b>
+                            </span>
+                        </div>
+                        <div>
+                            <font style="font-size:16px">
+                                <i>
+                                    Verifies VCs
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="864" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Verifier...</text>
+    </switch>
+    <rect width="151" height="70" x="146" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:147px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <span style="font-size:16px">
+                                <b>
+                                    <i>
+                                        Issuer
+                                    </i>
+                                </b>
+                            </span>
+                        </div>
+                        <div>
+                            <font style="font-size:16px">
+                                <i>
+                                    Issues VCs
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="222" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Issuer...</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m221.5 91 .5 140h133.76" pointer-events="stroke"/>
+        <path d="m363.26 231-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:141px;margin-left:222px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:17px">
+                            Verify Identifiers
+                        </font>
+                        <div>
+                            <font style="font-size:17px">
+                                and use Schemas
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="222" y="145" font-family="Helvetica" font-size="12" text-anchor="middle">Verify Identifiers...</text>
+    </switch>
+    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+        <path fill="none" d="m863.5 91 .5 140H729.24" pointer-events="stroke"/>
+        <path d="m721.74 231 10-5-2.5 5 2.5 5Z" pointer-events="all"/>
+    </g>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:141px;margin-left:864px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:17px">
+                            Verify Identifiers
+                        </font>
+                        <div>
+                            <font style="font-size:17px">
+                                and Schemas
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="864" y="145" font-family="Helvetica" font-size="12" text-anchor="middle">Verify Identifiers...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M297.5 69V43h138.99V32.5L466.5 56l-30.01 23.5V69Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:368px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:15px">
+                            Issue Credentials
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="368" y="59" font-family="Helvetica" font-size="12" text-anchor="middle">Issue Credentials</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m618.54 74-.08-26 138.99-.41-.03-10.5L787.5 60.5l-29.94 23.59-.03-10.5Z" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:60px;margin-left:688px">
+                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
+                        <font style="font-size:15px">
+                            Send Presentation
+                        </font>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="688" y="64" font-family="Helvetica" font-size="12" text-anchor="middle">Send Presentation</text>
+    </switch>
 </svg>

--- a/diagrams/presentation.drawio
+++ b/diagrams/presentation.drawio
@@ -1,0 +1,31 @@
+<mxfile host="Electron" modified="2024-03-13T08:57:31.494Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="fmnAsIPzv1PYgucT5Ek-" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2485" dy="1895" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1060" y="-519" as="sourcePoint" />
+            <mxPoint x="-1060" y="-519" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;" parent="1" vertex="1">
+          <mxGeometry x="-1010" y="-780" width="919.3600000000001" height="750" as="geometry" />
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-5" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 60px;&quot;&gt;Verifiable Presentation&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-741.2903225806451" width="701.6168421052632" height="72.58064516129032" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Presentation Metadata&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#d21414;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-634.8387096774194" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-1" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Verifiable Credential(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#1b17d3;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-429.1935483870968" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Proof(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#146121;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-223.5483870967742" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/presentation.svg
+++ b/diagrams/presentation.svg
@@ -1,20 +1,79 @@
-<svg version="1.1" viewBox="0 0 325 240" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg">
-<style><![CDATA[
-	text {font-size:20px;text-anchor:middle}
-	rect {stroke:#000;stroke-width:1uu;}
-	#background {fill:#fff;width:100%;height:100%;stroke:none}
-]]></style>
-<rect id="background" x="-5" y="-5"/>
-
-<rect fill="#ddd" x="5" y="5" width="310" height="225" rx="25"/>
-<text x="160" y="45" font-family="sans-serif" font-size="2em" font-weight="bold">Verifiable Presentation</text>
-
-<rect fill="#bad" x="40" y="65" width="240" height="40" rx="4"/>
-<text x="160" y="90">Presentation Metadata</text>
-
-<rect fill="#c7a" x="40" y="120" width="240" height="40" rx="4"/>
-<text x="160" y="145">Verifiable Credential(s)</text>
-
-<rect fill="#acf" x="40" y="175" width="240" height="40" rx="4"/>
-<text x="160" y="200">Proof(s)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 1021 793">
+    <rect width="919.36" height="750" x="79" y="21" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="90" ry="90"/>
+    <rect width="701.62" height="72.58" x="187.87" y="59.71" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:96px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:60px">
+                                    Verifiable Presentation
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="101" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Presentation</text>
+    </switch>
+    <rect width="701.62" height="145.16" x="187.87" y="166.16" fill="none" stroke="#d21414" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:239px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font size="1">
+                                <i style="font-size:60px">
+                                    Presentation Metadata
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="242" font-family="Helvetica" font-size="12" text-anchor="middle">Presentation Metadata</text>
+    </switch>
+    <rect width="701.62" height="145.16" x="187.87" y="371.81" fill="none" stroke="#1b17d3" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:444px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font size="1">
+                                <i style="font-size:60px">
+                                    Verifiable Credential(s)
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="448" font-family="Helvetica" font-size="12" text-anchor="middle">Verifiable Credential(s)</text>
+    </switch>
+    <rect width="701.62" height="145.16" x="187.87" y="577.45" fill="none" stroke="#146121" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:650px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font size="1">
+                                <i style="font-size:60px">
+                                    Proof(s)
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="654" font-family="Helvetica" font-size="12" text-anchor="middle">Proof(s)</text>
+    </switch>
 </svg>

--- a/diagrams/privacy-spectrum.svg
+++ b/diagrams/privacy-spectrum.svg
@@ -20,7 +20,6 @@
 		<stop offset="0.95" stop-color="#fff"/>
   </linearGradient>
 </defs>
-<rect id="background"/>
 
 <rect x="40" y="135" width="660" height="40" fill="url(#grade)" fill-opacity="0.6"/>
 <text x="90" y="170">...less privacy...</text>

--- a/diagrams/vc.drawio
+++ b/diagrams/vc.drawio
@@ -1,0 +1,31 @@
+<mxfile host="Electron" modified="2024-03-13T09:01:25.685Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="a1KS-VJ9tzcFpFGrsW_S" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2485" dy="1895" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1060" y="-519" as="sourcePoint" />
+            <mxPoint x="-1060" y="-519" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;" parent="1" vertex="1">
+          <mxGeometry x="-1010" y="-780" width="919.3600000000001" height="750" as="geometry" />
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-5" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 60px;&quot;&gt;Verifiable Credential&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-741.2903225806451" width="701.6168421052632" height="72.58064516129032" as="geometry" />
+        </mxCell>
+        <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Credential Metadata&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#D21414;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-634.8387096774194" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-1" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Claim(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#1b17d3;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-429.1935483870968" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Proof(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#146121;" parent="1" vertex="1">
+          <mxGeometry x="-901.1284210526316" y="-223.5483870967742" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/vc.svg
+++ b/diagrams/vc.svg
@@ -1,21 +1,79 @@
-<svg version="1.1" viewBox="0 0 325 240" xmlns="http://www.w3.org/2000/svg">
-<style><![CDATA[
-	text {font-size:20px;text-anchor:middle}
-	rect {stroke:#000;stroke-width:1uu;}
-	#background {fill:#fff;width:100%;height:100%;stroke:none}
-]]></style>
-<rect id="background"/>
-
-<rect x="5" y="5" fill="#ddd" width="310" height="225" rx="25"/>
-
-<text font-family="sans-serif" font-size="2em" font-weight="bold" x="160" y="45">Verifiable Credential</text>
-
-<rect fill="#dab" x="40" y="65" width="240" height="40" rx="4"/>
-<text x="160" y="90">Credential Metadata</text>
-
-<rect fill="#fe9" x="40" y="120" width="240" height="40" rx="4"/>
-<text x="160" y="145">Claim(s)</text>
-
-<rect fill="#bda" x="40" y="175" width="240" height="40" rx="4"/>
-<text x="160" y="200">Proof(s)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 1021 793">
+    <rect width="919.36" height="750" x="79" y="21" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="90" ry="90"/>
+    <rect width="701.62" height="72.58" x="187.87" y="59.71" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:96px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:60px">
+                                    Verifiable Credential
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="101" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Credential</text>
+    </switch>
+    <rect width="701.62" height="145.16" x="187.87" y="166.16" fill="none" stroke="#d21414" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:239px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font size="1">
+                                <i style="font-size:60px">
+                                    Credential Metadata
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="242" font-family="Helvetica" font-size="12" text-anchor="middle">Credential Metadata</text>
+    </switch>
+    <rect width="701.62" height="145.16" x="187.87" y="371.81" fill="none" stroke="#1b17d3" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:444px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font size="1">
+                                <i style="font-size:60px">
+                                    Claim(s)
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="448" font-family="Helvetica" font-size="12" text-anchor="middle">Claim(s)</text>
+    </switch>
+    <rect width="701.62" height="145.16" x="187.87" y="577.45" fill="none" stroke="#146121" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:650px;margin-left:189px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div>
+                            <font size="1">
+                                <i style="font-size:60px">
+                                    Proof(s)
+                                </i>
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="539" y="654" font-family="Helvetica" font-size="12" text-anchor="middle">Proof(s)</text>
+    </switch>
 </svg>

--- a/diagrams/zkp-cred-pres.drawio
+++ b/diagrams/zkp-cred-pres.drawio
@@ -1,50 +1,53 @@
-<mxfile host="Electron" modified="2024-03-13T10:36:28.372Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="mWShyHUcKUSRfcpUkt9t" version="24.0.4" type="device">
+<mxfile host="Electron" modified="2024-03-14T11:51:33.512Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="SFCGo7x2g5unzUKZpz3y" version="24.0.4" type="device">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
     <mxGraphModel dx="2584" dy="2099" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-54" value="&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#253db6;" vertex="1" parent="1">
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" parent="1" vertex="1">
+          <mxGeometry x="-1117" y="-800" width="240" height="450" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-2" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
+          <mxGeometry x="-1092" y="-601.16" width="190" height="104" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-54" value="&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#253db6;" parent="1" vertex="1">
           <mxGeometry x="-550" y="-805" width="320" height="930" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-61" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=-0.002;entryY=0.073;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="NV7x72Zd9u3rbeVEopfi-3" target="4NoEkOULwa_hqzR1PTxX-28">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-61" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=-0.002;entryY=0.073;entryDx=0;entryDy=0;entryPerimeter=0;" parent="1" source="NV7x72Zd9u3rbeVEopfi-3" target="4NoEkOULwa_hqzR1PTxX-28" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-770" y="-710" as="sourcePoint" />
             <mxPoint x="-630" y="-560" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-62" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.002;exitY=0.922;exitDx=0;exitDy=0;entryX=-0.006;entryY=0.92;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" edge="1" parent="1" source="NV7x72Zd9u3rbeVEopfi-3" target="4NoEkOULwa_hqzR1PTxX-28">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-62" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.002;exitY=0.922;exitDx=0;exitDy=0;entryX=-0.006;entryY=0.92;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="NV7x72Zd9u3rbeVEopfi-3" target="4NoEkOULwa_hqzR1PTxX-28" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-867" y="-410" as="sourcePoint" />
             <mxPoint x="-488" y="-340" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-63" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.002;exitY=0.898;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-10">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-63" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.002;exitY=0.898;exitDx=0;exitDy=0;exitPerimeter=0;" parent="1" source="4NoEkOULwa_hqzR1PTxX-10" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-867" y="-375" as="sourcePoint" />
             <mxPoint x="-510" y="-20" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-64" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.006;exitY=0.056;exitDx=0;exitDy=0;entryX=-0.002;entryY=0.07;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-10" target="4NoEkOULwa_hqzR1PTxX-43">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-64" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.006;exitY=0.056;exitDx=0;exitDy=0;entryX=-0.002;entryY=0.07;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" parent="1" source="4NoEkOULwa_hqzR1PTxX-10" target="4NoEkOULwa_hqzR1PTxX-43" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="-857" y="-365" as="sourcePoint" />
             <mxPoint x="-491" y="-324" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-66" value="" style="endArrow=none;dashed=1;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.432;exitY=0.316;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-2" target="4NoEkOULwa_hqzR1PTxX-31">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-66" value="" style="endArrow=none;dashed=1;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" parent="1" target="4NoEkOULwa_hqzR1PTxX-31" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-660" y="-300" as="sourcePoint" />
+            <mxPoint x="-990" y="-530" as="sourcePoint" />
             <mxPoint x="-610" y="-350" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-67" value="" style="endArrow=none;dashed=1;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.747;exitY=0.316;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-13" target="4NoEkOULwa_hqzR1PTxX-46">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-67" value="" style="endArrow=none;dashed=1;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;" parent="1" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
-            <mxPoint x="-940" y="-180" as="sourcePoint" />
-            <mxPoint x="-415" y="-70" as="targetPoint" />
+            <mxPoint x="-950" y="-54" as="sourcePoint" />
+            <mxPoint x="-485" y="-87.69589285714278" as="targetPoint" />
           </mxGeometry>
-        </mxCell>
-        <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" parent="1" vertex="1">
-          <mxGeometry x="-1117" y="-800" width="240" height="450" as="geometry" />
         </mxCell>
         <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
           <mxGeometry relative="1" as="geometry">
@@ -52,104 +55,206 @@
             <mxPoint x="-1060" y="-599" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-6" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential 1&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-6" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential 1&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
           <mxGeometry x="-1107" y="-788" width="220" height="31.94" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-9" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-9" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="-1057" y="-119" as="sourcePoint" />
             <mxPoint x="-1057" y="-119" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" parent="1" vertex="1">
           <mxGeometry x="-1117" y="-320" width="240" height="450" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-15" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential 2&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-15" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential 2&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
           <mxGeometry x="-1107" y="-310" width="220" height="31.94" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-51" value="&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#166a1f;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-51" value="&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#166a1f;" parent="1" vertex="1">
           <mxGeometry x="-530" y="-660" width="280" height="690" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-52" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-52" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
           <mxGeometry x="-500" y="-650" width="220" height="31.94" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-55" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; …&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;strokeColor=#166a1f;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-55" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;strokeColor=#166a1f;" parent="1" vertex="1">
           <mxGeometry x="-530" y="-760" width="280" height="88" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-56" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div&gt;&lt;span style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Common Link Secret&lt;/span&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;strokeColor=#166a1f;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-56" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;strokeColor=#166a1f;" parent="1" vertex="1">
           <mxGeometry x="-530" y="50" width="280" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-57" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-54" target="4NoEkOULwa_hqzR1PTxX-54">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-57" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" source="4NoEkOULwa_hqzR1PTxX-54" target="4NoEkOULwa_hqzR1PTxX-54" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-58" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Presentation&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-58" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Presentation&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
           <mxGeometry x="-500" y="-791.94" width="220" height="31.94" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-48" value="" style="group;strokeColor=none;container=0;" vertex="1" connectable="0" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-48" value="" style="group;strokeColor=none;container=0;" parent="1" vertex="1" connectable="0">
           <mxGeometry x="-510" y="-290" width="240" height="300" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-49" value="" style="group;strokeColor=none;container=0;" vertex="1" connectable="0" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-49" value="" style="group;strokeColor=none;container=0;" parent="1" vertex="1" connectable="0">
           <mxGeometry x="-510" y="-610" width="240" height="300" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-27" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-27" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="-450" y="-439" as="sourcePoint" />
             <mxPoint x="-450" y="-439" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-28" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-28" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" parent="1" vertex="1">
           <mxGeometry x="-510" y="-610" width="240" height="300" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-33" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Derived Credential 1&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-33" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Derived Credential 1&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
           <mxGeometry x="-500" y="-600" width="220" height="31.94" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-30" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-30" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-485" y="-560" width="190" height="105.84" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-31" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;ageOver 18&lt;/span&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-31" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-485" y="-441.15999999999997" width="190" height="41.16" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-32" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Knowledge of Signature&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-32" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-485" y="-380" width="190" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-42" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-42" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="-450" y="-119" as="sourcePoint" />
             <mxPoint x="-450" y="-119" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-43" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-43" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" parent="1" vertex="1">
           <mxGeometry x="-510" y="-290" width="240" height="300" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-44" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Derived Credential 2&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-44" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Derived Credential 2&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
           <mxGeometry x="-500" y="-280" width="220" height="31.94" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-45" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-45" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-485" y="-240" width="190" height="105.84" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-46" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;Degree&lt;/span&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-46" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-485" y="-121.15999999999997" width="190" height="41.16" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-47" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Knowledge of Signature&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-47" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;&amp;nbsp;&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-485" y="-60" width="190" height="50" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-1" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&amp;nbsp;&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Expiration Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-1" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-1092" y="-754.16" width="190" height="140" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-2" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Given Name&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Family Name&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Birth Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
-          <mxGeometry x="-1092" y="-601.16" width="190" height="104" as="geometry" />
-        </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-3" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Signature&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Proof of Correctness&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Attributes&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-1092" y="-483.15999999999997" width="190" height="107.03" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-12" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Expiration Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-12" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-1092" y="-274.15999999999997" width="190" height="140" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-13" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;University&amp;nbsp;&amp;nbsp;&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp; &amp;nbsp;Department&lt;/span&gt;&lt;br&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Degree Awarded&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/span&gt;&lt;br&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-13" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-1092" y="-121.15999999999997" width="190" height="104" as="geometry" />
         </mxCell>
-        <mxCell id="4NoEkOULwa_hqzR1PTxX-14" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Signature&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Proof of Correctness&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Attributes&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-14" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" parent="1" vertex="1">
           <mxGeometry x="-1092" y="-3.159999999999968" width="190" height="107.03" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-1" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;…&lt;/font&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-520" y="-754.16" width="100" height="72" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-5" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1080.5" y="-597.16" width="159" height="93" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-6" value="" style="group" vertex="1" connectable="0" parent="ogGgAtrba4owZQfqpPe0-5">
+          <mxGeometry width="159" height="93" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-2" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Credential Subject:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-6">
+          <mxGeometry width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-3" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Given Name&lt;/span&gt;&lt;br&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;Family Name&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;Birth Date&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;…&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-6">
+          <mxGeometry x="19" y="23" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-12" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1080.5" y="-476.14" width="159" height="93" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-13" value="" style="group" vertex="1" connectable="0" parent="ogGgAtrba4owZQfqpPe0-12">
+          <mxGeometry width="159" height="93" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-14" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Proof:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-13">
+          <mxGeometry width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-15" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Signature&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Proof of Correctness&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Attributes&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;…&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-13">
+          <mxGeometry x="19" y="23" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-16" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issue Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Expiration Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;…&lt;/font&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-1080.5" y="-745.06" width="100" height="122" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-17" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issue Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Expiration Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;…&lt;/font&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-1080.5" y="-266.15999999999997" width="100" height="122" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-18" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1080.5" y="4" width="159" height="93" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-19" value="" style="group" vertex="1" connectable="0" parent="ogGgAtrba4owZQfqpPe0-18">
+          <mxGeometry width="159" height="93" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-20" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Proof:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-19">
+          <mxGeometry width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-21" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Signature&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Proof of Correctness&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Attributes&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;…&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-19">
+          <mxGeometry x="19" y="23" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-26" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-1080.5" y="-129.16000000000003" width="159" height="101" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-24" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;Credential Subject:&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-26">
+          <mxGeometry width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-25" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;University&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;Department&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;Degree Awarded&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;…&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-26">
+          <mxGeometry x="19" y="31" width="140" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-27" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issue Date&lt;/font&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-477" y="-239.16000000000003" width="100" height="102" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-28" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Issue Date&lt;/font&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-477" y="-560" width="100" height="102" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-33" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-477" y="-107" width="190" height="27" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-31" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Credential Subject:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-33">
+          <mxGeometry width="140" height="17.74193548387097" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-32" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Degree&lt;/span&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-33">
+          <mxGeometry x="19" y="2.1612903225806406" width="171" height="24.838709677419363" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-34" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-477" y="-45.5" width="190" height="27" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-35" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Proof:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-34">
+          <mxGeometry width="140" height="17.74193548387097" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-36" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Knowledge of Signature&lt;/span&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-34">
+          <mxGeometry x="19" y="2.1612903225806406" width="171" height="24.838709677419363" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-37" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-477" y="-364" width="190" height="27" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-38" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Proof:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-37">
+          <mxGeometry width="140" height="17.74193548387097" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-39" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Knowledge of Signature&lt;/span&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-37">
+          <mxGeometry x="19" y="2.1612903225806406" width="171" height="24.838709677419363" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-40" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-477" y="-430.08000000000004" width="190" height="27" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-41" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Credential Subject:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-40">
+          <mxGeometry width="140" height="17.74193548387097" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-42" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Age Over 18&lt;/span&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-40">
+          <mxGeometry x="19" y="2.1612903225806406" width="171" height="24.838709677419363" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-43" value="" style="group" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-520" y="64" width="190" height="27" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-44" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;Proof:&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;br&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-43">
+          <mxGeometry width="140" height="17.74193548387097" as="geometry" />
+        </mxCell>
+        <mxCell id="ogGgAtrba4owZQfqpPe0-45" value="&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;Common Link Secret&lt;/span&gt;&lt;/div&gt;" style="text;html=1;align=left;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="ogGgAtrba4owZQfqpPe0-43">
+          <mxGeometry x="19" y="2.1612903225806406" width="171" height="24.838709677419363" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/diagrams/zkp-cred-pres.drawio
+++ b/diagrams/zkp-cred-pres.drawio
@@ -1,0 +1,157 @@
+<mxfile host="Electron" modified="2024-03-13T10:36:28.372Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="mWShyHUcKUSRfcpUkt9t" version="24.0.4" type="device">
+  <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
+    <mxGraphModel dx="2584" dy="2099" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-54" value="&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#253db6;" vertex="1" parent="1">
+          <mxGeometry x="-550" y="-805" width="320" height="930" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-61" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.25;exitDx=0;exitDy=0;entryX=-0.002;entryY=0.073;entryDx=0;entryDy=0;entryPerimeter=0;" edge="1" parent="1" source="NV7x72Zd9u3rbeVEopfi-3" target="4NoEkOULwa_hqzR1PTxX-28">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-770" y="-710" as="sourcePoint" />
+            <mxPoint x="-630" y="-560" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-62" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.002;exitY=0.922;exitDx=0;exitDy=0;entryX=-0.006;entryY=0.92;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" edge="1" parent="1" source="NV7x72Zd9u3rbeVEopfi-3" target="4NoEkOULwa_hqzR1PTxX-28">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-867" y="-410" as="sourcePoint" />
+            <mxPoint x="-488" y="-340" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-63" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.002;exitY=0.898;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-10">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-867" y="-375" as="sourcePoint" />
+            <mxPoint x="-510" y="-20" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-64" value="" style="endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1.006;exitY=0.056;exitDx=0;exitDy=0;entryX=-0.002;entryY=0.07;entryDx=0;entryDy=0;entryPerimeter=0;exitPerimeter=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-10" target="4NoEkOULwa_hqzR1PTxX-43">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-857" y="-365" as="sourcePoint" />
+            <mxPoint x="-491" y="-324" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-66" value="" style="endArrow=none;dashed=1;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.432;exitY=0.316;exitDx=0;exitDy=0;exitPerimeter=0;entryX=0;entryY=0.75;entryDx=0;entryDy=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-2" target="4NoEkOULwa_hqzR1PTxX-31">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-660" y="-300" as="sourcePoint" />
+            <mxPoint x="-610" y="-350" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-67" value="" style="endArrow=none;dashed=1;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.747;exitY=0.316;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-13" target="4NoEkOULwa_hqzR1PTxX-46">
+          <mxGeometry width="50" height="50" relative="1" as="geometry">
+            <mxPoint x="-940" y="-180" as="sourcePoint" />
+            <mxPoint x="-415" y="-70" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" parent="1" vertex="1">
+          <mxGeometry x="-1117" y="-800" width="240" height="450" as="geometry" />
+        </mxCell>
+        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1060" y="-599" as="sourcePoint" />
+            <mxPoint x="-1060" y="-599" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-6" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential 1&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-1107" y="-788" width="220" height="31.94" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-9" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-1057" y="-119" as="sourcePoint" />
+            <mxPoint x="-1057" y="-119" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-10" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" vertex="1" parent="1">
+          <mxGeometry x="-1117" y="-320" width="240" height="450" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-15" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential 2&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-1107" y="-310" width="220" height="31.94" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-51" value="&lt;span style=&quot;color: rgba(0, 0, 0, 0); font-family: monospace; font-size: 0px; text-align: start; text-wrap: nowrap;&quot;&gt;%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E&lt;/span&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#166a1f;" vertex="1" parent="1">
+          <mxGeometry x="-530" y="-660" width="280" height="690" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-52" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Verifiable Credential&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-500" y="-650" width="220" height="31.94" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-55" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; …&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;strokeColor=#166a1f;" vertex="1" parent="1">
+          <mxGeometry x="-530" y="-760" width="280" height="88" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-56" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div&gt;&lt;span style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Common Link Secret&lt;/span&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;strokeColor=#166a1f;" vertex="1" parent="1">
+          <mxGeometry x="-530" y="50" width="280" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-57" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=1;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1" source="4NoEkOULwa_hqzR1PTxX-54" target="4NoEkOULwa_hqzR1PTxX-54">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-58" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Presentation&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-500" y="-791.94" width="220" height="31.94" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-48" value="" style="group;strokeColor=none;container=0;" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-510" y="-290" width="240" height="300" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-49" value="" style="group;strokeColor=none;container=0;" vertex="1" connectable="0" parent="1">
+          <mxGeometry x="-510" y="-610" width="240" height="300" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-27" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-450" y="-439" as="sourcePoint" />
+            <mxPoint x="-450" y="-439" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-28" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" vertex="1" parent="1">
+          <mxGeometry x="-510" y="-610" width="240" height="300" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-33" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Derived Credential 1&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-500" y="-600" width="220" height="31.94" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-30" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-485" y="-560" width="190" height="105.84" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-31" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;ageOver 18&lt;/span&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-485" y="-441.15999999999997" width="190" height="41.16" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-32" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Knowledge of Signature&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-485" y="-380" width="190" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-42" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-450" y="-119" as="sourcePoint" />
+            <mxPoint x="-450" y="-119" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-43" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;labelPosition=center;verticalLabelPosition=middle;align=center;verticalAlign=middle;spacingTop=0;strokeColor=#bc1a1a;" vertex="1" parent="1">
+          <mxGeometry x="-510" y="-290" width="240" height="300" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-44" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 19px;&quot;&gt;Derived Credential 2&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="-500" y="-280" width="220" height="31.94" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-45" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-485" y="-240" width="190" height="105.84" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-46" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;Degree&lt;/span&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-485" y="-121.15999999999997" width="190" height="41.16" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-47" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Knowledge of Signature&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-485" y="-60" width="190" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-1" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&amp;nbsp;&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Expiration Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-1092" y="-754.16" width="190" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-2" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Given Name&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Family Name&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Birth Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-1092" y="-601.16" width="190" height="104" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-3" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Signature&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Proof of Correctness&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Attributes&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-1092" y="-483.15999999999997" width="190" height="107.03" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-12" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Context&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Type&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;ID&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issuer&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Issue Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Expiration Date&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-1092" y="-274.15999999999997" width="190" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-13" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Credential Subject:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;University&amp;nbsp;&amp;nbsp;&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp; &amp;nbsp;Department&lt;/span&gt;&lt;br&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp; &amp;nbsp; &amp;nbsp;Degree Awarded&lt;/span&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;span style=&quot;background-color: initial;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/span&gt;&lt;br&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-1092" y="-121.15999999999997" width="190" height="104" as="geometry" />
+        </mxCell>
+        <mxCell id="4NoEkOULwa_hqzR1PTxX-14" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp;Proof:&lt;/font&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Signature&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Proof of Correctness&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;Attributes&lt;/font&gt;&lt;/div&gt;&lt;div style=&quot;font-size: 14px;&quot;&gt;&lt;font style=&quot;font-size: 14px;&quot;&gt;&amp;nbsp; &amp;nbsp;…&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;align=left;flipV=1;" vertex="1" parent="1">
+          <mxGeometry x="-1092" y="-3.159999999999968" width="190" height="107.03" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>

--- a/diagrams/zkp-cred-pres.svg
+++ b/diagrams/zkp-cred-pres.svg
@@ -1,139 +1,584 @@
-<svg version="1.1" viewBox="0 0 1160 1135" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<style><![CDATA[
-		rect,path {stroke:#000;stroke-width:1px;}
-		text {fill:#000;font-size:24px;font-family:sans-serif}
-		*[role=heading]{font-size:1.5em;font-weight:bold}
-		#background {fill:#fff;width:100%;height:100%;stroke:none}
-	]]></style>
-
-<defs>
-	<symbol id="vc-metadata">
-		<rect fill="#cef" width="270" height="175"/>
-
-		<text x="10" y="25">Context</text>
-		<text x="10" y="50">Type</text>
-		<text x="10" y="75">ID</text>
-		<text x="10" y="100">Issuer</text>
-		<text x="10" y="125">Issue Date</text>
-		<text x="10" y="150">Expiration Date</text>
-		<text x="20" y="170"> ...</text>
-
-		<rect fill="#def" y="325" width="270" height="125"/>
-		<text x="10" y="350">Proof:</text>
-		<text x="20" y="375">Signature</text>
-		<text x="20" y="400">Proof of Correctness</text>
-		<text x="20" y="425">Attributes</text>
-		<text x="30" y="445"> ...</text>
-
-</symbol>
-
-<symbol id="derived-vc-metadata">
-	<!-- Template for a derived credential (one line of subject)
-  To use this:
-
-	<use href="#derived-vc-metadata" x="[XValue]" y="[YValue]"/>
-  <text x="[XValue]+..." y="[YValue]+35" aria-role="heading">[Derived Credential title]</text>
-
-	<text x="[XValue+30]" y="[YValue+205]">Credential Subject:</text>
-	<text x="[XValue+40]" y="[YValue+230]">[SubjectValue]</text>
-
-(optionally wrapped in a <g> with a comment labeling it)
- -->
-	<rect fill="#bda" width="320" height="330" rx="20"/>
-	<rect fill="#cef" x="20" y="45" width="280" height="130"/>
-
-	<text x="30" y="70">Context</text>
-	<text x="30" y="95">Type</text>
-	<text x="30" y="120">ID</text>
-	<text x="30" y="145">Issuer</text>
-	<text x="30" y="170">Issue Date</text>
-
-	<rect fill="#def" x="20" y="180" width="280" height="60"/>
-
-	<rect fill="#def" x="20" y="250" width="280" height="60"/>
-	<text x="30" y="275">Proof:</text>
-	<text x="40" y="300">Knowledge of Signature</text>
-</symbol>
-
-</defs>
-
-<rect id="background"/>
-
-<g>
-<rect fill="#bda" x="60" y="60" rx="20" width="310" height="510"/>
-<text x="90" y="95" role="heading">Verifiable Credential 1</text>
-
-<use href="#vc-metadata" x="80" y="115" />
-
-<rect fill="#def" x="80" y="300" width="270" height="125"/>
-<text x="90" y="325">Credential Subject:</text>
-<text x="100" y="350">Given Name</text>
-<text x="100" y="375">Family Name</text>
-<text x="100" y="400">Birth Date</text>
-<text x="110" y="420"> ...</text>
-</g>
-
-<g>
-<rect fill="#bda" x="60" y="620" rx="20" width="310" height="510"/>
-<text x="90" y="655" role="heading">Verifiable Credential 2</text>
-
-<use href="#vc-metadata" x="80" y="675" />
-
-<rect fill="#def" x="80" y="860" width="270" height="125"/>
-<text x="90" y="885">Credential Subject:</text>
-<text x="100" y="910">University</text>
-<text x="110" y="935">Department</text>
-<text x="120" y="960">Degree Awarded</text>
-<text x="130" y="980"> ...</text>
-</g>
-
-<g><!-- Presentation -->
-<rect fill="#f99" x="640" y="85" width="420" height="1000" rx="15"/>
-<text x="780" y="115" role="heading">Presentation</text>
-
-  <g><title>Presentation Metadata block</title>
-  <rect fill="#fda" x="660" y="130" width="380" height="100"/>
-  <text x="670" y="155">Context</text>
-  <text x="670" y="180">Type</text>
-  <text x="670" y="205">ID</text>
-  <text x="680" y="225"> ...</text>
-  </g>
-
-  <rect fill="#fda" x="660" y="240" width="380" height="750"/>
-  <text x="700" y="270" role="heading">Verifiable Credential</text>
-
-    <g><!-- derived credential 1 -->
-    <use href="#derived-vc-metadata" x="685" y="285"/>
-    <text x="700" y="320" role="heading">Derived Credential 1</text>
-
-    <text x="715" y="490">Credential Subject:</text>
-    <text x="725" y="515">ageOver18</text>
-    </g>
-
-    <g><!-- derived credential 2 -->
-    <use href="#derived-vc-metadata" x="685" y="630"/>
-    <text x="700" y="665" role="heading">Derived Credential 2</text>
-
-    <text x="715" y="835">Credential Subject:</text>
-    <text x="725" y="860">degree</text>
-    </g>
-
-  <g><!-- presentation proof -->
-  <rect fill="#fda" x="660" y="1000" width="380" height="60"/>
-  <text x="670" y="1025">Proof:</text>
-  <text x="680" y="1050">Common Link Secret</text>
-  </g>
-
-</g>
-
-<g><title>Derived credential information is a subset from the credentials</title>
-<path d="m370 90l315 220"/>
-<path stroke-dasharray="4,3" d="m200 390l520 115"/>
-<path d="m370 550l315 50"/>
-
-<path d="m370 640l315 30"/>
-<path stroke-dasharray="4,3" d="m295 955l430 -100"/>
-<path d="m370 1115l315 -170"/>
-</g>
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 930 982">
+    <rect width="320" height="930" x="588" y="21" fill="none" stroke="#253db6" stroke-width="3" pointer-events="all" rx="38.4" ry="38.4"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:318px;height:1px;padding-top:486px;margin-left:589px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <span style="color:transparent;font-family:monospace;font-size:0;text-align:start;text-wrap:nowrap">
+                            %3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="748" y="490" font-family="Helvetica" font-size="12" text-anchor="middle">%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%...</text>
+    </switch>
+    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m261 138.5 366.52 99.4M261.48 440.9 626.56 492M261.48 910.1 628 806M262.44 531.2 627.52 557" pointer-events="stroke"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M128.08 295.98 653 415.71M187.93 775.98 653 734" pointer-events="stroke"/>
+    <rect width="240" height="450" x="21" y="26" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
+    <rect width="220" height="31.94" x="31" y="38" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:218px;height:1px;padding-top:54px;margin-left:32px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:19px">
+                                    Verifiable Credential 1
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="141" y="59" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Credential 1</text>
+    </switch>
+    <rect width="240" height="450" x="21" y="506" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
+    <rect width="220" height="31.94" x="31" y="516" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:218px;height:1px;padding-top:532px;margin-left:32px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:19px">
+                                    Verifiable Credential 2
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="141" y="537" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Credential 2</text>
+    </switch>
+    <rect width="280" height="690" x="608" y="166" fill="none" stroke="#166a1f" stroke-width="3" pointer-events="all" rx="33.6" ry="33.6"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:278px;height:1px;padding-top:511px;margin-left:609px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <span style="color:transparent;font-family:monospace;font-size:0;text-align:start;text-wrap:nowrap">
+                            %3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%2F%3E%3CmxCell%20id%3D%221%22%20parent%3D%220%22%2F%3E%3CmxCell%20id%3D%222%22%20value%3D%22%26lt%3Bi%26gt%3B%26lt%3Bb%26gt%3B%26lt%3Bfont%20style%3D%26quot%3Bfont-size%3A%2019px%3B%26quot%3B%26gt%3BVerifiable%20Credential%201%26lt%3B%2Ffont%26gt%3B%26lt%3B%2Fb%26gt%3B%26lt%3B%2Fi%26gt%3B%22%20style%3D%22text%3Bhtml%3D1%3Balign%3Dcenter%3BverticalAlign%3Dmiddle%3BwhiteSpace%3Dwrap%3Brounded%3D0%3BfontSize%3D16%3B%22%20vertex%3D%221%22%20parent%3D%221%22%3E%3CmxGeometry%20x%3D%22-1107%22%20y%3D%22-788%22%20width%3D%22220%22%20height%3D%2231.94%22%20as%3D%22geometry%22%2F%3E%3C%2FmxCell%3E%3C%2Froot%3E%3C%2FmxGraphModel%3E
+                        </span>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="748" y="515" font-family="Helvetica" font-size="12" text-anchor="middle">%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%...</text>
+    </switch>
+    <rect width="220" height="31.94" x="638" y="176" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:218px;height:1px;padding-top:192px;margin-left:639px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:19px">
+                                    Verifiable Credential
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="748" y="197" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Credential</text>
+    </switch>
+    <rect width="280" height="88" x="608" y="66" fill="none" stroke="#166a1f" stroke-width="3" pointer-events="all" rx="10.56" ry="10.56" transform="matrix(1 0 0 -1 0 220)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:278px;height:1px;padding-top:110px;margin-left:610px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="610" y="114" font-family="Helvetica" font-size="12">Context...</text>
+    </switch>
+    <rect width="280" height="50" x="608" y="876" fill="none" stroke="#166a1f" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 1802)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:278px;height:1px;padding-top:901px;margin-left:610px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Proof:
+                        </font>
+                        <div>
+                            <span style="font-size:14px">
+                                Common Link Secret
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="610" y="905" font-family="Helvetica" font-size="12">Proof:...</text>
+    </switch>
+    <rect width="220" height="31.94" x="638" y="34.06" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:218px;height:1px;padding-top:50px;margin-left:639px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:19px">
+                                    Presentation
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="748" y="55" font-family="Helvetica" font-size="16" text-anchor="middle">Presentation</text>
+    </switch>
+    <rect width="240" height="300" x="628" y="216" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
+    <rect width="220" height="31.94" x="638" y="226" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:218px;height:1px;padding-top:242px;margin-left:639px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:19px">
+                                    Derived Credential 1
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="748" y="247" font-family="Helvetica" font-size="16" text-anchor="middle">Derived Credential 1</text>
+    </switch>
+    <rect width="190" height="105.84" x="653" y="266" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.7" ry="12.7" transform="matrix(1 0 0 -1 0 637.84)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:319px;margin-left:655px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="323" font-family="Helvetica" font-size="12">Context...</text>
+    </switch>
+    <rect width="190" height="41.16" x="653" y="384.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="4.94" ry="4.94" transform="matrix(1 0 0 -1 0 810.84)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:405px;margin-left:655px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Credential Subject:
+                        </font>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                ageOver 18
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="409" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+    </switch>
+    <rect width="190" height="50" x="653" y="446" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 942)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:471px;margin-left:655px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Proof:
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Knowledge of Signature
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="475" font-family="Helvetica" font-size="12">Proof:...</text>
+    </switch>
+    <rect width="240" height="300" x="628" y="536" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
+    <rect width="220" height="31.94" x="638" y="546" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:218px;height:1px;padding-top:562px;margin-left:639px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <i>
+                            <b>
+                                <font style="font-size:19px">
+                                    Derived Credential 2
+                                </font>
+                            </b>
+                        </i>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="748" y="567" font-family="Helvetica" font-size="16" text-anchor="middle">Derived Credential 2</text>
+    </switch>
+    <rect width="190" height="105.84" x="653" y="586" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.7" ry="12.7" transform="matrix(1 0 0 -1 0 1277.84)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:639px;margin-left:655px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="643" font-family="Helvetica" font-size="12">Context...</text>
+    </switch>
+    <rect width="190" height="41.16" x="653" y="704.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="4.94" ry="4.94" transform="matrix(1 0 0 -1 0 1450.84)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:725px;margin-left:655px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Credential Subject:
+                        </font>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Degree
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="729" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+    </switch>
+    <rect width="190" height="50" x="653" y="766" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 1582)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:791px;margin-left:655px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Proof:
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Knowledge of Signature
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="795" font-family="Helvetica" font-size="12">Proof:...</text>
+    </switch>
+    <rect width="190" height="140" x="46" y="71.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="16.8" ry="16.8" transform="matrix(1 0 0 -1 0 283.68)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:142px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Expiration Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="145" font-family="Helvetica" font-size="12">Context...</text>
+    </switch>
+    <rect width="190" height="104" x="46" y="224.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.48" ry="12.48" transform="matrix(1 0 0 -1 0 553.68)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:277px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Credential Subject:
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Given Name
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Family Name
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Birth Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="280" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+    </switch>
+    <rect width="190" height="107.03" x="46" y="342.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.84" ry="12.84" transform="matrix(1 0 0 -1 0 792.72)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:396px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Proof:
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Signature
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Proof of Correctness
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Attributes
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="400" font-family="Helvetica" font-size="12">Proof:...</text>
+    </switch>
+    <rect width="190" height="140" x="46" y="551.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="16.8" ry="16.8" transform="matrix(1 0 0 -1 0 1243.68)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:622px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Expiration Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="625" font-family="Helvetica" font-size="12">Context...</text>
+    </switch>
+    <rect width="190" height="104" x="46" y="704.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.48" ry="12.48" transform="matrix(1 0 0 -1 0 1513.68)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:757px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Credential Subject:
+                        </font>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                University
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Department
+                            </span>
+                            <br/>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Degree Awarded
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                …
+                            </span>
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="760" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+    </switch>
+    <rect width="190" height="107.03" x="46" y="822.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.84" ry="12.84" transform="matrix(1 0 0 -1 0 1752.72)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:876px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Proof:
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Signature
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Proof of Correctness
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Attributes
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="880" font-family="Helvetica" font-size="12">Proof:...</text>
+    </switch>
 </svg>

--- a/diagrams/zkp-cred-pres.svg
+++ b/diagrams/zkp-cred-pres.svg
@@ -1,4 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 930 982">
+    <rect width="240" height="450" x="21" y="26" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
+    <rect width="190" height="104" x="46" y="224.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.48" ry="12.48" transform="matrix(1 0 0 -1 0 553.68)"/>
     <rect width="320" height="930" x="588" y="21" fill="none" stroke="#253db6" stroke-width="3" pointer-events="all" rx="38.4" ry="38.4"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -15,8 +17,7 @@
         <text xmlns="http://www.w3.org/2000/svg" x="748" y="490" font-family="Helvetica" font-size="12" text-anchor="middle">%3CmxGraphModel%3E%3Croot%3E%3CmxCell%20id%3D%220%22%...</text>
     </switch>
     <path fill="none" stroke="#000" stroke-miterlimit="10" d="m261 138.5 366.52 99.4M261.48 440.9 626.56 492M261.48 910.1 628 806M262.44 531.2 627.52 557" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M128.08 295.98 653 415.71M187.93 775.98 653 734" pointer-events="stroke"/>
-    <rect width="240" height="450" x="21" y="26" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
+    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="m148 296 505 119.71M188 772l465-33.7" pointer-events="stroke"/>
     <rect width="220" height="31.94" x="31" y="38" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -91,55 +92,7 @@
         <text xmlns="http://www.w3.org/2000/svg" x="748" y="197" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Credential</text>
     </switch>
     <rect width="280" height="88" x="608" y="66" fill="none" stroke="#166a1f" stroke-width="3" pointer-events="all" rx="10.56" ry="10.56" transform="matrix(1 0 0 -1 0 220)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:278px;height:1px;padding-top:110px;margin-left:610px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Context
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Type
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                ID
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                …
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="610" y="114" font-family="Helvetica" font-size="12">Context...</text>
-    </switch>
     <rect width="280" height="50" x="608" y="876" fill="none" stroke="#166a1f" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 1802)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:278px;height:1px;padding-top:901px;margin-left:610px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Proof:
-                        </font>
-                        <div>
-                            <span style="font-size:14px">
-                                Common Link Secret
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="610" y="905" font-family="Helvetica" font-size="12">Proof:...</text>
-    </switch>
     <rect width="220" height="31.94" x="638" y="34.06" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
@@ -180,59 +133,18 @@
         <text xmlns="http://www.w3.org/2000/svg" x="748" y="247" font-family="Helvetica" font-size="16" text-anchor="middle">Derived Credential 1</text>
     </switch>
     <rect width="190" height="105.84" x="653" y="266" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.7" ry="12.7" transform="matrix(1 0 0 -1 0 637.84)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:319px;margin-left:655px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Context
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Type
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                ID
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Issuer
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Issue Date
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="655" y="323" font-family="Helvetica" font-size="12">Context...</text>
-    </switch>
     <rect width="190" height="41.16" x="653" y="384.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="4.94" ry="4.94" transform="matrix(1 0 0 -1 0 810.84)"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:405px;margin-left:655px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Credential Subject:
-                        </font>
-                        <div style="font-size:14px">
-                            <span style="background-color:initial">
-                                ageOver 18
-                            </span>
-                        </div>
+                        <font style="font-size:14px"/>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="655" y="409" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="409" font-family="Helvetica" font-size="12">  </text>
     </switch>
     <rect width="190" height="50" x="653" y="446" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 942)"/>
     <switch transform="translate(-.5 -.5)">
@@ -240,19 +152,12 @@
             <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:471px;margin-left:655px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Proof:
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Knowledge of Signature
-                            </font>
-                        </div>
+                        <font style="font-size:14px"/>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="655" y="475" font-family="Helvetica" font-size="12">Proof:...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="475" font-family="Helvetica" font-size="12">  </text>
     </switch>
     <rect width="240" height="300" x="628" y="536" fill="none" stroke="#bc1a1a" stroke-width="3" pointer-events="all" rx="28.8" ry="28.8"/>
     <rect width="220" height="31.94" x="638" y="546" fill="none" pointer-events="all"/>
@@ -275,11 +180,351 @@
         <text xmlns="http://www.w3.org/2000/svg" x="748" y="567" font-family="Helvetica" font-size="16" text-anchor="middle">Derived Credential 2</text>
     </switch>
     <rect width="190" height="105.84" x="653" y="586" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.7" ry="12.7" transform="matrix(1 0 0 -1 0 1277.84)"/>
+    <rect width="190" height="41.16" x="653" y="704.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="4.94" ry="4.94" transform="matrix(1 0 0 -1 0 1450.84)"/>
+    <rect width="190" height="50" x="653" y="766" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 1582)"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:639px;margin-left:655px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:791px;margin-left:655px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
                     <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px"/>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="655" y="795" font-family="Helvetica" font-size="12">  </text>
+    </switch>
+    <rect width="190" height="140" x="46" y="71.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="16.8" ry="16.8" transform="matrix(1 0 0 -1 0 283.68)"/>
+    <rect width="190" height="107.03" x="46" y="342.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.84" ry="12.84" transform="matrix(1 0 0 -1 0 792.72)"/>
+    <rect width="190" height="140" x="46" y="551.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="16.8" ry="16.8" transform="matrix(1 0 0 -1 0 1243.68)"/>
+    <rect width="190" height="104" x="46" y="704.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.48" ry="12.48" transform="matrix(1 0 0 -1 0 1513.68)"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:757px;margin-left:48px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px"/>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="48" y="760" font-family="Helvetica" font-size="12"> </text>
+    </switch>
+    <rect width="190" height="107.03" x="46" y="822.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.84" ry="12.84" transform="matrix(1 0 0 -1 0 1752.72)"/>
+    <rect width="100" height="72" x="618" y="71.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:98px;height:1px;padding-top:108px;margin-left:620px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="620" y="113" font-family="Helvetica" font-size="16">Context...</text>
+    </switch>
+    <rect width="140" height="50" x="57.5" y="228.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:254px;margin-left:60px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Credential Subject:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="60" y="259" font-family="Helvetica" font-size="16">Credential Subjec...</text>
+    </switch>
+    <rect width="140" height="70" x="76.5" y="251.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:287px;margin-left:79px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Given Name
+                            </span>
+                            <br/>
+                        </div>
+                        <div style="font-size:14px">
+                            Family Name
+                        </div>
+                        <div style="font-size:14px">
+                            Birth Date
+                        </div>
+                        <div style="font-size:14px">
+                            …
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="79" y="292" font-family="Helvetica" font-size="16">Given Name...</text>
+    </switch>
+    <rect width="140" height="50" x="57.5" y="349.86" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:375px;margin-left:60px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Proof:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="60" y="380" font-family="Helvetica" font-size="16">Proof:
+</text>
+    </switch>
+    <rect width="140" height="70" x="76.5" y="372.86" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:408px;margin-left:79px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Signature
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Proof of Correctness
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Attributes
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            …
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="79" y="413" font-family="Helvetica" font-size="16">Signature...</text>
+    </switch>
+    <rect width="100" height="122" x="57.5" y="80.94" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:98px;height:1px;padding-top:142px;margin-left:60px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Expiration Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="60" y="147" font-family="Helvetica" font-size="16">Context...</text>
+    </switch>
+    <rect width="100" height="122" x="57.5" y="559.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:98px;height:1px;padding-top:621px;margin-left:60px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <font style="font-size:14px">
+                            Context
+                        </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Expiration Date
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                …
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="60" y="626" font-family="Helvetica" font-size="16">Context...</text>
+    </switch>
+    <rect width="140" height="50" x="57.5" y="830" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:855px;margin-left:60px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Proof:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="60" y="860" font-family="Helvetica" font-size="16">Proof:
+</text>
+    </switch>
+    <rect width="140" height="70" x="76.5" y="853" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:888px;margin-left:79px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Signature
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Proof of Correctness
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Attributes
+                            </span>
+                        </div>
+                        <div style="font-size:14px">
+                            …
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="79" y="893" font-family="Helvetica" font-size="16">Signature...</text>
+    </switch>
+    <rect width="140" height="50" x="57.5" y="696.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:722px;margin-left:60px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            Credential Subject:
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="60" y="727" font-family="Helvetica" font-size="16">Credential Subjec...</text>
+    </switch>
+    <rect width="140" height="70" x="76.5" y="727.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:763px;margin-left:79px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            University
+                        </div>
+                        <div style="font-size:14px">
+                            Department
+                        </div>
+                        <div style="font-size:14px">
+                            Degree Awarded
+                        </div>
+                        <div style="font-size:14px">
+                            …
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="79" y="768" font-family="Helvetica" font-size="16">University...</text>
+    </switch>
+    <rect width="100" height="102" x="661" y="586.84" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:98px;height:1px;padding-top:638px;margin-left:663px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <font style="font-size:14px">
                             Context
                         </font>
@@ -307,17 +552,69 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="655" y="643" font-family="Helvetica" font-size="12">Context...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="663" y="643" font-family="Helvetica" font-size="16">Context...</text>
     </switch>
-    <rect width="190" height="41.16" x="653" y="704.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="4.94" ry="4.94" transform="matrix(1 0 0 -1 0 1450.84)"/>
+    <rect width="100" height="102" x="661" y="266" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:725px;margin-left:655px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:98px;height:1px;padding-top:317px;margin-left:663px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <font style="font-size:14px">
-                            Credential Subject:
+                            Context
                         </font>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Type
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                ID
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issuer
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Issue Date
+                            </font>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="663" y="322" font-family="Helvetica" font-size="16">Context...</text>
+    </switch>
+    <rect width="140" height="17.74" x="661" y="719" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:728px;margin-left:663px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Credential Subject:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="663" y="733" font-family="Helvetica" font-size="16">Credential Subjec...</text>
+    </switch>
+    <rect width="171" height="24.84" x="680" y="721.16" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:169px;height:1px;padding-top:734px;margin-left:682px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div style="font-size:14px">
                             <span style="background-color:initial">
                                 Degree
@@ -327,258 +624,157 @@
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="655" y="729" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="682" y="738" font-family="Helvetica" font-size="16">Degree</text>
     </switch>
-    <rect width="190" height="50" x="653" y="766" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="6" ry="6" transform="matrix(1 0 0 -1 0 1582)"/>
+    <rect width="140" height="17.74" x="661" y="780.5" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:791px;margin-left:655px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:789px;margin-left:663px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Proof:
-                        </font>
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div style="font-size:14px">
                             <font style="font-size:14px">
+                                Proof:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="663" y="794" font-family="Helvetica" font-size="16">Proof:
+</text>
+    </switch>
+    <rect width="171" height="24.84" x="680" y="782.66" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:169px;height:1px;padding-top:795px;margin-left:682px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
                                 Knowledge of Signature
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="655" y="795" font-family="Helvetica" font-size="12">Proof:...</text>
-    </switch>
-    <rect width="190" height="140" x="46" y="71.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="16.8" ry="16.8" transform="matrix(1 0 0 -1 0 283.68)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:142px;margin-left:48px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Context
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Type
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                ID
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Issuer
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Issue Date
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Expiration Date
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                …
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="48" y="145" font-family="Helvetica" font-size="12">Context...</text>
-    </switch>
-    <rect width="190" height="104" x="46" y="224.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.48" ry="12.48" transform="matrix(1 0 0 -1 0 553.68)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:277px;margin-left:48px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Credential Subject:
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Given Name
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Family Name
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Birth Date
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                …
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="48" y="280" font-family="Helvetica" font-size="12">Credential Subject:...</text>
-    </switch>
-    <rect width="190" height="107.03" x="46" y="342.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.84" ry="12.84" transform="matrix(1 0 0 -1 0 792.72)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:396px;margin-left:48px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Proof:
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Signature
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Proof of Correctness
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Attributes
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                …
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="48" y="400" font-family="Helvetica" font-size="12">Proof:...</text>
-    </switch>
-    <rect width="190" height="140" x="46" y="551.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="16.8" ry="16.8" transform="matrix(1 0 0 -1 0 1243.68)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:622px;margin-left:48px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Context
-                        </font>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Type
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                ID
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Issuer
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Issue Date
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Expiration Date
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                …
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="48" y="625" font-family="Helvetica" font-size="12">Context...</text>
-    </switch>
-    <rect width="190" height="104" x="46" y="704.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.48" ry="12.48" transform="matrix(1 0 0 -1 0 1513.68)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:757px;margin-left:48px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Credential Subject:
-                        </font>
-                        <div style="font-size:14px">
-                            <span style="background-color:initial">
-                                University
                             </span>
                         </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="682" y="800" font-family="Helvetica" font-size="16">Knowledge of Signature</text>
+    </switch>
+    <rect width="140" height="17.74" x="661" y="462" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:471px;margin-left:663px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div style="font-size:14px">
-                            <span style="background-color:initial">
-                                Department
-                            </span>
-                            <br/>
+                            <font style="font-size:14px">
+                                Proof:
+                            </font>
                         </div>
                         <div style="font-size:14px">
-                            <span style="background-color:initial">
-                                Degree Awarded
-                            </span>
-                        </div>
-                        <div style="font-size:14px">
-                            <span style="background-color:initial">
-                                …
-                            </span>
                             <br/>
                         </div>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="48" y="760" font-family="Helvetica" font-size="12">Credential Subject:...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="663" y="476" font-family="Helvetica" font-size="16">Proof:
+</text>
     </switch>
-    <rect width="190" height="107.03" x="46" y="822.84" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="12.84" ry="12.84" transform="matrix(1 0 0 -1 0 1752.72)"/>
+    <rect width="171" height="24.84" x="680" y="464.16" fill="none" pointer-events="all"/>
     <switch transform="translate(-.5 -.5)">
         <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:188px;height:1px;padding-top:876px;margin-left:48px">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:169px;height:1px;padding-top:477px;margin-left:682px">
                 <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font style="font-size:14px">
-                            Proof:
-                        </font>
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
                         <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Signature
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Proof of Correctness
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                Attributes
-                            </font>
-                        </div>
-                        <div style="font-size:14px">
-                            <font style="font-size:14px">
-                                …
-                            </font>
+                            <span style="background-color:initial">
+                                Knowledge of Signature
+                            </span>
                         </div>
                     </div>
                 </div>
             </div>
         </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="48" y="880" font-family="Helvetica" font-size="12">Proof:...</text>
+        <text xmlns="http://www.w3.org/2000/svg" x="682" y="481" font-family="Helvetica" font-size="16">Knowledge of Signature</text>
+    </switch>
+    <rect width="140" height="17.74" x="661" y="395.92" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:405px;margin-left:663px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Credential Subject:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="663" y="410" font-family="Helvetica" font-size="16">Credential Subjec...</text>
+    </switch>
+    <rect width="171" height="24.84" x="680" y="398.08" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:169px;height:1px;padding-top:411px;margin-left:682px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Age Over 18
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="682" y="415" font-family="Helvetica" font-size="16">Age Over 18</text>
+    </switch>
+    <rect width="140" height="17.74" x="618" y="890" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:138px;height:1px;padding-top:899px;margin-left:620px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <font style="font-size:14px">
+                                Proof:
+                            </font>
+                        </div>
+                        <div style="font-size:14px">
+                            <br/>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="620" y="904" font-family="Helvetica" font-size="16">Proof:
+</text>
+    </switch>
+    <rect width="171" height="24.84" x="637" y="892.16" fill="none" pointer-events="all"/>
+    <switch transform="translate(-.5 -.5)">
+        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe flex-start;width:169px;height:1px;padding-top:905px;margin-left:639px">
+                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:left">
+                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
+                        <div style="font-size:14px">
+                            <span style="background-color:initial">
+                                Common Link Secret
+                            </span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </foreignObject>
+        <text xmlns="http://www.w3.org/2000/svg" x="639" y="909" font-family="Helvetica" font-size="16">Common Link Secret</text>
     </switch>
 </svg>

--- a/index.html
+++ b/index.html
@@ -409,7 +409,7 @@ ecosystem.
         </dl>
 
         <figure id="roles">
-          <img style="margin: auto; display: block; width: 75%;"
+          <img style="margin: auto; display: block; width: 100%;"
                src="diagrams/ecosystem.svg" alt="diagram showing how
                credentials flow from issuer to holder and
                presentations flow from holder to verifier where all
@@ -728,7 +728,7 @@ property</dfn>-<dfn class="lint-ignore">value</dfn> relationships.
         </p>
 
         <figure id="basic-structure">
-          <img style="margin: auto; display: block; width: 50%;"
+          <img style="margin: auto; display: block; width: 80%;"
             src="diagrams/claim.svg" alt="subject has a property which
             has a value">
           <figcaption style="text-align: center;">
@@ -744,7 +744,7 @@ as shown in <a href="#basic-example"></a> below.
         </p>
 
         <figure id="basic-example">
-          <img style="margin: auto; display: block; width: 60%;"
+          <img style="margin: auto; display: block; width: 80%;"
             src="diagrams/claim-example.svg" alt="Pat has an alumniOf
             property whose value is Example University">
           <figcaption style="text-align: center;">
@@ -761,7 +761,7 @@ professor.
         </p>
 
         <figure id="multiple-claims">
-          <img style="margin: auto; display: block; width: 75%;"
+          <img style="margin: auto; display: block; width: 90%;"
             src="diagrams/claim-extended.svg" alt="extends previous
             diagram with another property called knows whose value is
             Sam, and Sam has a property jobTitle whose value is Professor">
@@ -2578,7 +2578,7 @@ Section <a href="#zero-knowledge-proofs"></a>.
           </p>
 
           <figure>
-            <img style="margin: auto; display: block; width: 50%;"
+            <img style="margin: auto; display: block; width: 80%;"
                  src="diagrams/claim-example-2.svg" alt="Pat has a property
                  overAge whose value is 21">
             <figcaption style="text-align: center;">
@@ -3937,7 +3937,7 @@ will be added here in the future, or this section will be removed.
         </p>
 
         <figure>
-          <img style="margin: auto; display: block; width: 75%;"
+          <img style="margin: auto; display: block; width: 98%;"
             src="diagrams/zkp-cred-pres.svg" alt="Verifiable
             Credential 1 and Verifiable Credential 2 on the left map
             to Derived Credential 1 and Derived Credential 2 inside a


### PR DESCRIPTION
I have re-created the older diagrams with two goals in mind:

- Have some consistency in the "visual language" of the older and newer diagrams (@davidlehn, this was one of your remarks in an older PR)
- All diagrams are now (I hope) dark-mode ready

What dark-mode readiness means:
- Diagrams have a transparent background
- The interior of the various figures (ellipses, rectangles, etc.) are "no-fill", i.e., they are all transparent
- Be careful about colors, because dark mode may mean transforming them into other colors

I have made _no_ change on the diagrams' content. Please, if you review this PR, do _not_ ask here to make a content change on the diagrams; raise a separate issue and I will be happy to take care of it in a separate PR.

All diagrams, except one, are edited using the drawio format. The PR includes both the drawio and the SVG files.

The default preview is useless, because it does not perform the include action. Use the [dedicated preview](https://raw.githack.com/w3c/vc-data-model/iherman-diagrams-for-dark-mode/index.html) for review.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1458.html" title="Last updated on Mar 13, 2024, 11:00 AM UTC (97ba9f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1458/d41c9af...97ba9f0.html" title="Last updated on Mar 13, 2024, 11:00 AM UTC (97ba9f0)">Diff</a>