### PR TITLE
Removing sha3 reference from the vocabulary table.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6980,7 +6980,7 @@ Implementations that depend on RDF vocabulary processing MUST ensure that the
 following vocabulary URLs used in the base context ultimately resolve to the
 following files when loading the JSON-LD serializations, which are normative. Other semantically equivalent
 serializations of the vocabulary files MAY be used by implementations.
-Cryptographic hashes are provided for all the JSON-LD content to ensure that developers can
+Cryptographic hash is provided for all the JSON-LD content to ensure that developers can
 verify that the content of each file is correct.
         </p>
 
@@ -6988,7 +6988,7 @@ verify that the content of each file is correct.
           <thead>
             <tr>
               <th>URL</th>
-              <th>JSON-LD Content and Hashes</th>
+              <th>JSON-LD Content and Hash</th>
             </tr>
           </thead>
           <tbody>

--- a/index.html
+++ b/index.html
@@ -6978,10 +6978,10 @@ implementer feedback that requires the referenced URLs to be modified.
         <p>
 Implementations that depend on RDF vocabulary processing MUST ensure that the
 following vocabulary URLs used in the base context ultimately resolve to the
-following files when loading the JSON-LD serializations, which are normative. Other semantically equivalent
-serializations of the vocabulary files MAY be used by implementations.
-Cryptographic hash is provided for all the JSON-LD content to ensure that developers can
-verify that the content of each file is correct.
+following files when loading the JSON-LD serializations, which are normative.
+Other semantically equivalent serializations of the vocabulary files MAY be used
+by implementations. A cryptographic hash is provided for each JSON-LD document
+to ensure that developers can verify that the content of each file is correct.
         </p>
 
         <table class="simple">

--- a/index.html
+++ b/index.html
@@ -6988,7 +6988,7 @@ to ensure that developers can verify that the content of each file is correct.
           <thead>
             <tr>
               <th>URL</th>
-              <th>JSON-LD Content and Hash</th>
+              <th>JSON-LD Documents and Hashes</th>
             </tr>
           </thead>
           <tbody>

--- a/index.html
+++ b/index.html
@@ -6999,8 +6999,6 @@ https://www.w3.org/2018/credentials#
               <td>
 https://www.w3.org/2018/credentials/index.jsonld<br><br>
 sha256: `z52TgKqh2nqTCuACI8lCvhRdjwxQjeVmuOMCDCEijq4=`<br><br>
-sha3-512: <code>m8Ss+jgZiyL2Ws/ICJcWjHFd9PccJWsXPvMatBOhrH<wbr>
-h0qCBrzfgO2zO1OQQbTL7zoPgLseIbcxJJpunD2bkoRA==</code>
               </td>
             </tr>
             <tr>
@@ -7010,8 +7008,6 @@ https://w3id.org/security#
               <td>
 https://w3c.github.io/vc-data-integrity/vocab/security/vocabulary.jsonld<br><br>
 sha256: `LEaoTyf796eTaSlYWjfPe3Yb+poCW9TjWYTbFDmC0tc=`<br><br>
-sha3-512: <code>f4DhJ3xhT8nT+GZ8UUZi4QC+HT//wXE2fRTgUP4UNw<wbr>
-e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
               </td>
             </tr>
           </tbody>
@@ -7019,9 +7015,9 @@ e4kvel2PFfd6jcofHBm9BjwEiGzVFGv4K+fFTKXRD2NA==</code>
 
         <p>
 It is possible to confirm the cryptographic digests listed above by running
-a command like the following (replacing `&lt;DOCUMENT_URL>` and `&lt;DIGEST_ALGORITHM>`
-with appropriate values) through a modern UNIX-like OS command line interface:
-`curl -sL -H "Accept: application/ld+json" &lt;DOCUMENT_URL> | openssl dgst -&lt;DIGEST_ALGORITHM> -binary | openssl base64 -nopad -a`
+a command like the following, replacing `&lt;DOCUMENT_URL>`
+with the appropriate value, through a modern UNIX-like OS command line interface:
+`curl -sL -H "Accept: application/ld+json" &lt;DOCUMENT_URL> | openssl dgst -sha256 -binary | openssl base64 -nopad -a`
         </p>
 
         <p class="note"


### PR DESCRIPTION
Although the [WG discussion](https://github.com/w3c/vc-data-model/issues/1455#issuecomment-1994834278) on #1455 did not formally conclude (due to a lack of meeting time), I have the feeling that we were heading for a consensus to remove the sha3 hashes from the vocabulary table. This PR just does that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1459.html" title="Last updated on Mar 23, 2024, 10:10 PM UTC (c94a4b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1459/9db6fe3...c94a4b8.html" title="Last updated on Mar 23, 2024, 10:10 PM UTC (c94a4b8)">Diff</a>