### PR TITLE
fix: unmatch tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -2447,7 +2447,7 @@ The example below shows a [=verifiable presentation=]:
   "id": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
   "type": ["VerifiablePresentation", "ExamplePresentation"],
   <span class="highlight">"verifiableCredential": [{ <span class="comment">...</span> }]
-}
+}</span>
         </pre>
 
         <p>
@@ -2940,7 +2940,7 @@ The [=verifier=] <a href="#lifecycle-details">verifies</a>.
 The [=verifier=] <a href="#lifecycle-details">validates</a> claims.
           </li>
           <li>
-The [=verifier=] applies valid claims</a>.
+The [=verifier=] applies valid claims.
           </li>
         </ol>
 
@@ -4508,8 +4508,6 @@ either explicitly defined as JSON-LD `@context` mappings (e.g.,
 `@vocab` feature that applies to all undefined terms.
           </li>
        </ul>
-
-        </p>
 
         <section>
           <h3>Syntactic Sugar</h3>
@@ -7465,7 +7463,7 @@ parenthetical remark '(a named graph)'
         Each [=verifiable credential graph=] contains a single
         <a href="#defn-EnvelopedVerifiableCredential">`EnvelopedVerifiableCredential`</a> instance,
         referring, via a `data:` URL [[RFC2397]], to a verifiable credential secured via
-        an [=enveloping proof=]</a>.
+        an [=enveloping proof=].
       </p>
 
       <figure id="info-graph-vp-jwt-mult-creds">

--- a/index.html
+++ b/index.html
@@ -2940,7 +2940,7 @@ The [=verifier=] <a href="#lifecycle-details">verifies</a>.
 The [=verifier=] <a href="#lifecycle-details">validates</a> claims.
           </li>
           <li>
-The [=verifier=] applies valid claims.
+The [=verifier=] applies valid [=claims=].
           </li>
         </ol>
 


### PR DESCRIPTION
I fixed some of tags are not matching.
It closes #1460


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukasjhan/vc-data-model/pull/1461.html" title="Last updated on Mar 21, 2024, 12:35 AM UTC (5853699)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1461/fc22559...lukasjhan:5853699.html" title="Last updated on Mar 21, 2024, 12:35 AM UTC (5853699)">Diff</a>