### PR TITLE
Move section on code injection to security considerations.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6357,6 +6357,54 @@ propriety of [=credential=] use, stakeholders are urged to assess the
 specific context of their intended application.
         </p>
       </section>
+
+      <section class="informative">
+        <h3>Code Injection</h3>
+
+        <p>
+It is possible to include data in [=verifiable credentials=] that include
+executable code or scripting languages. Authors of verifiable credentials are
+advised to avoid doing so, unless necessary, and the risks have been mitigated
+to the extent possible.
+        </p>
+
+        <p>
+For example, when a single natural language string contains multiple languages
+or annotations, the contents of the string might require additional structure or
+markup in order to be presented correctly. It is possible to use markup
+languages, such as HTML, to label spans of text in different languages or to
+supply string-internal markup needed for proper display of [=bidirectional
+text=]. It is also possible to use the `rdf:HTML` datatype to encode such values
+accurately in JSON-LD.
+        </p>
+
+        <p>
+Despite the ability to encode information as HTML, implementers are strongly
+discouraged from doing this because it:
+        </p>
+
+        <ul>
+          <li>
+Requires some version of an HTML processor, which increases the burden of
+processing language and base direction information.
+          </li>
+          <li>
+Increases the security attack surface when utilizing this data model because
+naively processing HTML could result in executing a `script` tag that
+an attacker injected at some point during the data production process.
+          </li>
+        </ul>
+
+        <p>
+If implementers feel they need to use HTML, or other markup languages capable of
+containing executable scripts, to address a specific use case, they are advised
+to analyze how an attacker would use the markup to mount injection attacks
+against a consumer of the markup and then deploy mitigations against the
+identified attacks such as running the HTML rendering engine in a sandbox with
+no ability to have access to the network.
+        </p>
+      </section>
+
     </section>
 
     <section class="informative">
@@ -6536,45 +6584,6 @@ associated with them SHOULD be treated as if the language value is `undefined`
 (language tag "`und`"). Natural language string values that do not have a base
 direction associated with them SHOULD be treated as if the direction value is
 "`auto`".
-        </p>
-      </section>
-
-      <section class="informative">
-        <h3>Complex Language Markup</h3>
-
-        <p>
-When a single natural language string contains multiple languages or
-annotations, the contents of the string might require additional structure or
-markup in order to be presented correctly. It is possible to use markup
-languages, such as HTML, to label spans of text in different languages or to
-supply string-internal markup needed for proper display of [=bidirectional
-text=]. It is also possible to use the `rdf:HTML` datatype to
-encode such values accurately in JSON-LD.
-        </p>
-
-        <p>
-Despite the ability to encode information as HTML, implementers are strongly
-discouraged from doing this because it:
-        </p>
-
-        <ul>
-          <li>
-Requires some version of an HTML processor, which increases the burden of
-processing language and base direction information.
-          </li>
-          <li>
-Increases the security attack surface when utilizing this data model because
-blindly processing HTML could result in executing a `script` tag that
-an attacker injected at some point during the data production process.
-          </li>
-        </ul>
-
-        <p>
-If implementers feel they must use HTML, or other markup languages capable of
-containing executable scripts, to address a specific use case, they are advised
-to analyze how an attacker would use the markup to mount injection attacks
-against a consumer of the markup and then deploy mitigations against the
-identified attacks.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -6362,7 +6362,7 @@ specific context of their intended application.
         <h3>Code Injection</h3>
 
         <p>
-It is possible to include data in [=verifiable credentials=] that include
+It is possible for data in [=verifiable credentials=] to include
 executable code or scripting languages. Authors of verifiable credentials are
 advised to avoid doing so, unless necessary, and the risks have been mitigated
 to the extent possible.
@@ -6373,24 +6373,24 @@ For example, when a single natural language string contains multiple languages
 or annotations, the contents of the string might require additional structure or
 markup in order to be presented correctly. It is possible to use markup
 languages, such as HTML, to label spans of text in different languages or to
-supply string-internal markup needed for proper display of [=bidirectional
+supply string-internal markup needed for the proper display of [=bidirectional
 text=]. It is also possible to use the `rdf:HTML` datatype to encode such values
 accurately in JSON-LD.
         </p>
 
         <p>
 Despite the ability to encode information as HTML, implementers are strongly
-discouraged from doing this because it:
+discouraged from doing so, for the following reasons:
         </p>
-
+        
         <ul>
           <li>
-Requires some version of an HTML processor, which increases the burden of
+It requires some version of an HTML processor, which increases the burden of
 processing language and base direction information.
           </li>
           <li>
-Increases the security attack surface when utilizing this data model because
-naively processing HTML could result in executing a `script` tag that
+It increases the security attack surface when utilizing this data model, because
+naively processing HTML could result in the execution of a `script` tag that
 an attacker injected at some point during the data production process.
           </li>
         </ul>
@@ -6398,10 +6398,10 @@ an attacker injected at some point during the data production process.
         <p>
 If implementers feel they need to use HTML, or other markup languages capable of
 containing executable scripts, to address a specific use case, they are advised
-to analyze how an attacker would use the markup to mount injection attacks
-against a consumer of the markup and then deploy mitigations against the
-identified attacks such as running the HTML rendering engine in a sandbox with
-no ability to have access to the network.
+to analyze how an attacker could use the markup to mount injection attacks
+against a consumer of the markup, and then deploy mitigations against the
+identified attacks, such as running the HTML rendering engine in a sandbox with
+no ability to access the network.
         </p>
       </section>
 


### PR DESCRIPTION
This PR is an attempt to address issue #1254 by moving the "Complex Markup" section into the "Security Considerations" section and warning about code injection attacks.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1463.html" title="Last updated on Apr 2, 2024, 1:33 PM UTC (ca5efaa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1463/a80301d...ca5efaa.html" title="Last updated on Apr 2, 2024, 1:33 PM UTC (ca5efaa)">Diff</a>