### PR TITLE
Address Jeffrey Yasskin's review comments that are Editorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -1292,30 +1292,23 @@ Software systems that process the kinds of objects specified in this document
 use type information to determine whether or not a provided
 [=verifiable credential=] or [=verifiable presentation=] is appropriate
 for the intended use case. This specification defines a `type`
-[=property=] for the expression of type information. This type information
-can be used during [=validation=] processes as described in Appendix
-<a href="#validation"></a>.
+[=property=] for the expression of object type information. This type
+information can be used during [=validation=] processes as described in Appendix
+[[[#validation-0]]].
         </p>
 
         <p>
-[=Verifiable credentials=] and [=verifiable presentations=] MUST have a
-`type` [=property=]. That is, any [=credential=] or
-[=presentation=] that does not have `type` [=property=]
-<em>is not [=verifiable=]</em>, so is neither a [=verifiable credential=]
-nor a [=verifiable presentation=].
+[=Verifiable credentials=] and [=verifiable presentations=] MUST express a
+`type` [=property=] with an associated value.
         </p>
 
         <dl>
           <dt><dfn class="export" data-lt="type|types">type</dfn></dt>
           <dd>
-The value of the `type` [=property=] MUST be, or map to (through
-interpretation of the `@context` property), one or more [=URLs=].
-If more than one [=URL=] is provided, the [=URLs=] MUST be interpreted
-as an unordered set. Syntactic conveniences SHOULD be used to ease developer
-usage. Such conveniences might include JSON-LD terms. It is RECOMMENDED that
-each [=URL=] in the `type` be one which, if dereferenced, results
-in a document containing machine-readable information about the
-`type`.
+The value of the `type` [=property=] MUST be one or more
+<a href="https://www.w3.org/TR/json-ld/#dfn-term">terms</a> and/or absolute
+[=URLs=] (<a data-cite="URL#absolute-url-string">absolute url string</a>). If
+more than one value is provided, the order does not matter.
           </dd>
         </dl>
 
@@ -1392,7 +1385,7 @@ A valid [=credential=] status [=type=]. For example,<br>
               </td>
               <td>
 A valid terms of use [=type=]. For example,<br>
-`"type": "ExampleTermsPolicy"`)
+`"type": "ExampleTermsPolicy"`
               </td>
             </tr>
 
@@ -1460,11 +1453,10 @@ Title of the degree in the `name` property.
         </ul>
 
         <p>
-This enables implementers to rely on values associated with the
-`type` property for [=verification=] purposes. The expectation of
-[=types=] and their associated properties should be documented in at least a
-human-readable specification, and preferably, in an additional machine-readable
-representation.
+This enables implementers to rely on values associated with the `type` property
+for [=verification=] purposes. [=Types=], and their associated properties, are
+expected to be documented in at least a human-readable specification, and
+preferably, in an additional machine-readable representation.
         </p>
 
         <p class="note">

--- a/index.html
+++ b/index.html
@@ -3098,17 +3098,23 @@ is also desirable to know that the contents of the JSON-LD context(s) used in
 the [=verifiable credential=] are the same when used by both the [=issuer=] and
 [=verifier=].
         </p>
+
+        <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
+The requirement that contexts be listed in `relatedResource` is currently being
+debated in the VCWG. This requirement might be removed in future iterations of
+the specification.
+        </p>
+
         <p>
-To extend integrity protection to a related resource, a
-[=verifiable credential=], an author MAY include the `relatedResource`
-property:
+To extend integrity protection to a related resource, an [=issuer=] of a
+[=verifiable credential=] MAY include the `relatedResource` property:
         </p>
 
         <dl>
           <dt id="defn-relatedResource">relatedResource</dt>
           <dd>
 The value of the `relatedResource` property MUST be associated with one or
-more objects containing the following values:
+more objects of the following form:
             <table class="simple">
               <thead>
                 <th>Property</th>
@@ -3118,9 +3124,9 @@ more objects containing the following values:
                 <tr>
                   <td>`id`</td>
                   <td>
-The REQUIRED identifier for the resource, as defined in Section
-[[[#identifiers]]]. The value MUST be unique among the list of related
-resource objects.
+The identifier for the resource is REQUIRED and conforms to the format defined
+in Section [[[#identifiers]]]. The value MUST be unique among the list of
+related resource objects.
                   </td>
                 </tr>
                 <tr>
@@ -3145,16 +3151,10 @@ A cryptographic digest, as defined in [[[VC-DATA-INTEGRITY]]].
                 </tr>
               </tbody>
             </table>
-Each value associated with `relatedResource` MUST contain at least a `digestSRI`
-or `digestMultibase` value.
+Each object associated with `relatedResource` MUST contain at least a
+`digestSRI` or `digestMultibase` value.
           </dd>
         </dl>
-
-        <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
-The requirement that contexts be listed in `relatedResource` is currently being
-debated in the VCWG. This requirement might be removed in future iterations of
-the specification.
-        </p>
 
         <p class="issue" title="Unification of cryptographic hash expression formats are under discussion">
 The Working Group is currently attempting to determine whether cryptographic hash
@@ -3165,7 +3165,7 @@ are arguments for and against unification that the WG is currently debating.
 
         <p>
 If a `mediaType` is listed, implementations that retrieve the resource
-over [[[?HTTP]]] SHOULD:
+using [[[?RFC9110]]] SHOULD:
         </p>
         <ul>
           <li>
@@ -3177,7 +3177,7 @@ use the media type in the `Content-Type` HTTP Header.
         </ul>
 
         <p>
-Any object in the [=verifiable credential=] that contains an `id` [[URL]]
+Any object in the [=verifiable credential=] that contains an `id`
 property MAY be annotated with integrity information as specified in this
 section.
         </p>

--- a/index.html
+++ b/index.html
@@ -798,8 +798,8 @@ time period, a representative image, [=verification material=], status
 information, and so on. A
 [=verifiable credential=] is a set of tamper-evident [=claims=] and metadata
 that cryptographically prove who issued it. Examples of [=verifiable
-credentials=] include digital employee identification cards, digital birth
-certificates, and digital educational certificates.
+credentials=] include, but are not limited to, digital employee identification
+cards, digital birth certificates, and digital educational certificates.
         </p>
 
         <figure id="basic-vc">
@@ -890,10 +890,11 @@ arrow, to a separate rectangle, containing a single text field:
         </figure>
 
         <p class="note">
-[=Credential=] identifiers are often used to identify specific instances
-of a [=credential=]. These identifiers can also be used for correlation. A
-[=holder=] wanting to minimize correlation is advised to use a selective
-disclosure scheme that does not reveal the [=credential=] identifier.
+[=Credential=] identifiers can be used to identify specific instances
+of a [=credential=]. These identifiers could also be used for unwanted
+correlation. A [=holder=] wanting to minimize correlation is advised
+to use a selective disclosure scheme that does not reveal the
+[=credential=] identifier.
         </p>
 
         <p class="note">
@@ -1303,12 +1304,12 @@ use type information to determine whether or not a provided
 [=verifiable credential=] or [=verifiable presentation=] is appropriate
 for the intended use case. This specification defines a `type`
 [=property=] for the expression of object type information. This type
-information can be used during [=validation=] processes as described in Appendix
+information can be used during [=validation=] processes, as described in Appendix
 [[[#validation]]].
         </p>
 
         <p>
-[=Verifiable credentials=] and [=verifiable presentations=] MUST express a
+[=Verifiable credentials=] and [=verifiable presentations=] MUST contain a
 `type` [=property=] with an associated value.
         </p>
 
@@ -1479,7 +1480,7 @@ the same URL.
         <p class="note" title="Creating new verifiable credential types">
 Explaining how to create new types of [=verifiable credentials=] is beyond
 the scope of this specification. Readers that are interested in doing so are
-advised to read the Section on
+advised to read the section on
 <a data-cite="?VC-IMP-GUIDE#creating-new-credential-types">
 Creating New Credential Types</a> in the [[[?VC-IMP-GUIDE]]].
         </p>
@@ -3192,7 +3193,7 @@ Specification authors that write algorithms that fetch a resource based on the
 `id` of an object inside a [=conforming document=] need to consider whether
 that resource's content is vital to the validity of that document. If it is, the
 specification MUST produce a validation error unless the resource matches the
-expected media type and cryptographic digest
+expected media type and cryptographic digest.
         </p>
         <p>
 Implementers are urged to consult appropriate sources, such as the
@@ -5090,7 +5091,7 @@ credential=].
         <p>
 [=Securing mechanism=] specification authors are advised to avoid enabling
 identifier-based correlation by designing their technologies, when possible,
-to avoid the use of correlating identifiers.
+to avoid the use of correlating identifiers that cannot be selectively disclosed.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -5211,59 +5211,65 @@ make purchases without revealing more PII than necessary.
 
         <p>
 Privacy violations occur when information divulged in one context leaks into
-another. Accepted best practice for preventing such violations is to limit the
-information requested, and received, to the absolute minimum necessary. This
-data minimization approach is required by regulation in multiple jurisdictions,
-including the Health Insurance Portability and Accountability Act (HIPAA) in the
-United States and the General Data Protection Regulation (GDPR) in the European
-Union.
+another. One accepted best practice for preventing such a violation is for
+[=verifiers=] to limit the information requested, and received, to the absolute
+minimum necessary for a particular transaction. This data minimization approach
+is required by regulation in multiple jurisdictions, including the Health
+Insurance Portability and Accountability Act (HIPAA) in the United States and
+the General Data Protection Regulation (GDPR) in the European Union.
         </p>
         <p>
 With [=verifiable credentials=], data minimization for [=issuers=] means
-limiting the content of a [=verifiable credential=] to the minimum required
-by potential [=verifiers=] for expected use. For [=verifiers=], data
-minimization means limiting the scope of the information requested or
-required for accessing services.
+limiting the content of a [=verifiable credential=] to the minimum required by
+potential [=verifiers=] for expected use. For [=verifiers=], data minimization
+means limiting the scope of the information requested or required for accessing
+services.
         </p>
         <p>
 For example, a driver's license containing a driver's ID number, height, weight,
-birthday, and home address is a [=credential=] containing more information
-than is necessary to establish that the person is above a certain age.
+birthday, and home address expressed as a [=verifiable credential=] contains
+more information than is necessary to establish that the person is above a
+certain age.
         </p>
 
         <p>
-It is considered best practice for [=issuers=] to atomize information or use
-a signature scheme that allows for [=selective disclosure=]. For example, an
+It is considered best practice for [=issuers=] to atomize information or use a
+securing mechanism that allows for [=selective disclosure=]. For example, an
 [=issuer=] of driver's licenses could issue a [=verifiable credential=]
-containing every property that appears on a driver's license, as well as a set
-of [=verifiable credentials=] where every [=verifiable credential=]
-contains only a single property, such as a person's birthday. It could also
-issue more abstract [=verifiable credentials=] (for example, a
-[=verifiable credential=] containing only an `ageOver` property).
-One possible adaptation would be for [=issuers=] to provide secure HTTP
-endpoints for retrieving single-use [=bearer credentials=] that promote the
-pseudonymous usage of [=verifiable credentials=]. Implementers that find this
-impractical or unsafe, should consider using [=selective disclosure=] schemes
-that eliminate dependence on [=issuers=] at proving time and reduce temporal
-correlation risk from [=issuers=].
+containing every property that appears on a driver's license and allow each
+property to be selectively disclosed by the [=holder=]. It could also issue more
+abstract [=verifiable credentials=] (for example, a [=verifiable credential=]
+containing only an `ageOver` property). One possible adaptation would be for
+[=issuers=] to provide secure HTTP endpoints for retrieving single-use [=bearer
+credentials=] that promote the pseudonymous usage of [=verifiable credentials=].
+Implementers that find this impractical or unsafe, might consider using
+[=selective disclosure=] schemes that eliminate dependence on [=issuers=] at
+proving time and reduce temporal correlation risk from [=issuers=].
         </p>
 
         <p>
 [=Verifiers=] are urged to only request information that is absolutely
 necessary for a specific transaction to occur. This is important for at least
-two reasons. It:
+two reasons.
         </p>
 
         <ul>
           <li>
-Reduces the liability on the [=verifier=] for handling highly sensitive
-information that it does not need to.
+It reduces the liability on the [=verifier=] for handling highly sensitive
+information that it does not need to, and
           </li>
           <li>
-Enhances the privacy of the individual by only asking for information required
-for a specific transaction.
+it enhances the privacy of the individual by only asking for information
+required for a specific transaction.
           </li>
         </ul>
+
+        <p>
+Implementers of software used by [=holders=] are urged to disclose what
+information is being requested by a [=verifier=] such that a [=holder=] can
+push back on the over-collection of information that is unnecessary for the
+transaction.
+        </p>
 
         <p class="note">
 While it is possible to practice the principle of minimum disclosure, it might

--- a/index.html
+++ b/index.html
@@ -5023,38 +5023,54 @@ to protect personally identifiable information.
         <h3>Identifier-Based Correlation</h3>
 
         <p>
+[=Verifiable credentials=] might contain long-lived identifiers that could be
+used to correlate individuals. These types of identifiers include [=subject=]
+identifiers, email addresses, government-issued identifiers, organization-issued
+identifiers, addresses, healthcare vitals, and many other sorts of long-lived
+identifiers. Implementers of software used by [=holders=] are advised to strive
+to detect identifiers in [=verifiable credentials=] containing information that
+could be used to correlate individuals and warn [=holders=] when they are
+getting ready to share this information. The rest of this section elaborates
+on guidance related to the use of long-lived identifiers.
+        </p>
+
+        <p>
 [=Subjects=] of [=verifiable credentials=] are identified using the `id`
 property, as defined in Section [[[#identifiers]]], and are used in places such
 as the `credentialSubject.id` property. The identifiers used to identify a
 [=subject=] create a greater risk of correlation when the identifiers are
-long-lived or used across more than one web domain.
+long-lived or used across more than one web domain. Other types of identifiers
+that fall into this category are email addresses, government-issued identifiers,
+and organization-issued identifiers.
         </p>
 
         <p>
 Similarly, disclosing the [=credential=] identifier (such as in
-[[[#example-usage-of-the-id-property]]]) leads to
-situations where multiple [=verifiers=], or an [=issuer=] and a [=verifier=],
-can collude to correlate the [=holder=]. If [=holders=] want to reduce
-correlation, they are advised to use [=verifiable credentials=] from [=issuers=]
-that allow selectively disclosing correlating identifiers in a [=verifiable
-presentation=]. Such approaches expect the [=holder=] to generate the identifier
-and might even allow hiding the identifier from the [=issuer=] through the use
-of techniques like
+[[[#example-usage-of-the-id-property]]]) leads to situations where multiple
+[=verifiers=], or an [=issuer=] and a [=verifier=], can collude to correlate the
+[=holder=].
+        </p>
+
+        <p>
+If [=holders=] want to reduce correlation, they are advised to use [=verifiable
+credentials=] from [=issuers=] that allow selectively disclosing correlating
+identifiers in a [=verifiable presentation=]. Such approaches expect the
+[=holder=] to generate the identifier and might even allow hiding the identifier
+from the [=issuer=] through the use of techniques like
 <a href="https://en.wikipedia.org/wiki/Blind_signature">blind signatures</a>,
 while still keeping the identifier embedded and signed in the [=verifiable
 credential=].
         </p>
 
         <p>
-Securing mechanism specification authors are advised to avoid enabling
+[=Securing mechanism=] specification authors are advised to avoid enabling
 identifier-based correlation by designing their technologies, when possible,
 to avoid the use of correlating identifiers.
         </p>
 
         <p>
-If strong anti-correlation properties are a requirement in a
-[=verifiable credentials=] system, it is strongly advised that identifiers
-are either:
+If strong anti-correlation properties are a requirement in a [=verifiable
+credentials=] system, it is strongly advised that identifiers are either:
         </p>
 
         <ul>
@@ -5116,26 +5132,6 @@ properties of the cryptography used. See Sections
 [[[#long-lived-identifier-based-correlation]]],
 [[[#metadata-based-correlation]]], [[[#correlation-during-validation]]],
 and most of the other sections in Section [[[#privacy-considerations]]].
-        </p>
-      </section>
-
-      <section class="informative">
-        <h3>Long-Lived-Identifier-Based Correlation</h3>
-
-        <p>
-[=Verifiable credentials=] might contain long-lived identifiers that could
-be used to correlate individuals. These types of identifiers include
-[=subject=] identifiers, email addresses, government-issued identifiers,
-organization-issued identifiers, addresses, healthcare vitals,
-[=verifiable credential=]-specific JSON-LD contexts, and many other sorts of
-long-lived identifiers.
-        </p>
-
-        <p>
-Organizations providing software to [=holders=] should strive to identify
-fields in [=verifiable credentials=] containing information that could be
-used to correlate individuals and warn [=holders=] when this information is
-shared.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@ Information related to the type of [=credential=] this is (for example, a
 Dutch passport, an American driving license, or a health insurance card)
           </li>
           <li>
-Information related to specific attributes or properties being asserted by
+Information related to specific properties being asserted by
 the issuing authority about the [=subject=] (for example, nationality,
 the classes of vehicle entitled to drive, or date of birth)
           </li>
@@ -570,7 +570,7 @@ from them. A holder is often, but not always, a [=subject=] of the
         <dd>
 The means for keeping track of [=entities=] across contexts. Digital
 identities enable tracking and customization of [=entity=] interactions
-across digital contexts, typically using identifiers and attributes. Unintended
+across digital contexts, typically using identifiers and properties. Unintended
 distribution or use of identity information can compromise privacy. Collection
 and use of such information should follow the principle of
 [=data minimization=].
@@ -1081,7 +1081,7 @@ tooling to start issuing, holding, and verifying prototype credentials.
 It is expected that a developer will change `MyPrototypeCredential` below to
 the type of credential they would like to create. Since
 [=verifiable credentials=] talk about subjects, each property-value pair in
-the `credentialSubject` object expresses a particular attribute of the
+the `credentialSubject` object expresses a particular property of the
 credential subject. Once a developer has added a number of these property-value
 combinations, the modified object can be sent to [=verifiable credential=]
 issuer software and a [=verifiable credential=] will be created for the
@@ -1123,7 +1123,7 @@ mean the same thing to each other. This might be referred to as
         </p>
         <p>
 [=Verifiable credentials=] and [=verifiable presentations=] have many
-attributes and values that are identified by [=URLs=] [[URL]]. However,
+properties and values that are identified by [=URLs=] [[URL]]. However,
 those [=URLs=] can be long and not very human-friendly. In such cases,
 short-form human-friendly aliases can be more helpful. This specification uses
 the `@context` [=property=] to map such short-form aliases to the
@@ -1572,9 +1572,9 @@ respectively. See
         </p>
 
         <p class="note">
-The `@direction` attributes in the examples below are not required
+The `@direction` property in the examples below are not required
 for the associated single-language strings, as their default directions are the
-same as those set in the attribute. We include the `@direction` attributes here
+same as those set in the value. We include the `@direction` property here
 for clarity of demonstration, and to make copy+paste+edit deliver functional
 results. Implementers are encouraged to read the section on
 <a data-cite="JSON-LD11#string-internationalization">JSON-LD String Internationalization</a>
@@ -3788,9 +3788,9 @@ have at least a draft specification that is being incubated in a community group
               <td>`confidenceMethod`</td>
               <td>
 A property used for specifying one or more methods that a verifier might use to
-increase their confidence that the value of an attribute in or of a verifiable
+increase their confidence that the value of a property in or of a verifiable
 credential or verifiable presentation is accurate, including but not limited to
-attributes such as `initialRecipient` (a/k/a `issuee`), `presenter`,
+properties such as `initialRecipient` (a/k/a `issuee`), `presenter`,
 `authorizedPresenter`, `holder`, etc. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#confidenceMethod`.
                 <p class="issue" title="(AT RISK) Reservation depends on implementations">
@@ -5175,11 +5175,11 @@ than is necessary to establish that the person is above a certain age.
 It is considered best practice for [=issuers=] to atomize information or use
 a signature scheme that allows for [=selective disclosure=]. For example, an
 [=issuer=] of driver's licenses could issue a [=verifiable credential=]
-containing every attribute that appears on a driver's license, as well as a set
+containing every property that appears on a driver's license, as well as a set
 of [=verifiable credentials=] where every [=verifiable credential=]
-contains only a single attribute, such as a person's birthday. It could also
+contains only a single property, such as a person's birthday. It could also
 issue more abstract [=verifiable credentials=] (for example, a
-[=verifiable credential=] containing only an `ageOver` attribute).
+[=verifiable credential=] containing only an `ageOver` property).
 One possible adaptation would be for [=issuers=] to provide secure HTTP
 endpoints for retrieving single-use [=bearer credentials=] that promote the
 pseudonymous usage of [=verifiable credentials=]. Implementers that find this
@@ -5619,7 +5619,7 @@ that insist on collection and long-term retention of personally identifiable
 information can cause harm to individuals and organizations if that same
 information is compromised and accessed by an attacker. The technologies
 described by this specification enable [=holders=] to more-readily prove
-attributes about themselves and others, reducing the need for long-term data
+properties about themselves and others, reducing the need for long-term data
 retention by [=verifiers=]. Alternatives include keeping logs that the
 information was collected and checked, as well as random tests to ensure
 that compliance regimes are operating as expected.
@@ -5953,7 +5953,7 @@ While the data model outlines the structure and data elements necessary for a
 authorization of presented [=credentials=]. To address this concern,
 implementers might need to explore supplementary methods, such as binding
 [=verifiable credentials=] to strong authentication mechanisms or using
-additional attributes in [=verifiable presentations=]
+additional properties in [=verifiable presentations=]
 to enable proof of control.
         </p>
       </section>
@@ -6253,7 +6253,7 @@ MUST contain a `@value` property whose value is a string, and SHOULD contain a
 `@language` property whose value is a string containing a well-formed
 `Language-Tag` as defined by [[BCP47]], and MAY contain a `@direction` property
 whose value is a [=base direction=] string defined by the `@direction`
-attribute in [[JSON-LD11]]. The language value object MUST NOT include any other
+property in [[JSON-LD11]]. The language value object MUST NOT include any other
 keys beyond `@value`, `@language`, and `@direction`.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -5186,23 +5186,23 @@ list while performing status checks on a [=verifiable credential=].
         <h3>Favor Abstract Claims</h3>
 
         <p>
-To enable recipients of [=verifiable credentials=] to use them in a variety
-of circumstances without revealing more PII than necessary for transactions,
-[=issuers=] should consider limiting the information published in a
-[=credential=] to a minimal set needed for the expected purposes. One way to
-avoid placing PII in a [=credential=] is to use an abstract [=property=]
-that meets the needs of [=verifiers=] without providing specific information
-about a [=subject=].
+To enable recipients of [=verifiable credentials=] to use them in a variety of
+circumstances without revealing more PII than necessary for transactions,
+[=issuers=] are advised to limit the information published in a [=verifiable
+credential=] to a minimal set needed for the expected purposes. One way to avoid
+placing PII in a [=verifiable credential=] is to use an abstract [=property=]
+that meets the needs of [=verifiers=] without providing overly-specific
+information about a [=subject=].
         </p>
         <p>
 For example, this document uses the `ageOver` [=property=]
-instead of a specific birthdate, which constitutes much stronger PII. If
+instead of a specific birthdate, which represents mroe sensitive PII. If
 retailers in a specific market commonly require purchasers to be older than a
 certain age, an [=issuer=] trusted in that market might choose to offer a
 [=verifiable credential=] claiming that [=subjects=] have met that
 requirement instead of offering [=verifiable credentials=] containing
-[=claims=] about specific birthdates. This enables individual customers to
-make purchases without revealing specific PII.
+[=claims=] about the customer's birthday. This enables individual customers to
+make purchases without revealing more PII than necessary.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1304,7 +1304,7 @@ use type information to determine whether or not a provided
 for the intended use case. This specification defines a `type`
 [=property=] for the expression of object type information. This type
 information can be used during [=validation=] processes as described in Appendix
-[[[#validation-0]]].
+[[[#validation]]].
         </p>
 
         <p>
@@ -5365,16 +5365,15 @@ to unduly correlate the [=holder=].
       </section>
 
       <section class="informative">
-        <h3>Validation</h3>
+        <h3>Correlation During Validation</h3>
 
         <p>
 When processing [=verifiable credentials=], [=verifiers=]
 evaluate any relevant [=claims=] before relying upon them. This
 evaluation might be done in any manner desired, as long as it satisfies
 the requirements of the [=verifier=] doing the validation.
-Many verifiers will perform the checks listed in Appendix <a
-href="#validation-0"></a> as well as a variety of specific business process
-checks such as:
+Many verifiers will perform the checks listed in Appendix [[[#validation]]] as
+well as a variety of specific business process checks such as:
         </p>
 
         <ul>
@@ -6151,7 +6150,7 @@ enforce authorized use of their data after [=presentation=].
 While valid cryptographic signatures and successful status checks signify the
 reliability of [=credentials=], they do not signify that all
 [=credentials=] are interchangeable for all contexts. It is crucial that
-[=verifiers=] also <a href="#validation-0">validate</a> any claims which
+[=verifiers=] also <a href="#validation">validate</a> any claims which
 might be relevant, considering the source and nature of the claim as well as
 privilege or service for which the credential is presented.
         </p>

--- a/index.html
+++ b/index.html
@@ -4988,12 +4988,12 @@ and de-anonymizing capabilities.
         </p>
 
         <p>
-Implementers are strongly advised to warn [=holders=] when they share data
-with these kinds of characteristics. [=Issuers=] are strongly advised to
-provide privacy-protecting [=verifiable credentials=] when possible. For
-example, issuing `ageOver` [=verifiable credentials=] instead of
-date of birth [=verifiable credentials=] when a [=verifier=] wants to
-determine whether an [=entity=] is over the age of 18.
+Implementers of software used by [=holders=] are strongly advised to warn
+[=holders=] when they share data with these kinds of characteristics.
+[=Issuers=] are strongly advised to provide privacy-protecting [=verifiable
+credentials=] when possible. For example, issuing `ageOver` [=verifiable
+credentials=] instead of date of birth [=verifiable credentials=] when a
+[=verifier=] wants to determine whether an [=entity=] is over the age of 18.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -914,12 +914,11 @@ specific dog, but is issued to its owner.
 
         <p>
 Enhancing privacy is a key design feature of this specification. Therefore, it
-is important for [=entities=] using this technology to be able to express
-only the portions of their persona that are appropriate for a given situation.
-The expression of a subset of one's persona is called a
-[=verifiable presentation=]. Examples of different personas include a
-person's professional persona, their online gaming persona, their
-family persona, or an incognito persona.
+is important for [=entities=] using this technology to be able to express only
+the portions of their persona that are appropriate for a given situation. The
+expression of a subset of one's persona is called a [=verifiable presentation=].
+Examples of different personas include a person's professional persona, their
+online gaming persona, their family persona, or an incognito persona.
         </p>
 
         <p>
@@ -1043,13 +1042,25 @@ arrow, to a separate rectangle, containing a single text field:
         </figure>
 
 
-        <p class="note">
+        <p class="note"
+          title="Presentations can contain multiple verifiable credentials">
 It is possible to have a [=presentation=], such as a collection of university credentials, which
 draws on multiple [=credentials=] about different [=subjects=] that are
 often, but not required to be, related.
 This is achieved by using the `verifiableCredential` property to
 refer to multiple [=verifiable credentials=].
 See Appendix <a href="#additional-diagrams-for-verifiable-presentations"></a> for more details.
+        </p>
+
+        <p class="note"
+          title="Presentations can be presented by issuers and verifiers">
+As described in Section [[[#ecosystem-overview]]], an [=entity=] can take
+on one or more roles as they step through a particular credential exchange.
+While a [=holder=] is typically expected to generate [=presentations=], a
+[=issuer=] or [=verifier=] might generate a presentation to identify themselves
+to a [=holder=]. This might occur if the [=holder=] needs higher assurance
+from the [=issuer=] or [=verifier=] before handing over sensitive information
+contained in a [=verifiable presentation=].
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -641,10 +641,10 @@ specification defines how verifiers verify [=verifiable credentials=] and
 [=verifiable presentations=].<br/>
 It also specifies that [=verifiers=] validate claims in [=verifiable
 credentials=] before relying on them. However, the means for such validation
-vary widely and are outside the scope of this specification. It is expected
-that [=verifiers=] will trust certain [=issuers=] for certain claims and
-apply their own rules to determine which claims in which [=credentials=]
-are suitable for use by their systems.
+vary widely and are outside the scope of this specification. [=Verifiers=]
+trust certain [=issuers=] for certain claims and apply their own rules to
+determine which claims in which [=credentials=] are suitable for use by their
+systems.
         </dd>
         <dt><dfn class="export">verifiable credential</dfn></dt>
         <dd>
@@ -1076,14 +1076,14 @@ tooling to start issuing, holding, and verifying prototype credentials.
         </p>
 
         <p>
-It is expected that a developer will change `MyPrototypeCredential` below to
-the type of credential they would like to create. Since
-[=verifiable credentials=] talk about subjects, each property-value pair in
-the `credentialSubject` object expresses a particular property of the
-credential subject. Once a developer has added a number of these property-value
-combinations, the modified object can be sent to [=verifiable credential=]
-issuer software and a [=verifiable credential=] will be created for the
-developer. From a prototyping standpoint, that is all a developer needs to do.
+A developer will change `MyPrototypeCredential` below to the type of credential
+they would like to create. Since [=verifiable credentials=] talk about subjects,
+each property-value pair in the `credentialSubject` object expresses a
+particular property of the credential subject. Once a developer has added a
+number of these property-value combinations, the modified object can be sent to
+[=verifiable credential=] issuer software and a [=verifiable credential=] will
+be created for the developer. From a prototyping standpoint, that is all a
+developer needs to do.
         </p>
 
         <pre class="example nohighlight" title="A template for creating prototype verifiable credentials">
@@ -1273,12 +1273,11 @@ also known as a [=DID=].
         <p class="note">
 As of this publication, [=DIDs=] are a new type of identifier that are not
 necessary for [=verifiable credentials=] to be useful. Specifically,
-[=verifiable credentials=] do not depend on [=DIDs=] and [=DIDs=] do
-not depend on [=verifiable credentials=]. However, it is expected that many
-[=verifiable credentials=] will use [=DIDs=] and that software libraries
-implementing this specification will probably need to resolve [=DIDs=].
-[=DID=]-based URLs are used for expressing identifiers associated with
-[=subjects=], [=issuers=], [=holders=], credential status lists,
+[=verifiable credentials=] do not depend on [=DIDs=] and [=DIDs=] do not depend
+on [=verifiable credentials=]. However, many [=verifiable credentials=] will use
+[=DIDs=] and software libraries implementing this specification will need to
+resolve [=DIDs=]. [=DID=]-based URLs are used for expressing identifiers
+associated with [=subjects=], [=issuers=], [=holders=], credential status lists,
 cryptographic keys, and other machine-readable information associated with a
 [=verifiable credential=].
         </p>
@@ -2106,11 +2105,11 @@ guidance in Section <a href="#types"></a> MUST be followed.
 The precise content of the [=credential=] status information is determined by
 the specific `credentialStatus` [=type=] definition, and varies
 depending on factors such as whether it is simple to implement or if it is
-privacy-enhancing. It is expected that the value will provide enough information
-to determine the current status of the [=credential=] and that machine
-readable information will be retrievable from the URL. For example, the object
-could contain a link to an external document which notes whether or not the
-[=credential=] is suspended or revoked.
+privacy-enhancing. The value will provide enough information to determine the
+current status of the [=credential=] and that machine readable information will
+be retrievable from the URL. For example, the object could contain a link to an
+external document which notes whether or not the [=credential=] is suspended or
+revoked.
         </p>
 
         <pre class="example nohighlight"
@@ -2346,8 +2345,8 @@ dereferenced, results in a document containing machine-readable information
 about the [=holder=] that can be used to [=verify=] the information
 expressed in the [=verifiable presentation=].
 If the `holder` [=property=] is absent, information about the
-[=holder=] is expected to either be obtained via the securing mechanism, or
-to not pertain to the [=validation=] of the [=verifiable presentation=].
+[=holder=] is obtained either via the securing mechanism, or
+does not pertain to the [=validation=] of the [=verifiable presentation=].
           </dd>
         </dl>
 
@@ -2776,17 +2775,16 @@ The [=verifier=] expects the [=issuer=] to verifiably issue the
 either of the following:
             <ul>
               <li>
-An [=issuer=] is expected to secure a [=credential=] with a
-<a href="#securing-mechanisms">securing mechanism</a> which establishes
-that the [=issuer=] generated the [=credential=]. (In other words, an
-[=issuer=] is expected to [=issue=] a [=verifiable credential=].)
+An [=issuer=] secures a [=credential=] with a
+<a href="#securing-mechanisms">securing mechanism</a> which establishes that the
+[=issuer=] generated the [=credential=]. In other words, an [=issuer=]
+[=issues=] a [=verifiable credential=].
               </li>
               <li>
-A [=credential=] is expected to be transmitted in a way that clearly
-establishes that the [=issuer=] generated the [=credential=], and that
-the [=credential=] was not tampered with in transit nor storage. This
-expectation could be weakened, depending on the risk assessment by the
-[=verifier=].
+A [=credential=] is transmitted in a way that clearly establishes that the
+[=issuer=] generated the [=credential=], and that the [=credential=] was not
+tampered with in transit nor storage. This expectation could be weakened,
+depending on the risk assessment by the [=verifier=].
               </li>
             </ul>
           </li>
@@ -4492,9 +4490,9 @@ system.
         <section class="informative">
           <h2>HTTP</h2>
           <p>
-It is expected that HTTP endpoints will use the media types associated with
-[=verifiable credentials=] and [=verifiable presentations=] in accept
-headers and when indicating content types.
+HTTP clients and servers use media types associated with [=verifiable
+credentials=] and [=verifiable presentations=] in accept headers and when
+indicating content types.
           </p>
           <p>
 Nonetheless, HTTP servers might ignore the accept header and return another
@@ -6399,22 +6397,22 @@ and are published in places like the [[[VC-SPECS]]].
 
         <p>
 The type of a credential is expressed via the <a href="#types">type</a>
-property. A [=verifiable credential=] of a specific type is expected to contain
-specific [=properties=] (which might be deeply nested) that can be used to determine whether or not the
-[=presentation=] satisfies a set of processing rules that the [=verifier=]
-executes. By requesting [=verifiable credentials=] of a particular `type`, the
-[=verifier=] is able to gather specific information from the [=holder=], which
-originated with the [=issuer=] of each [=verifiable credential=], that will
-enable the [=verifier=] to determine the next stage of an interaction with a [=holder=].
+property. A [=verifiable credential=] of a specific type contains specific
+[=properties=] (which might be deeply nested) that can be used to determine
+whether or not the [=presentation=] satisfies a set of processing rules that the
+[=verifier=] executes. By requesting [=verifiable credentials=] of a particular
+`type`, the [=verifier=] is able to gather specific information from the
+[=holder=], which originated with the [=issuer=] of each [=verifiable
+credential=], that will enable the [=verifier=] to determine the next stage of
+an interaction with a [=holder=].
         </p>
 
         <p>
 When a [=verifier=] requests a [=verifiable credential=] of a specific type,
 there will be a set of mandatory and optional [=claims=] that are associated
-with that type. It is expected that a [=verifier=]'s validation of a
-[=verifiable credential=] will fail when mandatory [=claims=] are not
-included, and that any [=claim=] that is not associated with the specific
-type will be ignored. In other words, a
+with that type. A [=verifier=]'s validation of a [=verifiable credential=] will
+fail when mandatory [=claims=] are not included, and that any [=claim=] that is
+not associated with the specific type will be ignored. In other words, a
 [=verifier=] will perform input validation on the [=verifiable credential=] it
 receives and will reject malformed input based on the credential type
 specification.
@@ -6427,15 +6425,14 @@ specification.
 
         <p>
 In the [=verifiable credentials=] presented by a [=holder=], the value
-associated with the `id` [=property=] for each
-`credentialSubject` is expected to identify a [=subject=] to the
-[=verifier=]. If the [=holder=] is also the [=subject=], then
-the [=verifier=] could authenticate the [=holder=] if they have
-[=verification=] metadata related to the [=holder=]. The [=verifier=]
-could then authenticate the [=holder=] using a signature generated by the [=holder=]
-contained in the [=verifiable presentation=]. The `id`
-[=property=] is optional. [=Verifiers=] could use other [=properties=]
-in a [=verifiable credential=] to uniquely identify a [=subject=].
+associated with the `id` [=property=] for each `credentialSubject` identifies a
+[=subject=] to the [=verifier=]. If the [=holder=] is also the [=subject=], then
+the [=verifier=] could authenticate the [=holder=] if they have [=verification=]
+metadata related to the [=holder=]. The [=verifier=] could then authenticate the
+[=holder=] using a signature generated by the [=holder=] contained in the
+[=verifiable presentation=]. The `id` [=property=] is optional. [=Verifiers=]
+could use other [=properties=] in a [=verifiable credential=] to uniquely
+identify a [=subject=].
         </p>
 
         <p class="note">
@@ -6450,9 +6447,8 @@ Guidelines [[VC-IMP-GUIDE]] document.
         <h3>Issuer</h3>
 
         <p>
-The value associated with the `issuer` [=property=] is expected
-to identify an [=issuer=] that is known to and trusted by the
-[=verifier=].
+The value associated with the `issuer` [=property=] identifies an [=issuer=]
+to the [=verifier=].
         </p>
 
         <p>
@@ -6475,15 +6471,15 @@ issuers in addition to, or instead of, the mapping described above.
       <section class="informative">
         <h4>Holder</h4>
         <p>
-The value associated with the `holder` [=property=] is expected
-to be usable to identify the [=holder=] to the [=verifier=].
+The value associated with the `holder` [=property=] is used to identify the
+[=holder=] to the [=verifier=].
         </p>
         <p>
 Often relevant metadata about the [=holder=], as identified by the value of
 the `holder` [=property=], is available to, or retrievable by, the
 [=verifier=]. For example, a [=holder=] can publish information containing
 the [=verification material=] used to secure [=verifiable presentations=]. This
-metadata is expected to be used when checking proofs on [=verifiable presentations=].
+metadata is used when checking proofs on [=verifiable presentations=].
 Some cryptographic identifiers contain all necessary metadata in the identifier itself.
 In those cases, no additional metadata is required. Other identifiers use verifiable data
 registries where such metadata is automatically published for use by
@@ -6583,7 +6579,7 @@ authentication or encryption, of the cryptographic public key.
 The public key is not suspended, revoked, or expired.
           </li>
           <li>
-The digital signature is expected to verify.
+The digital signature verifies.
           </li>
           <li>
 Any additional requirements defined by the securing mechanism are satisfied.
@@ -7128,9 +7124,9 @@ This media type can be used for credentials secured using an
 [=enveloping proof=].
         </p>
         <p>
-A [[JSON-LD11]] context is expected to be present in the body of the document, and
-as indicated by the presence of `ld+json` in the media type, the credential is
-expected to be a valid
+A [[JSON-LD11]] context is expected to be present in the body of the document,
+and as indicated by the presence of `ld+json` in the media type, the credential
+is expected to be a valid
 <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD
 document</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -1306,9 +1306,9 @@ information can be used during [=validation=] processes as described in Appendix
           <dt><dfn class="export" data-lt="type|types">type</dfn></dt>
           <dd>
 The value of the `type` [=property=] MUST be one or more
-<a href="https://www.w3.org/TR/json-ld/#dfn-term">terms</a> and/or absolute
-[=URLs=] (<a data-cite="URL#absolute-url-string">absolute url string</a>). If
-more than one value is provided, the order does not matter.
+<a data-cite="JSON-LD11#dfn-term">terms</a> and/or
+<a data-cite="URL#absolute-url-string">absolute URL strings</a>. If more than
+one value is provided, the order does not matter.
           </dd>
         </dl>
 
@@ -1424,13 +1424,13 @@ more easily detect and process this additional information.
         </p>
 
         <p>
-When processing encapsulated objects defined in this specification, (for
-example, objects associated with the `credentialSubject` object or
-deeply nested therein), software systems SHOULD use the [=type=] information
-specified in encapsulating objects higher in the hierarchy. Specifically, an
-encapsulating object, such as a [=credential=], SHOULD convey the associated
-object [=types=] so that [=verifiers=] can quickly determine the contents
-of an associated object based on the encapsulating object [=type=].
+When processing encapsulated objects defined in this specification, such as
+objects associated with the `credentialSubject` object or deeply nested therein,
+software systems SHOULD use the [=type=] information specified in encapsulating
+objects higher in the hierarchy. Specifically, an encapsulating object, such as
+a [=credential=], SHOULD convey the associated object [=types=] so that
+[=verifiers=] can quickly determine the contents of an associated object based
+on the encapsulating object [=type=].
         </p>
 
         <p>
@@ -1454,16 +1454,24 @@ Title of the degree in the `name` property.
 
         <p>
 This enables implementers to rely on values associated with the `type` property
-for [=verification=] purposes. [=Types=], and their associated properties, are
-expected to be documented in at least a human-readable specification, and
-preferably, in an additional machine-readable representation.
+for [=verification=] purposes. Object types, and their associated values, are
+expected to be documented in at least a human-readable specification that can
+be found at the [=URL=] for the type. For example, the human-readable
+definition for the `BitstringStatusList` type can be found at
+<a href="https://www.w3.org/ns/credentials/status/#BitstringStatusList">
+https://www.w3.org/ns/credentials/status/#BitstringStatusList</a>. It is also
+suggested that a
+<a href="https://www.w3.org/ns/credentials/status/index.jsonld">
+machine-readable version</a> be provided, through HTTP content negotiation, at
+the same URL.
         </p>
 
-        <p class="note">
-The type system used in the data model described in this specification allows
-for multiple ways to associate types with data. Implementers and authors are
-urged to read the section on typing in the Verifiable Credentials
-Implementation Guidelines [[?VC-IMP-GUIDE]].
+        <p class="note" title="Creating new verifiable credential types">
+Explaining how to create new types of [=verifiable credentials=] is beyond
+the scope of this specification. Readers that are interested in doing so are
+advised to read the Section on
+<a data-cite="?VC-IMP-GUIDE#creating-new-credential-types">
+Creating New Credential Types</a> in the [[[?VC-IMP-GUIDE]]].
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -4978,13 +4978,13 @@ policy.
 
         <p>
 Data associated with [=verifiable credentials=] stored in the
-`credential.credentialSubject` field is susceptible to privacy
-violations when shared with [=verifiers=]. Personally identifying data, such
-as a government-issued identifier, shipping address, and full name, can be
-easily used to determine, track, and correlate an [=entity=]. Even
-information that does not seem personally identifiable, such as the
-combination of a birthdate and a postal code, has very powerful correlation
-and de-anonymizing capabilities.
+`credential.credentialSubject` field is susceptible to privacy violations when
+shared with [=verifiers=]. Personally identifying data, such as a
+government-issued identifier, shipping address, and full name, can be easily
+used to determine, track, and correlate an [=entity=]. Even information that
+does not seem to be personally identifiable, such as the combination of a
+birthdate and a postal code, has very powerful correlation and de-anonymizing
+capabilities.
         </p>
 
         <p>
@@ -5004,6 +5004,17 @@ from those who should not access it. Mechanisms that could be considered include
 Transport Layer Security (TLS) or other means of encrypting the data while in
 transit, as well as encryption or data access control mechanisms to protect
 the data in a [=verifiable credential=] while at rest.
+        </p>
+
+        <p>
+In general, individuals are advised to assume that a [=verifiable credential=],
+like most physical credentials, will leak personally identifiable information
+when shared. To combat this leakage, the [=verifiable credential=], and the
+securing mechanism, need to be specifically designed to avoid correlation.
+[=Verifiable credentials=] that are specifically designed to prevent the leakage
+of personally identifiable information do exist. Individuals and implementers
+are urged to prefer these types of credentials over ones that are not designed
+to protect personally identifiable information.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1115,27 +1115,18 @@ and context files that happen to fit their use case. They can explore the
         <p>
 When two software systems need to exchange data, they need to use terminology
 that both systems understand. As an analogy, consider how two people
-communicate. Both people must use the same language and the words they use must
-mean the same thing to each other. This might be referred to as
-<em>the context of a conversation</em>.
+communicate effectively by using the same language where the words they use,
+such as "name" and "website", mean the same thing to each individual. This is
+sometimes referred to as <em>the context of a conversation</em>. This
+specification uses a similar concept to achieve similar results for software
+systems by establishing a context in which to communicate.
         </p>
         <p>
-[=Verifiable credentials=] and [=verifiable presentations=] have many
-properties and values that are identified by [=URLs=] [[URL]]. However,
-those [=URLs=] can be long and not very human-friendly. In such cases,
-short-form human-friendly aliases can be more helpful. This specification uses
-the `@context` [=property=] to map such short-form aliases to the
-[=URLs=] required by specific [=verifiable credentials=] and [=verifiable
-presentations=].
-       </p>
-  <p class="note">
-In JSON-LD, the `@context` [=property=] can also be used to
-communicate other details, such as datatype information, language information,
-transformation rules, and so on, which are beyond the needs of this
-specification, but might be useful in the future or to related work. For more
-information, see
-<a href="https://www.w3.org/TR/json-ld11/#the-context">Section 3.1: The Context</a>
-of the [[[JSON-LD11]]] [[JSON-LD11]] specification.
+Software systems that process [=verifiable credentials=] and [=verifiable
+presentations=] identify terminology by using [=URLs=] [[URL]] for each term.
+However, those [=URLs=] can be long and not very human-friendly and short-form,
+human-friendly aliases can be more helpful. This specification uses the
+`@context` [=property=] to map such short-form aliases to the [=URLs=].
         </p>
         <p>
 [=Verifiable credentials=] and [=verifiable presentations=] MUST include a
@@ -1145,11 +1136,10 @@ of the [[[JSON-LD11]]] [[JSON-LD11]] specification.
         <dl>
           <dt><dfn class="export">@context</dfn></dt>
           <dd>
-The value of the `@context` [=property=] MUST be an ordered set
+The value of the `@context` [=property=] MUST be an [=ordered set=]
 where the first item is a [=URL=] with the value
-`https://www.w3.org/ns/credentials/v2`. For reference, a copy of
-the base context is provided in Appendix <a href="#base-context"></a>.
-Subsequent items in the array MUST be composed of any combination of
+`https://www.w3.org/ns/credentials/v2`.
+Subsequent items in the [=ordered set=] MUST be composed of any combination of
 [=URLs=] and/or objects where each is processable as a
 <a data-cite="JSON-LD11#the-context">JSON-LD Context</a>.
           </dd>
@@ -1178,25 +1168,33 @@ Subsequent items in the array MUST be composed of any combination of
         <p>
 The example above uses the base context [=URL=]
 (`https://www.w3.org/ns/credentials/v2`) to establish that the
-conversation is about a [=verifiable credential=]. The second [=URL=]
-(`https://www.w3.org/ns/credentials/examples/v2`) establishes that
-the conversation is about examples.
-        </p>
-
-        <p class="note">
-This document uses the example context [=URL=]
-(`https://www.w3.org/ns/credentials/examples/v2`) for the purpose
-of demonstrating examples. Implementations are expected to not use this
-[=URL=] for any other purpose, such as in pilot or production systems.
+data exchange is about a [=verifiable credential=].
         </p>
 
         <p>
-The data available at `https://www.w3.org/ns/credentials/v2` is a
-static document that is never updated and SHOULD be downloaded and cached. The
-associated human-readable vocabulary document for the Verifiable Credentials
-Data Model is available at
+The second [=URL=] (`https://www.w3.org/ns/credentials/examples/v2`) is used for
+the purpose of demonstrating examples. Implementations are expected to not use
+this [=URL=] for any other purpose, such as in pilot or production systems.
+        </p>
+
+        <p>
+The data available at `https://www.w3.org/ns/credentials/v2` is a static
+document that is never updated and SHOULD be downloaded and cached. For
+reference, a copy of the base context is provided in Appendix
+[[[#base-context]]]. The associated human-readable vocabulary document for
+the Verifiable Credentials Data Model is available at
 <a href="https://www.w3.org/2018/credentials/">https://www.w3.org/2018/credentials/</a>.
 This concept is further expanded on in Section <a href="#extensibility"></a>.
+        </p>
+
+        <p class="note" title="See JSON-LD for more information about @context.">
+In JSON-LD, the `@context` [=property=] can also be used to
+communicate other details, such as datatype information, language information,
+transformation rules, and so on, which are beyond the needs of this
+specification, but might be useful in the future or to related work. For more
+information, see
+<a href="https://www.w3.org/TR/json-ld11/#the-context">Section 3.1: The Context</a>
+of the [[[JSON-LD11]]] [[JSON-LD11]] specification.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -1154,10 +1154,7 @@ Subsequent items in the array MUST be composed of any combination of
 <a data-cite="JSON-LD11#the-context">JSON-LD Context</a>.
           </dd>
         </dl>
-        <p class="note">
-This specification requires a `@context` [=property=]
-to be present; this property is defined by [[JSON-LD11]].
-        </p>
+
         <pre class="example nohighlight" title="Usage of the @context property">
 {
   <span class="highlight">"@context": [

--- a/index.html
+++ b/index.html
@@ -5895,72 +5895,28 @@ confirmation of the validity of all [=verification material=] before using it.
         <p>
 [=Verifiable credentials=] often contain URLs to data that resides outside of
 the [=verifiable credential=] itself. Linked content that exists outside a
-[=verifiable credential=], such as images, JSON-LD Contexts, JSON Schemas,
-and other machine-readable data, are often not protected against tampering
-because the data resides outside of the protection of the
+[=verifiable credential=], such as images, JSON-LD extension contexts,
+JSON Schemas, and other machine-readable data, are not protected by default
+against tampering because the data resides outside of the protection of the
 <a href="#securing-mechanisms">securing mechanism</a> on the
-[=verifiable credential=]. For example, the content retrievable by
-dereferencing the following highlighted links is not integrity protected, but
-probably ought to be:
-        </p>
-
-        <pre class="example nohighlight"
-          title="Non-content-integrity protected links">
-{
-  "@context": [
-    <span class="highlight">"https://www.w3.org/ns/credentials/v2"</span>,
-    <span class="highlight">"https://www.w3.org/ns/credentials/examples/v2"</span>
-  ],
-  "id": "http://university.example/credentials/58473",
-  "type": ["VerifiableCredential", "ExampleAlumniCredential"],
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "image": <span class="highlight">"https://university.example/images/58473"</span>,
-    "alumniOf": {
-      "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
-      "name": "Example University"
-    }
-  }
-}
-        </pre>
-
-        <p>
-While this specification does not recommend any specific content integrity
-protection, document authors who want to ensure links to content are integrity
-protected are advised to use URL schemes that enforce content integrity.
-        </p>
-
-        <pre class="example nohighlight" title="Content-integrity protection for links to external data">
-{
-  "@context": [
-    "https://www.w3.org/ns/credentials/v2<span class="highlight">?hl=z3aq31uzgnZBuWNzUB</span>",
-    "https://www.w3.org/ns/credentials/examples/v2<span class="highlight">?hl=z8guWNzUBnZBu3aq31</span>"
-  ],
-  "id": "http://university.example/credentials/58473",
-  "type": ["VerifiableCredential", "ExampleAlumniCredential"],
-  "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "image": <span class="highlight">"https://example.com/image"</span>,
-    "alumniOf": {
-      "id": "did:example:c276e12ec21ebfeb1f712ebc6f1",
-      "name": "Example University"
-    }
-  }
-}
-        </pre>
-
-        <p class="note">
-It is debatable whether the JSON-LD Contexts above need protection because
-production implementations are expected to ship with static copies of important
-JSON-LD Contexts.
+[=verifiable credential=].
         </p>
 
         <p>
-While the example above is one way to achieve content integrity protection,
-there are other solutions that might be better suited for certain applications.
+This specification provides an optional mechanism, contained in Section
+[[[#integrity-of-related-resources]]], that is capable of ensuring the content
+integrity for external resources. While this mechanism need not be utilized
+for external resources that do not affect the security of the
+[=verifiable credential=], it is strongly suggested for external resources
+that could result in a security issue if the external content changes.
+        </p>
+
+        <p>
 Implementers are urged to understand how links to external machine-readable
 content that are not content-integrity protected could result in successful
-attacks against their applications.
+attacks against their applications and utilize the content integrity protection
+mechanism provided by this specification if a security issue could occur
+if the external resource is changed.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -2787,7 +2787,7 @@ either of the following:
 An [=issuer=] secures a [=credential=] with a
 <a href="#securing-mechanisms">securing mechanism</a> which establishes that the
 [=issuer=] generated the [=credential=]. In other words, an [=issuer=]
-[=issues=] a [=verifiable credential=].
+issues a [=verifiable credential=].
               </li>
               <li>
 A [=credential=] is transmitted in a way that clearly establishes that the
@@ -2809,7 +2809,7 @@ quickly if and when they no longer stand by those [=claims=].
           <li>
 The [=holder=] expects the [=repository=] to store [=credentials=] securely,
 to not release [=credentials=] to anyone other than the [=holder=] (which may
-subsequently [=present=] them to a [=verifier=]), and to not corrupt nor lose
+subsequently present them to a [=verifier=]), and to not corrupt nor lose
 [=credentials=] while they are in its care.
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -3089,85 +3089,110 @@ interoperability.
       <section>
         <h2>Integrity of Related Resources</h2>
         <p>
-When including a link to an external resource in a [=verifiable credential=],
-it is desirable to know whether the resource that is pointed to is the same at
-signing time as it is at verification time. This applies to cases where there is
-an external resource that is remotely retrieved as well as to cases where the
-[=issuer=] and/or [=verifier=] may have local cached copies of a resource.
+When including a link to an external resource in a [=verifiable credential=], it
+is desirable to know whether the resource has been modified after the
+[=verifiable credential=] was issued. This applies to cases where there is an
+external resource that is remotely retrieved, as well as to cases where the
+[=issuer=] and/or [=verifier=] might have local cached copies of a resource. It
+is also desirable to know that the contents of the JSON-LD context(s) used in
+the [=verifiable credential=] are the same when used by both the [=issuer=] and
+[=verifier=].
         </p>
         <p>
-It is also desirable to know that the contents of the JSON-LD context(s) used in
-the [=verifiable credential=] are the same when used by both the
-[=issuer=] and [=verifier=].
+To extend integrity protection to a related resource, a
+[=verifiable credential=], an author MAY include the `relatedResource`
+property:
         </p>
-        <p>
-To validate that a resource referenced by a [=verifiable credential=] is the
-same at verification time as it is at issuing time, an implementer MAY include a
-property named <code id="defn-relatedResource">relatedResource</code> that
-stores an array of objects that describe additional integrity metadata about
-each resource referenced by the [=verifiable credential=]. If
-`relatedResource` is present, there MUST be an object in the array
-for each remote resource for each context used in the verifiable credential.
-        </p>
+
+        <dl>
+          <dt id="defn-relatedResource">relatedResource</dt>
+          <dd>
+The value of the `relatedResource` property MUST be associated with one or
+more objects containing the following values:
+            <table class="simple">
+              <thead>
+                <th>Property</th>
+                <th>Description</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>`id`</td>
+                  <td>
+The REQUIRED identifier for the resource, as defined in Section
+[[[#identifiers]]]. The value MUST be unique among the list of related
+resource objects.
+                  </td>
+                </tr>
+                <tr>
+                  <td>`mediaType`</td>
+                  <td>
+An OPTIONAL valid media type as listed in the
+<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
+IANA Media Types</a> registry.
+                  </td>
+                </tr>
+                <tr>
+                  <td>`digestSRI`</td>
+                  <td>
+A cryptographic digest, as defined in [[[SRI]]].
+                  </td>
+                </tr>
+                <tr>
+                  <td>`digestMultibase`</td>
+                  <td>
+A cryptographic digest, as defined in [[[VC-DATA-INTEGRITY]]].
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+Each value associated with `relatedResource` MUST contain at least a `digestSRI`
+or `digestMultibase` value.
+          </dd>
+        </dl>
+
         <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
 The requirement that contexts be listed in `relatedResource` is currently being
 debated in the VCWG. This requirement might be removed in future iterations of
 the specification.
         </p>
-        <p>
-Each object in the `relatedResource` array MUST contain the
-following: the [[URL]] to the resource named `id` and the
-<code id="defn-digestSRI">digestSRI</code> information for the resource
-constructed using the method specified in
-<a href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource Integrity</a>.
-        </p>
+
         <p class="issue" title="Unification of cryptographic hash expression formats are under discussion">
 The Working Group is currently attempting to determine whether cryptographic hash
 expression formats can be unified across all of the VCWG core specifications.
 Candidates for this mechanism include `digestSRI` and `digestMultibase`. There
 are arguments for and against unification that the WG is currently debating.
         </p>
+
         <p>
-There MUST NOT be more than one object in the `relatedResource` per
-`id`.
-        </p>
-        <p>
-An object in the `relatedResource` array MAY contain a property named
-`mediaType` that indicates the expected media type for the indicated
-`resource`. If a `mediaType` is included, its value
-SHOULD:
+If a `mediaType` is listed, implementations that retrieve the resource
+over [[[?HTTP]]] SHOULD:
         </p>
         <ul>
           <li>
-be a valid media type as listed in the
-<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
-IANA Media Types</a> registry
+use the media type in the `Accept` HTTP Header, and
           </li>
           <li>
-be used when retrieving the content, such as via the `Accept` HTTP Header
-          </li>
-          <li>
-match the retrieved content media type, such as via the `Content-Type` HTTP
-Header.
+use the media type in the `Content-Type` HTTP Header.
           </li>
         </ul>
 
         <p>
 Any object in the [=verifiable credential=] that contains an `id` [[URL]]
 property MAY be annotated with integrity information as specified in this
-section by inclusion of `digestSRI`
-in the object.
+section.
         </p>
+
         <p>
-Any objects for which selective disclosure is desired SHOULD NOT be included as
-an object in the `relatedResource` array.
+Any objects for which selective disclosure or unlinkable disclosure is desired
+SHOULD NOT be included as an object in the `relatedResource` array.
         </p>
+
         <p>
 Specification authors that write algorithms that fetch a resource based on the
 `id` of an object inside a [=conforming document=] need to consider whether
 that resource's content is vital to the validity of that document. If it is, the
-specification MUST produce a validation error unless the resource has the
-expected media type and its bytes hash to the expected digest.
+specification MUST produce a validation error unless the resource matches the
+expected media type and cryptographic digest
         </p>
         <p>
 Implementers are urged to consult appropriate sources, such as the
@@ -3175,7 +3200,7 @@ Implementers are urged to consult appropriate sources, such as the
 FIPS 180-4 Secure Hash Standard</a> and the
 <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
 Commercial National Security Algorithm Suite 2.0</a> to ensure that they are
-chosing a current and reliable hash algorithm. At the time of this writing
+choosing a current and reliable hash algorithm. At the time of this writing
 `sha384` SHOULD be considered the minimum strength hash algorithm for use by
 implementers.
         </p>
@@ -3183,16 +3208,17 @@ implementers.
 The working group is discussing if we will adopt more aspects of subresource
 integrity as defined in [[SRI]] is adopted into the [[JSON-LD11]] specification as
 noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security">
-current security considerations</a> of that specification, this hash in the VC
-can serve as an additional check towards ensuring that a cached context used
-when issuing the VC matches the remote resource.
+current security considerations</a> of that specification, the
+approach described in this section can serve as an additional check towards
+ensuring that a cached context used when issuing
+a [=verifiable credential=] matches the remote resource.
         </p>
         <p>
 An example of a related resource integrity object referencing JSON-LD contexts.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the relatedResource property">
+          title="Usage of the relatedResource and digestSRI property">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestSRI":
@@ -3215,9 +3241,8 @@ integrity protected image.
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "image": {
     "id": "https://university.example.org/images/58473",
-    "digestSRI":
-      "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
     "mediaType": "application/svg+xml",
+    "digestMultibase": "zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
   },
   ...
 }

--- a/index.html
+++ b/index.html
@@ -3949,8 +3949,9 @@ Authentic Chained Data Containers</a> (ACDCs).
 If conceptually aligned digital credential formats can be transformed into a
 [=conforming document=] according to the rules provided in this section, they
 are considered <em>"compatible with the W3C Verifiable Credentials
-ecosystem"</em>. Specifications that describe how to perform transformations
-that enable compatibility with the Verifiable Credentials ecosystem:
+ecosystem"</em>. Specification authors are advised to adher to the following
+rules when documenting transformations that enable compatibility with the
+Verifiable Credentials ecosystem. The transformation specification
         </p>
 
         <ul>

--- a/index.html
+++ b/index.html
@@ -5453,6 +5453,13 @@ control and that does not upload or analyze your information beyond your
 expectations.
           </li>
         </ul>
+
+        <p>
+In addition to the mitigations above, the participation of civil society and
+regulators in the analysis and auditing of vendors can also ensure that there
+are legal protections in place, and enforced, for individuals affected by
+practices that are not aligned with their best interests.
+        </p>
       </section>
 
       <section class="informative">

--- a/index.html
+++ b/index.html
@@ -795,7 +795,7 @@ A [=credential=] is a set of one or more [=claims=] made by the same [=entity=].
 [=Credentials=] might also include an identifier and metadata to describe
 properties of the [=credential=], such as the [=issuer=], the validity date and
 time period, a representative image, [=verification material=], status
-information, and so on. The metadata might be signed by the [=issuer=]. A
+information, and so on. A
 [=verifiable credential=] is a set of tamper-evident [=claims=] and metadata
 that cryptographically prove who issued it. Examples of [=verifiable
 credentials=] include digital employee identification cards, digital birth
@@ -915,7 +915,7 @@ specific dog, but is issued to its owner.
         <p>
 Enhancing privacy is a key design feature of this specification. Therefore, it
 is important for [=entities=] using this technology to be able to express only
-the portions of their persona that are appropriate for a given situation. The
+the portions of their personas that are appropriate for given situations. The
 expression of a subset of one's persona is called a [=verifiable presentation=].
 Examples of different personas include a person's professional persona, their
 online gaming persona, their family persona, or an incognito persona.
@@ -1057,7 +1057,7 @@ See Appendix <a href="#additional-diagrams-for-verifiable-presentations"></a> fo
 As described in Section [[[#ecosystem-overview]]], an [=entity=] can take
 on one or more roles as they step through a particular credential exchange.
 While a [=holder=] is typically expected to generate [=presentations=], a
-[=issuer=] or [=verifier=] might generate a presentation to identify themselves
+[=issuer=] or [=verifier=] might generate a presentation to identify itself
 to a [=holder=]. This might occur if the [=holder=] needs higher assurance
 from the [=issuer=] or [=verifier=] before handing over sensitive information
 contained in a [=verifiable presentation=].
@@ -1092,7 +1092,7 @@ they would like to create. Since [=verifiable credentials=] talk about subjects,
 each property-value pair in the `credentialSubject` object expresses a
 particular property of the credential subject. Once a developer has added a
 number of these property-value combinations, the modified object can be sent to
-[=verifiable credential=] issuer software and a [=verifiable credential=] will
+the [=verifiable credential=] issuer software and a [=verifiable credential=] will
 be created for the developer. From a prototyping standpoint, that is all a
 developer needs to do.
         </p>
@@ -3975,7 +3975,7 @@ Authentic Chained Data Containers</a> (ACDCs).
 If conceptually aligned digital credential formats can be transformed into a
 [=conforming document=] according to the rules provided in this section, they
 are considered <em>"compatible with the W3C Verifiable Credentials
-ecosystem"</em>. Specification authors are advised to adher to the following
+ecosystem"</em>. Specification authors are advised to adhere to the following
 rules when documenting transformations that enable compatibility with the
 Verifiable Credentials ecosystem. The transformation specification
         </p>
@@ -5146,7 +5146,7 @@ signature values and metadata can be regenerated for each
 [=verifiable presentation=] using technologies that support unlinkable
 disclosure, such as the [[[?VC-DI-BBS]]] specification. It is advised that, if
 possible, [=verifiers=] prefer [=verifiable presentations=] that use this
-technology in order to enhance the privacy for [=holders=].
+technology in order to enhance the privacy for [=holders=] and [=subjects=].
         </p>
 
         <p class="note" title="Unlinkability is not a complete solution">
@@ -5253,12 +5253,12 @@ information about a [=subject=].
         </p>
         <p>
 For example, this document uses the `ageOver` [=property=]
-instead of a specific birthdate, which represents mroe sensitive PII. If
+instead of a specific birthdate, which represents more sensitive PII. If
 retailers in a specific market commonly require purchasers to be older than a
-certain age, an [=issuer=] trusted in that market might choose to offer a
-[=verifiable credential=] claiming that [=subjects=] have met that
+certain age, an [=issuer=] trusted in that market might choose to offer
+[=verifiable credentials=] claiming that [=subjects=] have met that
 requirement instead of offering [=verifiable credentials=] containing
-[=claims=] about the customer's birthday. This enables individual customers to
+[=claims=] about the customers' birthdays. This enables individual customers to
 make purchases without revealing more PII than necessary.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -3090,110 +3090,85 @@ interoperability.
       <section>
         <h2>Integrity of Related Resources</h2>
         <p>
-When including a link to an external resource in a [=verifiable credential=], it
-is desirable to know whether the resource has been modified after the
-[=verifiable credential=] was issued. This applies to cases where there is an
-external resource that is remotely retrieved, as well as to cases where the
-[=issuer=] and/or [=verifier=] might have local cached copies of a resource. It
-is also desirable to know that the contents of the JSON-LD context(s) used in
-the [=verifiable credential=] are the same when used by both the [=issuer=] and
-[=verifier=].
+When including a link to an external resource in a [=verifiable credential=],
+it is desirable to know whether the resource that is pointed to is the same at
+signing time as it is at verification time. This applies to cases where there is
+an external resource that is remotely retrieved as well as to cases where the
+[=issuer=] and/or [=verifier=] may have local cached copies of a resource.
         </p>
-
+        <p>
+It is also desirable to know that the contents of the JSON-LD context(s) used in
+the [=verifiable credential=] are the same when used by both the
+[=issuer=] and [=verifier=].
+        </p>
+        <p>
+To validate that a resource referenced by a [=verifiable credential=] is the
+same at verification time as it is at issuing time, an implementer MAY include a
+property named <code id="defn-relatedResource">relatedResource</code> that
+stores an array of objects that describe additional integrity metadata about
+each resource referenced by the [=verifiable credential=]. If
+`relatedResource` is present, there MUST be an object in the array
+for each remote resource for each context used in the verifiable credential.
+        </p>
         <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
 The requirement that contexts be listed in `relatedResource` is currently being
 debated in the VCWG. This requirement might be removed in future iterations of
 the specification.
         </p>
-
         <p>
-To extend integrity protection to a related resource, an [=issuer=] of a
-[=verifiable credential=] MAY include the `relatedResource` property:
+Each object in the `relatedResource` array MUST contain the
+following: the [[URL]] to the resource named `id` and the
+<code id="defn-digestSRI">digestSRI</code> information for the resource
+constructed using the method specified in
+<a href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource Integrity</a>.
         </p>
-
-        <dl>
-          <dt id="defn-relatedResource">relatedResource</dt>
-          <dd>
-The value of the `relatedResource` property MUST be associated with one or
-more objects of the following form:
-            <table class="simple">
-              <thead>
-                <th>Property</th>
-                <th>Description</th>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>`id`</td>
-                  <td>
-The identifier for the resource is REQUIRED and conforms to the format defined
-in Section [[[#identifiers]]]. The value MUST be unique among the list of
-related resource objects.
-                  </td>
-                </tr>
-                <tr>
-                  <td>`mediaType`</td>
-                  <td>
-An OPTIONAL valid media type as listed in the
-<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
-IANA Media Types</a> registry.
-                  </td>
-                </tr>
-                <tr>
-                  <td>`digestSRI`</td>
-                  <td>
-A cryptographic digest, as defined in [[[SRI]]].
-                  </td>
-                </tr>
-                <tr>
-                  <td>`digestMultibase`</td>
-                  <td>
-A cryptographic digest, as defined in [[[VC-DATA-INTEGRITY]]].
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-Each object associated with `relatedResource` MUST contain at least a
-`digestSRI` or `digestMultibase` value.
-          </dd>
-        </dl>
-
         <p class="issue" title="Unification of cryptographic hash expression formats are under discussion">
 The Working Group is currently attempting to determine whether cryptographic hash
 expression formats can be unified across all of the VCWG core specifications.
 Candidates for this mechanism include `digestSRI` and `digestMultibase`. There
 are arguments for and against unification that the WG is currently debating.
         </p>
-
         <p>
-If a `mediaType` is listed, implementations that retrieve the resource
-using [[[?RFC9110]]] SHOULD:
+There MUST NOT be more than one object in the `relatedResource` per
+`id`.
+        </p>
+        <p>
+An object in the `relatedResource` array MAY contain a property named
+`mediaType` that indicates the expected media type for the indicated
+`resource`. If a `mediaType` is included, its value
+SHOULD:
         </p>
         <ul>
           <li>
-use the media type in the `Accept` HTTP Header, and
+be a valid media type as listed in the
+<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
+IANA Media Types</a> registry
           </li>
           <li>
-use the media type in the `Content-Type` HTTP Header.
+be used when retrieving the content, such as via the `Accept` HTTP Header
+          </li>
+          <li>
+match the retrieved content media type, such as via the `Content-Type` HTTP
+Header.
           </li>
         </ul>
 
         <p>
-Any object in the [=verifiable credential=] that contains an `id`
+Any object in the [=verifiable credential=] that contains an `id` [[URL]]
 property MAY be annotated with integrity information as specified in this
-section.
+section by inclusion of `digestSRI`
+in the object.
         </p>
-
         <p>
-Any objects for which selective disclosure or unlinkable disclosure is desired
-SHOULD NOT be included as an object in the `relatedResource` array.
+Any objects for which selective disclosure is desired SHOULD NOT be included as
+an object in the `relatedResource` array.
         </p>
-
         <p>
 Specification authors that write algorithms that fetch a resource based on the
 `id` of an object inside a [=conforming document=] need to consider whether
 that resource's content is vital to the validity of that document. If it is, the
-specification MUST produce a validation error unless the resource matches the
-expected media type and cryptographic digest.
+specification MUST produce a validation error unless the resource has the
+expected media type and its bytes hash to the expected digest.
         </p>
         <p>
 Implementers are urged to consult appropriate sources, such as the
@@ -3201,7 +3176,7 @@ Implementers are urged to consult appropriate sources, such as the
 FIPS 180-4 Secure Hash Standard</a> and the
 <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
 Commercial National Security Algorithm Suite 2.0</a> to ensure that they are
-choosing a current and reliable hash algorithm. At the time of this writing
+chosing a current and reliable hash algorithm. At the time of this writing
 `sha384` SHOULD be considered the minimum strength hash algorithm for use by
 implementers.
         </p>
@@ -3209,17 +3184,16 @@ implementers.
 The working group is discussing if we will adopt more aspects of subresource
 integrity as defined in [[SRI]] is adopted into the [[JSON-LD11]] specification as
 noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security">
-current security considerations</a> of that specification, the
-approach described in this section can serve as an additional check towards
-ensuring that a cached context used when issuing
-a [=verifiable credential=] matches the remote resource.
+current security considerations</a> of that specification, this hash in the VC
+can serve as an additional check towards ensuring that a cached context used
+when issuing the VC matches the remote resource.
         </p>
         <p>
 An example of a related resource integrity object referencing JSON-LD contexts.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the relatedResource and digestSRI property">
+          title="Usage of the relatedResource property">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestSRI":
@@ -3242,8 +3216,9 @@ integrity protected image.
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "image": {
     "id": "https://university.example.org/images/58473",
+    "digestSRI":
+      "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
     "mediaType": "application/svg+xml",
-    "digestMultibase": "zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
   },
   ...
 }

--- a/index.html
+++ b/index.html
@@ -5022,22 +5022,32 @@ to protect personally identifiable information.
         <h3>Identifier-Based Correlation</h3>
 
         <p>
-[=Subjects=] of [=verifiable credentials=] are identified using the
-`credential.credentialSubject.id` field. The identifiers used to
-identify a [=subject=] create a greater risk of correlation when the
-identifiers are long-lived or used across more than one web domain.
+[=Subjects=] of [=verifiable credentials=] are identified using the `id`
+property, as defined in Section [[[#identifiers]]], and are used in places such
+as the `credentialSubject.id` property. The identifiers used to identify a
+[=subject=] create a greater risk of correlation when the identifiers are
+long-lived or used across more than one web domain.
         </p>
 
         <p>
-Similarly, disclosing the [=credential=] identifier
-(`credential.id`) leads to situations where multiple
-[=verifiers=], or an [=issuer=] and a [=verifier=], can collude to
-correlate the [=holder=]. If [=holders=] want to reduce correlation, they
-should use [=verifiable credential=] schemes that allow hiding the
-identifier during [=verifiable presentation=]. Such schemes expect the
-[=holder=] to generate the identifier and might even allow hiding the
-identifier from the [=issuer=], while still keeping the identifier embedded
-and signed in the [=verifiable credential=].
+Similarly, disclosing the [=credential=] identifier (such as in
+[[[#example-usage-of-the-id-property]]]) leads to
+situations where multiple [=verifiers=], or an [=issuer=] and a [=verifier=],
+can collude to correlate the [=holder=]. If [=holders=] want to reduce
+correlation, they are advised to use [=verifiable credentials=] from [=issuers=]
+that allow selectively disclosing correlating identifiers in a [=verifiable
+presentation=]. Such approaches expect the [=holder=] to generate the identifier
+and might even allow hiding the identifier from the [=issuer=] through the use
+of techniques like
+<a href="https://en.wikipedia.org/wiki/Blind_signature">blind signatures</a>,
+while still keeping the identifier embedded and signed in the [=verifiable
+credential=].
+        </p>
+
+        <p>
+Securing mechanism specification authors are advised to avoid enabling
+identifier-based correlation by designing their technologies, when possible,
+to avoid the use of correlating identifiers.
         </p>
 
         <p>
@@ -5047,6 +5057,9 @@ are either:
         </p>
 
         <ul>
+          <li>
+Selectively disclosable
+          </li>
           <li>
 Bound to a single origin
           </li>

--- a/index.html
+++ b/index.html
@@ -1247,7 +1247,7 @@ grant access to potentially sensitive information if not used judiciously.
           <dd>
 The `id` [=property=] is OPTIONAL. If present, the value of the `id`
 [=property=] MUST be a single [=URL=] which MAY be dereferenced. It is
-RECOMMENDED that the [=URL=] in the `id` be one which, if dereferenced, results
+RECOMMENDED that the [=URL=] in the `id` be one which, if dereferenceable, results
 in a document containing machine-readable information about the `id`.
           </dd>
         </dl>
@@ -5271,7 +5271,7 @@ Privacy violations occur when information divulged in one context leaks into
 another. One accepted best practice for preventing such a violation is for
 [=verifiers=] to limit the information requested, and received, to the absolute
 minimum necessary for a particular transaction. This data minimization approach
-is required by regulation in multiple jurisdictions, including the Health
+is required by regulations in multiple jurisdictions, including the Health
 Insurance Portability and Accountability Act (HIPAA) in the United States and
 the General Data Protection Regulation (GDPR) in the European Union.
         </p>

--- a/index.html
+++ b/index.html
@@ -1988,8 +1988,9 @@ T(([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9](\.[0-9]+)?|(24:00:00(\.0+)?))
         <h3>Securing Mechanisms</h3>
 
         <p>
-This specification recognizes two classes of securing mechanisms: those that use
-enveloping proofs and those that use embedded proofs.
+This specification recognizes two classes of
+<dfn class="export" data-lt="securing mechanism">securing mechanisms</dfn>:
+those that use enveloping proofs and those that use embedded proofs.
         </p>
 
         <p>
@@ -5076,22 +5077,45 @@ Not used at all, but instead replaced by short-lived, single-use bearer tokens.
         <h3>Signature-Based Correlation</h3>
 
         <p>
-The contents of a [=credential=] are secured using a securing mechanism.
-Values used to represent the securing mechanism
-create a greater risk of correlation when the same values are used across more
-than one session or domain and the value does not change.
+The contents of a [=verifiable credential=] are secured using a [=securing
+mechanism=]. Values used to represent the securing mechanism create a greater
+risk of correlation when the same values are used across more than one session
+or domain and the value does not change. Examples of these sorts of values
+include:
         </p>
+
+        <ul>
+          <li>
+the binary value of the digital signature,
+          </li>
+          <li>
+timestamp information associated with when the digital signature was created,
+and
+          </li>
+          <li>
+cryptographic material, such as a public key identifier, associated with the
+digital signature.
+          </li>
+        </ul>
 
         <p>
 If strong anti-correlation properties are required, it is advised that
-signature values and metadata are regenerated each time using technologies like
-third-party pairwise signatures, zero-knowledge proofs, or group signatures.
+[=issuers=] produce [=verifiable credentials=] where the
+signature values and metadata can be regenerated for each
+[=verifiable presentation=] using technologies that support unlinkable
+disclosure, such as the [[[?VC-DI-BBS]]] specification. It is advised that, if
+possible, [=verifiers=] prefer [=verifiable presentations=] that use this
+technology in order to enhance the privacy for [=holders=].
         </p>
 
-        <p class="note">
-Even when using anti-correlation signatures, information might still be
+        <p class="note" title="Unlinkability is not a complete solution">
+Even when using unlinkable signatures, information might still be
 contained in a [=verifiable credential=] that defeats the anti-correlation
-properties of the cryptography used.
+properties of the cryptography used. See Sections
+[[[#personally-identifiable-information]]], [[[#identifier-based-correlation]]],
+[[[#long-lived-identifier-based-correlation]]],
+[[[#metadata-based-correlation]]], [[[#correlation-during-validation]]],
+and most of the other sections in Section [[[#privacy-considerations]]].
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -791,14 +791,15 @@ expected to be added to the graph.
         <h3>Credentials</h3>
 
         <p>
-A [=credential=] is a set of one or more [=claims=] made by the same
-[=entity=]. [=Credentials=] might also include an identifier and metadata
-to describe properties of the [=credential=], such as the
-[=issuer=], the validity date and time period, a representative image,
-[=verification material=], the revocation
-mechanism, and so on. The metadata might be signed by the [=issuer=]. A
-[=verifiable credential=] is a set of tamper-evident [=claims=] and
-metadata that cryptographically prove who issued it.
+A [=credential=] is a set of one or more [=claims=] made by the same [=entity=].
+[=Credentials=] might also include an identifier and metadata to describe
+properties of the [=credential=], such as the [=issuer=], the validity date and
+time period, a representative image, [=verification material=], status
+information, and so on. The metadata might be signed by the [=issuer=]. A
+[=verifiable credential=] is a set of tamper-evident [=claims=] and metadata
+that cryptographically prove who issued it. Examples of [=verifiable
+credentials=] include digital employee identification cards, digital birth
+certificates, and digital educational certificates.
         </p>
 
         <figure id="basic-vc">
@@ -812,19 +813,6 @@ Basic components of a verifiable credential.
         </figure>
 
         <p>
-Examples of [=verifiable credentials=] include digital employee
-identification cards, digital birth certificates, and digital educational
-certificates.
-        </p>
-
-        <p class="note">
-[=Credential=] identifiers are often used to identify specific instances
-of a [=credential=]. These identifiers can also be used for correlation. A
-[=holder=] wanting to minimize correlation is advised to use a selective
-disclosure scheme that does not reveal the [=credential=] identifier.
-        </p>
-
-        <p>
 <a href="#basic-vc"></a> above shows the basic components of a
 [=verifiable credential=], but abstracts the details about how [=claims=]
 are organized into information [=graphs=], which are then organized into
@@ -832,14 +820,17 @@ are organized into information [=graphs=], which are then organized into
 </p>
         <p>
 <a href="#info-graph-vc"></a> below shows a more complete depiction of a
-[=verifiable credential=] using an [=embedded proof=] based on [[?VC-DATA-INTEGRITY]].
-It is composed of at least two information [=graphs=].
-The first of these information [=graphs=], the [=verifiable credential graph=] (which is the [=default graph=]),
-expresses the [=verifiable credential=] itself, through [=credential=] metadata and other [=claims=].
-The second information [=graph=], referred to by the `proof` property, is the <dfn>proof graph</dfn>
-of the [=verifiable credential=], and is a separate [=named graph=].
-The [=proof graph=] expresses the digital proof, which, in this case, is a digital
-signature.
+[=verifiable credential=] using an [=embedded proof=] based on
+[[[?VC-DATA-INTEGRITY]]]. It is composed of at least two information [=graphs=].
+The first of these information [=graphs=], the [=verifiable credential graph=]
+(which is the [=default graph=]), expresses the [=verifiable credential=]
+itself, through [=credential=] metadata and other [=claims=]. The second
+information [=graph=], referred to by the `proof` property, is the
+<dfn>proof graph</dfn> of the [=verifiable credential=], and is a separate
+[=named graph=]. The [=proof graph=] expresses the digital proof, which, in this
+case, is a digital signature. Readers that are interested in the need for
+multiple information graphs can refer to Section
+[[[#verifiable-credential-graphs]]].
         </p>
 
         <figure id="info-graph-vc">
@@ -897,6 +888,13 @@ arrow, to a separate rectangle, containing a single text field:
             based on [[[VC-JOSE-COSE]]] [[?VC-JOSE-COSE]].
           </figcaption>
         </figure>
+
+        <p class="note">
+[=Credential=] identifiers are often used to identify specific instances
+of a [=credential=]. These identifiers can also be used for correlation. A
+[=holder=] wanting to minimize correlation is advised to use a selective
+disclosure scheme that does not reveal the [=credential=] identifier.
+        </p>
 
         <p class="note">
 It is possible to have a [=credential=], such as a marriage certificate,
@@ -1231,7 +1229,7 @@ where pseudonymity is required. Developers are encouraged to read Section
 <a href="#identifier-based-correlation"></a> carefully when considering such
 scenarios. There are also other types of access and correlation mechanisms documented
 in Section <a href="#privacy-considerations"></a> that create privacy concerns.
-Where privacy is a strong consideration, it is permissible to omit the 
+Where privacy is a strong consideration, it is permissible to omit the
 `id` [=property=]. Some use cases do not need, or explicitly need to omit,
 the `id` [=property=]. Similarly, special attention is to be given to the choice between
 publicly resolvable URLs and other forms of identifiers. Publicly resolvable URLs can
@@ -2783,7 +2781,7 @@ The [=verifier=] expects the [=issuer=] to verifiably issue the
 either of the following:
             <ul>
               <li>
-An [=issuer=] is expected to secure a [=credential=] with a 
+An [=issuer=] is expected to secure a [=credential=] with a
 <a href="#securing-mechanisms">securing mechanism</a> which establishes
 that the [=issuer=] generated the [=credential=]. (In other words, an
 [=issuer=] is expected to [=issue=] a [=verifiable credential=].)
@@ -5628,7 +5626,7 @@ The data expressed in [=verifiable credentials=] and
 [=verifiable presentations=] are valuable since they contain authentic
 statements made by trusted third parties, such as [=issuers=], or
 individuals, such as [=holders=] and [=subjects=]. The storage and
-acessibility of this data can inadvertently create honeypots of 
+acessibility of this data can inadvertently create honeypots of
 sensitive data for malicious actors. These adversaries often seek to
 exploit such resevoirs of sensitive information, aiming to
 acquire and exchange that data for financial gain.
@@ -5639,9 +5637,9 @@ necessary to issue [=verifiable credentials=] to [=holders=] and
 manage the status and revocation of those credentials. Similarly,
 [=issuers=] are advised to avoid the practice of creating publicly
 resolvable credentials that include personally identifiable information
-(PII) or other sensitive data. Software implementers are advised 
-to safeguarded [=verifiable credentials=] using robust consent 
-and access control measures, ensuring that they remain 
+(PII) or other sensitive data. Software implementers are advised
+to safeguarded [=verifiable credentials=] using robust consent
+and access control measures, ensuring that they remain
 inaccessible to unauthorized entities.
         </p>
         <p>
@@ -6173,7 +6171,7 @@ accurately in JSON-LD.
 Despite the ability to encode information as HTML, implementers are strongly
 discouraged from doing so, for the following reasons:
         </p>
-        
+
         <ul>
           <li>
 It requires some version of an HTML processor, which increases the burden of

--- a/index.html
+++ b/index.html
@@ -2269,10 +2269,6 @@ Defined in Section [[[#data-schemas]]].
           <dd>
 Defined in Section [[[#credential-subject]]].
           </dd>
-          <dt>proof</dt>
-          <dd>
-Defined in [[[VC-DATA-INTEGRITY]]].
-          </dd>
         </dl>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -5559,20 +5559,22 @@ by:
 
         <ul>
           <li>
-Using a globally-unique identifier as the [=subject=] for any given
-[=credential=] and never re-use that [=credential=].
+The [=holder=] software providing a globally-unique identifier as the
+[=subject=] for any given [=verifiable credential=] and never reusing that
+[=verifiable credential=].
           </li>
           <li>
-If the [=credential=] supports revocation, using a globally-distributed
-service for revocation.
+The [=issuer=] using a globally-distributed service for revocation such that
+it is not contacted when revocation checks are performed.
           </li>
           <li>
-Designing revocation APIs that do not depend on submitting the ID of the
-[=credential=]. For example, use a revocation list instead of a query.
+Specification authors designing revocation mechanisms that do not depend on
+submitting a unique identifier for a [=verifiable credential=]. For example, by
+using a privacy-preserving revocation list instead of a query API.
           </li>
           <li>
-Avoiding the association of personally identifiable information with any
-specific long-lived [=subject=] identifier.
+[=Issuers=] avoiding the association of personally identifiable information with
+any specific long-lived [=subject=] identifier.
           </li>
         </ul>
 
@@ -5598,8 +5600,9 @@ long as each of those services uses the correlation in the expected manner.
         </p>
 
         <p>
-Privacy risks of [=credential=] usage occur when unintended or unexpected
-correlation arises from the presentation of [=credentials=].
+Privacy violations of [=verifiable credential=] usage occur when unintended or
+unexpected correlation arises from the presentation of those
+[=verifiable credentials=].
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1547,9 +1547,9 @@ respectively. See
         </p>
 
         <p class="note">
-The `@direction` property in the examples below are not required
+The `@direction` property in the examples below is not required
 for the associated single-language strings, as their default directions are the
-same as those set in the value. We include the `@direction` property here
+same as those set by the `@direction` value. We include the `@direction` property here
 for clarity of demonstration, and to make copy+paste+edit deliver functional
 results. Implementers are encouraged to read the section on
 <a data-cite="JSON-LD11#string-internationalization">JSON-LD String Internationalization</a>
@@ -2219,8 +2219,8 @@ from the [=issuer=] that can be used by the [=issuer=] to deduce
         <h3>Verifiable Credentials</h3>
 
         <p>
-[=Verifiable credentials=] are used to express properties about a [=subject=]
-as well as properties about the [=credential=] itself. The following properties
+[=Verifiable credentials=] are used to express properties of one or more [=subjects=]
+as well as properties of the [=credential=] itself. The following properties
 are defined in this specification for a [=verifiable credential=]:
         </p>
 
@@ -2276,7 +2276,7 @@ Defined in [[[VC-DATA-INTEGRITY]]].
         </dl>
 
         <p>
-A [=verifiable credential=] can be extended to have addition properties
+A [=verifiable credential=] can be extended to have additional properties
 through the extension mechanism defined in Section [[[#extensibility]]].
         </p>
 

--- a/index.html
+++ b/index.html
@@ -5129,7 +5129,6 @@ Even when using unlinkable signatures, information might still be
 contained in a [=verifiable credential=] that defeats the anti-correlation
 properties of the cryptography used. See Sections
 [[[#personally-identifiable-information]]], [[[#identifier-based-correlation]]],
-[[[#long-lived-identifier-based-correlation]]],
 [[[#metadata-based-correlation]]], [[[#correlation-during-validation]]],
 and most of the other sections in Section [[[#privacy-considerations]]].
         </p>

--- a/index.html
+++ b/index.html
@@ -1057,11 +1057,11 @@ See Appendix <a href="#additional-diagrams-for-verifiable-presentations"></a> fo
           title="Presentations can be presented by issuers and verifiers">
 As described in Section [[[#ecosystem-overview]]], an [=entity=] can take
 on one or more roles as they step through a particular credential exchange.
-While a [=holder=] is typically expected to generate [=presentations=], a
+While a [=holder=] is typically expected to generate [=presentations=], an
 [=issuer=] or [=verifier=] might generate a presentation to identify itself
 to a [=holder=]. This might occur if the [=holder=] needs higher assurance
 from the [=issuer=] or [=verifier=] before handing over sensitive information
-contained in a [=verifiable presentation=].
+as part of a [=verifiable presentation=].
         </p>
 
       </section>
@@ -1136,7 +1136,7 @@ systems by establishing a context in which to communicate.
         <p>
 Software systems that process [=verifiable credentials=] and [=verifiable
 presentations=] identify terminology by using [=URLs=] [[URL]] for each term.
-However, those [=URLs=] can be long and not very human-friendly and short-form,
+However, those [=URLs=] can be long and not very human-friendly, while short-form,
 human-friendly aliases can be more helpful. This specification uses the
 `@context` [=property=] to map such short-form aliases to the [=URLs=].
         </p>
@@ -1152,7 +1152,7 @@ The value of the `@context` [=property=] MUST be an [=ordered set=]
 where the first item is a [=URL=] with the value
 `https://www.w3.org/ns/credentials/v2`.
 Subsequent items in the [=ordered set=] MUST be composed of any combination of
-[=URLs=] and/or objects where each is processable as a
+[=URLs=] and/or objects, where each is processable as a
 <a data-cite="JSON-LD11#the-context">JSON-LD Context</a>.
           </dd>
         </dl>
@@ -1191,7 +1191,7 @@ this [=URL=] for any other purpose, such as in pilot or production systems.
 
         <p>
 The data available at `https://www.w3.org/ns/credentials/v2` is a static
-document that is never updated and SHOULD be downloaded and cached. For
+document that is never updated, and SHOULD be downloaded once and cached. For
 reference, a copy of the base context is provided in Appendix
 [[[#base-context]]]. The associated human-readable vocabulary document for
 the Verifiable Credentials Data Model is available at
@@ -1224,7 +1224,7 @@ allows for the expression of statements about specific things in the
 [=verifiable credential=] and is set by an [=issuer=] when expressing
 objects in a [=verifiable credential=] or a [=holder=] when expressing
 objects in a [=verifiable presentation=]. The `id` [=property=] expresses an
-identifier that others are expected to use when expressing statements about a
+identifier that others are expected to use when expressing statements about the
 specific thing identified by that identifier. Example `id` values
 include UUIDs (`urn:uuid:0c07c1ce-57cb-41af-bef2-1b932b986873`), HTTP URLs
 (`https://id.example/things#123`), and DIDs (`did:example:1234abcd`).
@@ -1247,7 +1247,7 @@ grant access to potentially sensitive information if not used judiciously.
           <dt><dfn class="export">id</dfn></dt>
           <dd>
 The `id` [=property=] is OPTIONAL. If present, the value of the `id`
-[=property=] MUST be a single [=URL=] which MAY be dereferenced. It is
+[=property=] MUST be a single [=URL=], which MAY be dereferenceable. It is
 RECOMMENDED that the [=URL=] in the `id` be one which, if dereferenceable, results
 in a document containing machine-readable information about the `id`.
           </dd>
@@ -2119,7 +2119,7 @@ The precise content of the [=credential=] status information is determined by
 the specific `credentialStatus` [=type=] definition, and varies
 depending on factors such as whether it is simple to implement or if it is
 privacy-enhancing. The value will provide enough information to determine the
-current status of the [=credential=] and that machine readable information will
+current status of the [=credential=] and whether machine readable information will
 be retrievable from the URL. For example, the object could contain a link to an
 external document which notes whether or not the [=credential=] is suspended or
 revoked.
@@ -2354,7 +2354,7 @@ dereferenced, results in a document containing machine-readable information
 about the [=holder=] that can be used to [=verify=] the information
 expressed in the [=verifiable presentation=].
 If the `holder` [=property=] is absent, information about the
-[=holder=] is obtained either via the securing mechanism, or
+[=holder=] either is obtained via the securing mechanism, or
 does not pertain to the [=validation=] of the [=verifiable presentation=].
           </dd>
         </dl>
@@ -3978,7 +3978,7 @@ If conceptually aligned digital credential formats can be transformed into a
 are considered <em>"compatible with the W3C Verifiable Credentials
 ecosystem"</em>. Specification authors are advised to adhere to the following
 rules when documenting transformations that enable compatibility with the
-Verifiable Credentials ecosystem. The transformation specification
+Verifiable Credentials ecosystem. The transformation specification —
         </p>
 
         <ul>
@@ -5010,7 +5010,7 @@ shared with [=verifiers=]. Personally identifying data, such as a
 government-issued identifier, shipping address, and full name, can be easily
 used to determine, track, and correlate an [=entity=]. Even information that
 does not seem to be personally identifiable, such as the combination of a
-birthdate and a postal code, has very powerful correlation and de-anonymizing
+birthdate and a postal code, has very powerful correlation and de-anonymization
 capabilities.
         </p>
 
@@ -5019,7 +5019,7 @@ Implementers of software used by [=holders=] are strongly advised to warn
 [=holders=] when they share data with these kinds of characteristics.
 [=Issuers=] are strongly advised to provide privacy-protecting [=verifiable
 credentials=] when possible. For example, issuing `ageOver` [=verifiable
-credentials=] instead of date of birth [=verifiable credentials=] when a
+credentials=] instead of `dateOfBirth` [=verifiable credentials=] for use when a
 [=verifier=] wants to determine whether an [=entity=] is over the age of 18.
         </p>
 
@@ -5096,7 +5096,8 @@ to avoid the use of correlating identifiers that cannot be selectively disclosed
 
         <p>
 If strong anti-correlation properties are a requirement in a [=verifiable
-credentials=] system, it is strongly advised that identifiers are either:
+credentials=] system, it is strongly advised that identifiers are one or more
+of the following:
         </p>
 
         <ul>
@@ -5123,7 +5124,7 @@ The contents of a [=verifiable credential=] are secured using a [=securing
 mechanism=]. Values used to represent the securing mechanism create a greater
 risk of correlation when the same values are used across more than one session
 or domain and the value does not change. Examples of these sorts of values
-include:
+include the following:
         </p>
 
         <ul>
@@ -5156,7 +5157,7 @@ contained in a [=verifiable credential=] that defeats the anti-correlation
 properties of the cryptography used. See Sections
 [[[#personally-identifiable-information]]], [[[#identifier-based-correlation]]],
 [[[#metadata-based-correlation]]], [[[#correlation-during-validation]]],
-and most of the other sections in Section [[[#privacy-considerations]]].
+and most of the other subsections of Section [[[#privacy-considerations]]].
         </p>
       </section>
 
@@ -5308,23 +5309,23 @@ proving time and reduce temporal correlation risk from [=issuers=].
         <p>
 [=Verifiers=] are urged to only request information that is absolutely
 necessary for a specific transaction to occur. This is important for at least
-two reasons.
+two reasons:
         </p>
 
         <ul>
           <li>
 It reduces the liability on the [=verifier=] for handling highly sensitive
-information that it does not need to, and
+information that it does not need to handle.
           </li>
           <li>
-it enhances the privacy of the individual by only asking for information
-required for a specific transaction.
+It enhances the privacy of the individual by only asking for information
+that is necessary for a specific transaction.
           </li>
         </ul>
 
         <p>
 Implementers of software used by [=holders=] are urged to disclose what
-information is being requested by a [=verifier=] such that a [=holder=] can
+information is being requested by a [=verifier=], such that a [=holder=] can
 push back on the over-collection of information that is unnecessary for the
 transaction.
         </p>
@@ -5723,7 +5724,7 @@ manage the status and revocation of those credentials. Similarly,
 [=issuers=] are advised to avoid the practice of creating publicly
 resolvable credentials that include personally identifiable information
 (PII) or other sensitive data. Software implementers are advised
-to safeguarded [=verifiable credentials=] using robust consent
+to safeguard [=verifiable credentials=] using robust consent
 and access control measures, ensuring that they remain
 inaccessible to unauthorized entities.
         </p>
@@ -5962,7 +5963,7 @@ against tampering because the data resides outside of the protection of the
 
         <p>
 This specification provides an optional mechanism, contained in Section
-[[[#integrity-of-related-resources]]], that is capable of ensuring the content
+[[[#integrity-of-related-resources]]], that is capable of ensuring content
 integrity for external resources. While this mechanism need not be utilized
 for external resources that do not affect the security of the
 [=verifiable credential=], it is strongly suggested for external resources
@@ -5972,7 +5973,7 @@ that could result in a security issue if the external content changes.
         <p>
 Implementers are urged to understand how links to external machine-readable
 content that are not content-integrity protected could result in successful
-attacks against their applications and utilize the content integrity protection
+attacks against their applications, and utilize the content integrity protection
 mechanism provided by this specification if a security issue could occur
 if the external resource is changed.
         </p>
@@ -6459,7 +6460,7 @@ an interaction with a [=holder=].
 When a [=verifier=] requests a [=verifiable credential=] of a specific type,
 there will be a set of mandatory and optional [=claims=] that are associated
 with that type. A [=verifier=]'s validation of a [=verifiable credential=] will
-fail when mandatory [=claims=] are not included, and that any [=claim=] that is
+fail when mandatory [=claims=] are not included, and any [=claim=] that is
 not associated with the specific type will be ignored. In other words, a
 [=verifier=] will perform input validation on the [=verifiable credential=] it
 receives and will reject malformed input based on the credential type

--- a/index.html
+++ b/index.html
@@ -2241,7 +2241,74 @@ from the [=issuer=] that can be used by the [=issuer=] to deduce
       </section>
 
       <section>
-        <h3>Presentations</h3>
+        <h3>Verifiable Credentials</h3>
+
+        <p>
+[=Verifiable credentials=] are used to express properties about a [=subject=]
+as well as properties about the [=credential=] itself. The following properties
+are defined in this specification for a [=verifiable credential=]:
+        </p>
+
+        <dl>
+          <dt>@context</dt>
+          <dd>
+Defined in Section [[[#contexts]]].
+          </dd>
+          <dt>id</dt>
+          <dd>
+Defined in Section [[[#identifiers]]].
+          </dd>
+          <dt>type</dt>
+          <dd>
+Defined in Section [[[#types]]].
+          </dd>
+          <dt>name</dt>
+          <dd>
+Defined in Section [[[#names-and-descriptions]]].
+          </dd>
+          <dt>description</dt>
+          <dd>
+Defined in Section [[[#names-and-descriptions]]].
+          </dd>
+          <dt>issuer</dt>
+          <dd>
+Defined in Section [[[#issuer]]].
+          </dd>
+          <dt>validFrom</dt>
+          <dd>
+Defined in Section [[[#validity-period]]].
+          </dd>
+          <dt>validUntil</dt>
+          <dd>
+Defined in Section [[[#validity-period]]].
+          </dd>
+          <dt>status</dt>
+          <dd>
+Defined in Section [[[#status]]].
+          </dd>
+          <dt>credentialSchema</dt>
+          <dd>
+Defined in Section [[[#data-schemas]]].
+          </dd>
+          <dt>credentialSubject</dt>
+          <dd>
+Defined in Section [[[#credential-subject]]].
+          </dd>
+          <dt>proof</dt>
+          <dd>
+Defined in [[[VC-DATA-INTEGRITY]]].
+          </dd>
+        </dl>
+
+        <p>
+A [=verifiable credential=] can be extended to have addition properties
+through the extension mechanism defined in Section [[[#extensibility]]].
+        </p>
+
+      </section>
+
+      <section>
+        <h3>Verifiable Presentations</h3>
 
         <p>
 [=Verifiable presentations=] MAY be used to aggregate information from

--- a/index.html
+++ b/index.html
@@ -1218,29 +1218,12 @@ about the same thing. This specification defines the optional `id`
 allows for the expression of statements about specific things in the
 [=verifiable credential=] and is set by an [=issuer=] when expressing
 objects in a [=verifiable credential=] or a [=holder=] when expressing
-objects in a [=verifiable presentation=]. Example `id` values
+objects in a [=verifiable presentation=]. The `id` [=property=] expresses an
+identifier that others are expected to use when expressing statements about a
+specific thing identified by that identifier. Example `id` values
 include UUIDs (`urn:uuid:0c07c1ce-57cb-41af-bef2-1b932b986873`), HTTP URLs
 (`https://id.example/things#123`), and DIDs (`did:example:1234abcd`).
         </p>
-
-        <p>
-<em>If</em> the `id` [=property=] is present:
-        </p>
-
-        <ul>
-          <li>
-The `id` [=property=] MUST express an identifier that others are
-expected to use when expressing statements about a specific thing identified
-by that identifier.
-          </li>
-          <li>
-The `id` [=property=] MUST NOT have more than one value.
-          </li>
-          <li>
-The value of the `id` [=property=] MUST be a [=URL=] which
-MAY be dereferenced.
-          </li>
-        </ul>
 
         <p class="note">
 Developers should remember that identifiers might be harmful in scenarios
@@ -1258,10 +1241,10 @@ grant access to potentially sensitive information if not used judiciously.
         <dl>
           <dt><dfn class="export">id</dfn></dt>
           <dd>
-The value of the `id` [=property=] MUST be a single [=URL=].
-It is RECOMMENDED that the [=URL=] in the `id` be one which, if
-dereferenced, results in a document containing machine-readable information
-about the `id`.
+The `id` [=property=] is OPTIONAL. If present, the value of the `id`
+[=property=] MUST be a single [=URL=] which MAY be dereferenced. It is
+RECOMMENDED that the [=URL=] in the `id` be one which, if dereferenced, results
+in a document containing machine-readable information about the `id`.
           </dd>
         </dl>
 


### PR DESCRIPTION
This PR is an attempt to address issue #1348 by fixing a large number of editorial concerns that @jyasskin raised. 

Specifically:

#### 1. Introduction

- [x] Use property terminology throughout entire specification. Fixed in c36dd64403f6c50b324a65a4d1ed762c54245068.

#### 1.1 What is a Verifiable Credential?

- [x] Specify which properties exist on a VC. Fixed in 42d38f222469159fa65eb641e1484e0de3a4487b.

#### 1.3 Use Cases and Requirements

- [x] Use non-normative wording instead of "should". This section has been removed by the specification.

#### 3.2 Credentials

- [x] Mention quoting and verifiable credential graph. Fixed in 6938250f25f9d5e7fc66b38955a310c5468e6fb4.

#### 4.1 Getting Started

- [x] Make section non-normative. This was done in a previous PR.

#### 4.2 Contexts

- [x] Use better language to specify ordered sets. Fixed to use INFRA in 19200373bda8f3595b10c99457fa6c7f7d112c65.
- [x] Remove redundant "This specification requires for a @context property to be present;" statement. Fixed in 52562ecdddcdf9e4701c3bfd15da3c4a5d924737.
- [x] Rewrite paragraph that contains "Verifiable credentials and verifiable presentations have many attributes and values that are identified by URLs" -- re-write paragraph to introduce contexts in a different way. Rewritten in 19200373bda8f3595b10c99457fa6c7f7d112c65.

#### 4.3 Identifiers

- [x] Merge the id and the "If the id property is present:" block. Fixed in 7a96f9e222834b5441c45a9ed24fa27cc8479db1.

#### 4.4 Types

- [x] Clarify that you can use a full URL, or you can use a JSON-LD term that maps to a URL. That is, you can't use a number, string, object, etc. Fixed in a45bb7b955bb3a7c03aa4770f78fbd18155cd523.
- [x] Point to VC-SPECS for some examples of "A valid proof type". Discussion of `proof` was removed from this section in a previous PR.
- [x] Clean up and reword section containing "This enables implementers to rely on values associated with the type property". Attempted clean up in c07066f7f5531783518a3f3458fa0f1595fdad62.

#### 5.1 Lifecycle Details

- [x] Add text on what a "verifiable data registry" and how it is used. Addressed in PR #1476.
- [x] Include operations that can be performed in ecosystem. Addressed in PR #1476.

#### 5.2 Trust Model

- [x] Wordsmith statements to say is that the verifier trusts the issuer to make the statements it's making after verification has been performed. Addressed in PR #1469.
- [x] Elaborate on why entities trust/depend on verifiable data registry. Addressed in PR #1469.
- [x] Explain why holder trusts the issuer. Addressed in PR #1469.
- [x] Say something about the verifier choosing the issuers they want to trust. Addressed in PR #1469.

#### 5.3.1 Semantic Interoperability

- [x] "is expected to be published" diffuses responsibility. Use active voice. Fixed in 024994aaf792c2c64a8b2a1bef0577b3d71bca19.

#### 5.4 Integrity of Related Resources

- [x] Editorial clean-up and simplification of normative statements to match other sections. Fixed in b3ac23cafe92eb92980b8c2d4612d0cdd9908b96 and e0c09880ba284d9da44d23b5c151fdf4bf113f7b.

#### 5.5 Refreshing

- [x] Add some text in https://w3c.github.io/vc-data-model/#presentations to say that issuers and verifiers can use presentations to prove who they are to a holder by providing their own credentials via a presentation. Fixed in f4b1e2553cd3e2f337fed599f10000db013a885d.

#### 5.11 Ecosystem Compatibility

- [x] Clarify intent of "rules" in section to be guidance to specification authors that desire compatability. Fixed in df1a45e183e78e73745f5c7a2fc73aa24459c446.

#### 6.3 Proof Formats

- [x] Change "The sections detailing" to "The specifications detailing". The section has been rewritten in a previous PR and the problematic text was removed in the rewrite.

#### 7. Privacy Considerations

- [x] "Implementers of software utilized by holders". This text no longer appears in the specification due to a previous PR.

#### 7.3 Personally Identifiable Information

- [x] Update "Implementers" to "Implementers of software utilized by holders". Fixed in 63d14639073df0c18318112ae3e392e44540fff3.
- [x] Say that people should assume a VC will leak PII unless the credential and securing mechanism is designed specifically to avoid correlation (and there are credential types designed specifically for this purpose). Fixed in cd6116ce4d1110ad682ade5ff2cb73b3a94b73f2.

#### 7.4 Identifier-Based Correlation

- [x] Specify that proof specifications are responsible for avoiding identifier-based correlation. Fixed in 69af3d52632df069e52007121409468c55394f0f.

#### 7.5 Signature-Based Correlation

- [x] Specify who is responsible for signature-based correlation and update section to match modern practices. Fixed in 

#### 7.6 Long-Lived Identifier-Based Correlation

- [x] Fold this section into the "Identifier-based Correlation" section and provide a refresh on the text. Fixed in 1c9ea793803687427e304cccbde8d5f27eef881b.
- [x] Say credential repository software needs to provide protections. Fixed in 1c9ea793803687427e304cccbde8d5f27eef881b.

#### 7.8 Favor Abstract Claims

- [x] Specify who should favor abstract claims -- "issuers should favor abstract claims". Fixed in bdc9c448941a0b09a1305dae314ed286d187252a.

#### 7.9 The Principle of Data Minimization

- [x] Specify that this is advice for issuers and verifiers. Remind credential repositories to disclose what fields the verifier is asking for, so that users can push back. Fixed in aca01b093e1b18e9d500c22572b6e31042fa72b5.

#### 7.11 Validation

- [x] Possibly move section into larger Validation section? Renamed section in 4ee5f171d0cdbb6af934867bef5e189d402234e2.

#### 7.12 Storage Providers and Data Mining

- [x] Say that civil society groups and regulators should play a part in this ecosystem (by doing evaluations and monitoring). Fixed in de2dec680a3b0804cc4f3889f60509b6ce23fb26.

#### 7.14 Usage Patterns

- [x] Localize mitigations to particular actors by saying things like "Authors of specifications for credentialStatus types", and "Using a globally-unique identifier" could be guidance for credential repositories to warn uses when they're re-using an ID. Fixed in 4dc6700220b51fc2929f90b51065f8444298bb7b.

#### 8.3 Content Integrity Protection

- [x] Update outdated text and speak to new `relatedResource` feature. Fixed in 8d9a3159f2b986e46fc15738fc05fdd5c2661d26.

#### A.1 Credential Type

- [x] Specify that the documents at the type's URL are expected to describe the available properties and their usage. The language for this was put in the Types section in  c07066f7f5531783518a3f3458fa0f1595fdad62.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1464.html" title="Last updated on May 5, 2024, 3:01 PM UTC (150bfbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1464/1153f74...150bfbb.html" title="Last updated on May 5, 2024, 3:01 PM UTC (150bfbb)">Diff</a>