### PR TITLE
add lost hyphen

### DIFF
--- a/index.html
+++ b/index.html
@@ -5298,7 +5298,7 @@ properties of the cryptography used.
       </section>
 
       <section class="informative">
-        <h3>Long-Lived Identifier-Based Correlation</h3>
+        <h3>Long-Lived-Identifier-Based Correlation</h3>
 
         <p>
 [=Verifiable credentials=] might contain long-lived identifiers that could


### PR DESCRIPTION
"Long-Lived Identifier-Based Correlation" (or "Long-Lived Correlation Based on Identifiers") is very different from "Long-Lived-Identifier-Based Correlation" (or "Correlation Based on Long-Lived Identifiers").


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-model/pull/1473.html" title="Last updated on Apr 8, 2024, 11:06 PM UTC (9260dda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1473/1ab385f...TallTed:9260dda.html" title="Last updated on Apr 8, 2024, 11:06 PM UTC (9260dda)">Diff</a>