### PR TITLE
Massage "Trust Model" into "Expectations"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3011,7 +3011,7 @@ The [=verifier=] expects the [=issuer=] to verifiably issue the
 either of the following:
             <ul>
               <li>
-A [=verifier=] is expected to secure a [=credential=] with a 
+An [=issuer=] is expected to secure a [=credential=] with a 
 <a href="#securing-mechanisms">securing mechanism</a> which establishes
 that the [=issuer=] generated the [=credential=]. (In other words, an
 [=issuer=] is expected to [=issue=] a [=verifiable credential=].)

--- a/index.html
+++ b/index.html
@@ -3000,41 +3000,46 @@ or [=verifier=].
         <h3>Trust Model</h3>
 
         <p>
-The [=verifiable credentials=] trust model is as follows:
+The [=verifiable credentials=] trust model is based on the following
+expectations:
         </p>
 
         <ul>
           <li>
-The [=verifier=] trusts the [=issuer=] to issue the [=credential=] that
-it received. To establish this trust, a [=credential=] is expected to either:
+The [=verifier=] expects the [=issuer=] to verifiably issue the
+[=credential=] that it received. This is established by satisfying
+either of the following:
             <ul>
               <li>
-Secure the [=credential=] with a <a href="#securing-mechanisms">securing mechanism</a> establishing that the
-[=issuer=] generated the [=credential=] (that is, it is a
-[=verifiable credential=]), or
+A [=verifier=] is expected to secure a [=credential=] with a 
+<a href="#securing-mechanisms">securing mechanism</a> establishing that
+the [=issuer=] generated the [=credential=] (that is, to [=issue=] a
+[=verifiable credential=]).
               </li>
               <li>
-Have been transmitted in a way clearly establishing that the [=issuer=]
-generated the [=verifiable credential=] and that the
-[=verifiable credential=] was not tampered with in transit or storage. This
-trust could be weakened depending on the risk assessment of the [=verifier=].
+A [=credential=] is expected to have been transmitted in a way clearly
+establishing that the [=issuer=] generated the [=credential=] and that
+the [=credential=] was not tampered with in transit or storage. This
+expectation could be weakened, depending on the risk assessment by the
+[=verifier=].
               </li>
             </ul>
           </li>
           <li>
-All [=entities=] trust the [=verifiable data registry=] to be
+All [=entities=] expect the [=verifiable data registry=] to be
 tamper-evident and to be a correct record of which data is controlled by which
 [=entities=].
           </li>
           <li>
-The [=holder=] and [=verifier=] trust the [=issuer=] to issue
-true (that is, not false) [=credentials=] about the [=subject=], and to
-revoke them quickly when appropriate.
+The [=holder=] and [=verifier=] expect the [=issuer=] to stand by [=claims=]
+it makes in [=credentials=] about the [=subject=], and to revoke [=credentials=]
+quickly if and when they no longer stand by those [=claims=].
           </li>
           <li>
-The [=holder=] trusts the [=repository=] to store [=credentials=]
-securely, to not release them to anyone other than the [=holder=], and to not
-corrupt or lose them while they are in its care.
+The [=holder=] expects the [=repository=] to store [=credentials=]
+securely, to not release [=credentials=] to anyone other than the [=holder=]
+(which may subsequently [=present=] them to a [=verifier=]), and to not
+corrupt nor lose [=credentials=] while they are in its care.
           </li>
         </ul>
 
@@ -3045,17 +3050,17 @@ the:
 
         <ul>
           <li>
-[=Issuer=] and the [=verifier=] do not need to trust the
-[=repository=]
+The [=issuer=] and [=verifier=] do not need to know anything about the
+[=repository=].
           </li>
           <li>
-[=Issuer=] does not need to know or trust the [=verifier=].
+The [=issuer=] does not need to know anything about the [=verifier=].
           </li>
         </ul>
 
         <p>
-By decoupling the trust between the [=identity provider=] and the
-[=relying party=] a more flexible and dynamic trust model is created such
+By decoupling the expectations between the [=identity provider=] and the
+[=relying party=], a more flexible and dynamic trust model is created, such
 that market competition and customer choice is increased.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -3007,18 +3007,18 @@ expectations:
         <ul>
           <li>
 The [=verifier=] expects the [=issuer=] to verifiably issue the
-[=credential=] that it received. This is established by satisfying
+[=credential=] that it receives. This can be established by satisfying
 either of the following:
             <ul>
               <li>
 A [=verifier=] is expected to secure a [=credential=] with a 
-<a href="#securing-mechanisms">securing mechanism</a> establishing that
-the [=issuer=] generated the [=credential=] (that is, to [=issue=] a
-[=verifiable credential=]).
+<a href="#securing-mechanisms">securing mechanism</a> which establishes
+that the [=issuer=] generated the [=credential=]. (In other words, a
+[=verifier=] is expected to [=issue=] a [=verifiable credential=].)
               </li>
               <li>
-A [=credential=] is expected to have been transmitted in a way that clearly
-establishes that the [=issuer=] generated the [=credential=] and that
+A [=credential=] is expected to be transmitted in a way that clearly
+establishes that the [=issuer=] generated the [=credential=], and that
 the [=credential=] was not tampered with in transit nor storage. This
 expectation could be weakened, depending on the risk assessment by the
 [=verifier=].
@@ -3035,10 +3035,10 @@ it makes in [=credentials=] about the [=subject=], and to revoke [=credentials=]
 quickly if and when they no longer stand by those [=claims=].
           </li>
           <li>
-The [=holder=] expects the [=repository=] to store [=credentials=]
-securely, to not release [=credentials=] to anyone other than the [=holder=]
-(which may subsequently [=present=] them to a [=verifier=]), and to not
-corrupt nor lose [=credentials=] while they are in its care.
+The [=holder=] expects the [=repository=] to store [=credentials=] securely,
+to not release [=credentials=] to anyone other than the [=holder=] (which may
+subsequently [=present=] them to a [=verifier=]), and to not corrupt nor lose
+[=credentials=] while they are in its care.
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -3013,8 +3013,8 @@ either of the following:
               <li>
 A [=verifier=] is expected to secure a [=credential=] with a 
 <a href="#securing-mechanisms">securing mechanism</a> which establishes
-that the [=issuer=] generated the [=credential=]. (In other words, a
-[=verifier=] is expected to [=issue=] a [=verifiable credential=].)
+that the [=issuer=] generated the [=credential=]. (In other words, an
+[=issuer=] is expected to [=issue=] a [=verifiable credential=].)
               </li>
               <li>
 A [=credential=] is expected to be transmitted in a way that clearly

--- a/index.html
+++ b/index.html
@@ -3017,18 +3017,17 @@ the [=issuer=] generated the [=credential=] (that is, to [=issue=] a
 [=verifiable credential=]).
               </li>
               <li>
-A [=credential=] is expected to have been transmitted in a way clearly
-establishing that the [=issuer=] generated the [=credential=] and that
-the [=credential=] was not tampered with in transit or storage. This
+A [=credential=] is expected to have been transmitted in a way that clearly
+establishes that the [=issuer=] generated the [=credential=] and that
+the [=credential=] was not tampered with in transit nor storage. This
 expectation could be weakened, depending on the risk assessment by the
 [=verifier=].
               </li>
             </ul>
           </li>
           <li>
-All [=entities=] expect the [=verifiable data registry=] to be
-tamper-evident and to be a correct record of which data is controlled by which
-[=entities=].
+All [=entities=] expect the [=verifiable data registry=] to be tamper-evident
+and to be a correct record of which data is controlled by which [=entities=].
           </li>
           <li>
 The [=holder=] and [=verifier=] expect the [=issuer=] to stand by [=claims=]
@@ -3045,7 +3044,7 @@ corrupt nor lose [=credentials=] while they are in its care.
 
         <p>
 This trust model differentiates itself from other trust models by ensuring
-the:
+the following:
         </p>
 
         <ul>
@@ -3059,15 +3058,14 @@ The [=issuer=] does not need to know anything about the [=verifier=].
         </ul>
 
         <p>
-By decoupling the expectations between the [=identity provider=] and the
-[=relying party=], a more flexible and dynamic trust model is created, such
-that market competition and customer choice is increased.
+By decoupling the expectations between the [=issuer=] and the [=verifier=],
+a more flexible and dynamic trust model is created, such that market
+competition and customer choice is increased.
         </p>
 
         <p>
 For more information about how this trust model interacts with various threat
-models studied by the Working Group, see the Verifiable Credentials Use Cases
-document [[VC-USE-CASES]].
+models studied by the Working Group, see the [[[VC-USE-CASES]]] [[VC-USE-CASES]].
         </p>
 
         <p class="note">


### PR DESCRIPTION
I didn't change the section title, but the "Trust Model" is no longer based on "Trust", but on "Expectations". I think this is more in line with our discussions, and on what the technology handles.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/vc-data-model/pull/1474.html" title="Last updated on Apr 16, 2024, 2:41 PM UTC (9c83d89)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1474/1ab385f...TallTed:9c83d89.html" title="Last updated on Apr 16, 2024, 2:41 PM UTC (9c83d89)">Diff</a>