### PR TITLE
Update media types to `application/vc` and `application/vp`

### DIFF
--- a/index.html
+++ b/index.html
@@ -7216,11 +7216,10 @@ for review, approval, and registration with IANA.
       </p>
 
       <section id="vc-ld-media-type">
-        <h2>application/vc+ld+json</h2>
+        <h2>application/vc</h2>
         <p>
-This specification registers the `application/vc+ld+json` Media Type
-specifically for identifying documents conforming to the Verifiable Credentials
-format.
+This specification registers the `application/vc` Media Type specifically for
+identifying documents conforming to the Verifiable Credentials format.
         </p>
         <table>
           <tr>
@@ -7229,7 +7228,7 @@ format.
           </tr>
           <tr>
             <td>Subtype name: </td>
-            <td>vc+ld+json</td>
+            <td>vc</td>
           </tr>
           <tr>
             <td>Required parameters: </td>
@@ -7238,10 +7237,10 @@ format.
           <tr>
             <td>Encoding considerations: </td>
             <td>
-Resources that use the "`application/vc+ld+json`" Media Type are
-required to conform to all of the requirements for the
-"`application/ld+json`" Media Type and are therefore subject to the
-same encoding considerations specified in Section 11 of [[RFC7159]].
+Resources that use the "`application/vc`" Media Type are required to conform to
+all of the requirements for the "`application/ld+json`" Media Type and are
+therefore subject to the same encoding considerations specified in Section 11 of
+[[RFC7159]].
             </td>
           </tr>
           <tr>
@@ -7267,21 +7266,20 @@ Credential implementations that justify the use of a specific media type.
 This media type can be used for credentials secured using an
 [=enveloping proof=].
         </p>
+
         <p>
-A [[JSON-LD11]] context is expected to be present in the body of the document,
-and as indicated by the presence of `ld+json` in the media type, the credential
-is expected to be a valid
+A [[JSON-LD11]] context is expected to be present in the body of the document.
+The credential is expected to be a valid
 <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD
 document</a>.
         </p>
       </section>
 
       <section id="vp-ld-media-type">
-        <h2>application/vp+ld+json</h2>
+        <h2>application/vp</h2>
         <p>
-This specification registers the `application/vp+ld+json` Media
-Type specifically for identifying documents conforming to the Verifiable
-Presentations format.
+This specification registers the `application/vp` Media Type specifically for
+identifying documents conforming to the Verifiable Presentations format.
         </p>
         <table>
           <tr>
@@ -7290,7 +7288,7 @@ Presentations format.
           </tr>
           <tr>
             <td>Subtype name: </td>
-            <td>vp+ld+json</td>
+            <td>vp</td>
           </tr>
           <tr>
             <td>Required parameters: </td>
@@ -7299,10 +7297,10 @@ Presentations format.
           <tr>
             <td>Encoding considerations: </td>
             <td>
-Resources that use the "`application/vp+ld+json`" Media Type are
-required to conform to all of the requirements for the
-"`application/ld+json`" Media Type and are therefore subject to the
-same encoding considerations specified in Section 11 of [[RFC7159]].
+Resources that use the "`application/vp`" Media Type are required to conform to
+all of the requirements for the "`application/ld+json`" Media Type and are
+therefore subject to the same encoding considerations specified in Section 11 of
+[[RFC7159]].
             </td>
           </tr>
           <tr>
@@ -7329,9 +7327,8 @@ This media type can be used for presentations secured using an
 [=enveloping proof=].
         </p>
         <p>
-A [[JSON-LD11]] context is expected to be present in the body of the document, and
-as indicated by the presence of `ld+json` in the media type, the credential is
-expected to be a valid
+A [[JSON-LD11]] context is expected to be present in the body of the document.
+The credential is expected to be a valid
 <a href="https://www.w3.org/TR/json-ld11/#dfn-json-ld-document">JSON-LD
 document</a>.
         </p>

--- a/index.html
+++ b/index.html
@@ -957,8 +957,8 @@ based on [[[VC-DATA-INTEGRITY]]] [[?VC-DATA-INTEGRITY]].
 namely 'Header', 'Payload', and 'Signature'. The 'Header' label is
 connected, with an arrow, to a separate rectangle on the right hand
 side containing six text fields: 'kid: aB8J-_Z', 'alg: ES384', and
-'cty: vc', iss: https://example.com, iat: 1704690029, and typ:
-vc+sd-jwt The 'Payload' label on the left side is connected,
+'cty: vc', 'iss: https://example.com', 'iat: 1704690029', and 'typ:
+vc+sd-jwt'. The 'Payload' label on the left side is connected,
 with an arrow, to a separate rectangle, containing a single graph. The
 rectangle has a label: 'verifiable credential graph (serialized in
 JSON)' The claims in the graph include 'Credential 123' as a subject
@@ -1109,8 +1109,8 @@ secured via an [=enveloping proof=] shown on <a href="#info-graph-vc-jwt"></a>.
 namely 'Header', 'Payload', and 'Signature'. The 'Header' label is
 connected, with an arrow, to a separate rectangle on the right hand
 side containing six text fields: 'kid: aB8J-_Z', 'alg: ES384', and
-'cty: vc', iss: https://example.com, iat: 1704690029, and typ:
-vp+sd-jwt The 'Payload' label of the left side is connected,
+'cty: vc', 'iss: https://example.com', 'iat: 1704690029', and 'typ:
+vp+sd-jwt'. The 'Payload' label of the left side is connected,
 with an arrow, to a separate rectangle, consisting of two related
 graphs (stacked vertically) connected by a an arrow labeled
 'verifiableCredential'. The two graphs have each a label 'verifiable
@@ -7399,8 +7399,8 @@ Diagram with, on the left, a box, labeled as 'JWT (Decoded)', and with
 three textual labels stacked vertically, namely 'Header', 'Payload', and
 'Signature'. The 'Header' label is connected, with an arrow, to a
 separate rectangle on the right hand side containing six text fields:
-'kid: aB8J-_Z', 'alg: ES384', and 'cty: vc', iss:
-https://example.com, iat: 1704690029, and typ: vp+sd-jwt The
+'kid: aB8J-_Z', 'alg: ES384', 'cty: vc', 'iss:
+https://example.com', 'iat: 1704690029', and 'typ: vp+sd-jwt'. The
 'Payload' label of the left side is connected, with an arrow, to a
 separate rectangle, consisting of three related graphs (stacked
 vertically) connected by two arrows labeled 'verifiableCredential'

--- a/index.html
+++ b/index.html
@@ -528,9 +528,9 @@ specification. Specifically, the relevant normative "MUST" statements in
 Sections <a href="#basic-concepts"></a>, <a href="#advanced-concepts"></a>, and
 <a href="#syntaxes"></a> of this document MUST be enforced.
 A conforming document is either a [=verifiable credential=] that MUST be
-serialized using the `application/vc+ld+json` media type or a
+serialized using the `application/vc` media type or a
 [=verifiable presentation=] that MUST be serialized using the
-`application/vp+ld+json` media type. A conforming document MUST be
+`application/vp` media type. A conforming document MUST be
 secured by at least one securing mechanism as described in Section
 <a href="#securing-mechanisms"></a>.
         </p>
@@ -957,8 +957,8 @@ based on [[[VC-DATA-INTEGRITY]]] [[?VC-DATA-INTEGRITY]].
 namely 'Header', 'Payload', and 'Signature'. The 'Header' label is
 connected, with an arrow, to a separate rectangle on the right hand
 side containing six text fields: 'kid: aB8J-_Z', 'alg: ES384', and
-'cty: vc+ld+json', iss: https://example.com, iat: 1704690029, and typ:
-vc+ld+json+sd-jwt The 'Payload' label on the left side is connected,
+'cty: vc', iss: https://example.com, iat: 1704690029, and typ:
+vc+sd-jwt The 'Payload' label on the left side is connected,
 with an arrow, to a separate rectangle, containing a single graph. The
 rectangle has a label: 'verifiable credential graph (serialized in
 JSON)' The claims in the graph include 'Credential 123' as a subject
@@ -1109,8 +1109,8 @@ secured via an [=enveloping proof=] shown on <a href="#info-graph-vc-jwt"></a>.
 namely 'Header', 'Payload', and 'Signature'. The 'Header' label is
 connected, with an arrow, to a separate rectangle on the right hand
 side containing six text fields: 'kid: aB8J-_Z', 'alg: ES384', and
-'cty: vc+ld+json', iss: https://example.com, iat: 1704690029, and typ:
-vp+ld+json+sd-jwt The 'Payload' label of the left side is connected,
+'cty: vc', iss: https://example.com, iat: 1704690029, and typ:
+vp+sd-jwt The 'Payload' label of the left side is connected,
 with an arrow, to a separate rectangle, consisting of two related
 graphs (stacked vertically) connected by a an arrow labeled
 'verifiableCredential'. The two graphs have each a label 'verifiable
@@ -1119,7 +1119,7 @@ graph (serialized in JSON)', respectively. The top graph in the
 rectangle has and object 'Presentation ABC' with 3 properties: 'type'
 of value VerifiablePresentation, 'termsOfUse' of value 'Do Not
 Archive'. The bottom graph includes
-'data:application/vc+ld+json+sd-jwt;QzVjV...RMjU' as a subject with a
+'data:application/vc+sd-jwt;QzVjV...RMjU' as a subject with a
 single property: 'type' of value `EnvelopedVerifiableCredential`.
 Finally, the 'Signature' label on the left side is connected, with an
 arrow, to a separate rectangle, containing a single text field:
@@ -2522,7 +2522,7 @@ enveloped [=verifiable credential=]:
   "type": ["VerifiablePresentation", "ExamplePresentation"],
   <span class="highlight">"verifiableCredential": [{
     "@context": "https://www.w3.org/ns/credentials/v2",
-    "id": "data:application/vc+ld+json+sd-jwt;QzVjV...RMjU",
+    "id": "data:application/vc+sd-jwt;QzVjV...RMjU",
     "type": "EnvelopedVerifiableCredential"
   }]</span>
 }
@@ -2571,7 +2571,7 @@ The example below shows an enveloped [=verifiable presentation=]:
           <pre class="example nohighlight" title="Basic structure of an enveloped verifiable presentation">
 {
   "@context": "https://www.w3.org/ns/credentials/v2",
-  <span class="highlight">"id": "data:application/vp+ld+json+jwt;eyJraWQiO...zhwGfQ",
+  <span class="highlight">"id": "data:application/vp+jwt;eyJraWQiO...zhwGfQ",
   "type": "EnvelopedVerifiablePresentation"</span>
 }
           </pre>
@@ -4308,10 +4308,10 @@ The data model as described in Sections
 a [=verifiable credential=] or [=verifiable presentation=]. All
 serializations are representations of that data model in a specific format. This
 section specifies how the data model is realized in JSON-LD for
-`application/vc+ld+json`, the base media type for Verifiable Credentials.
+`application/vc`, the base media type for Verifiable Credentials.
 Although syntactic mappings are only provided for JSON-LD, applications and
 services can use any other data representation syntax (such as XML, YAML, or
-CBOR) that is capable of being mapped back to `application/vc+ld+json`. As the
+CBOR) that is capable of being mapped back to `application/vc`. As the
 [=verification=] and [=validation=] requirements are defined in terms of
 the data model, all serialization syntaxes have to be deterministically
 translated to the data model for processing, [=validation=], or comparison.
@@ -4388,7 +4388,7 @@ This specification restricts the usage of JSON-LD representations of
 the data model. JSON-LD <a
 href="https://www.w3.org/TR/json-ld/#compacted-document-form">compacted document
 form</a> MUST be utilized for all representations of the data model in the
-base media type, `application/vc+ld+json`.
+base media type, `application/vc`.
         </p>
 
         <p>
@@ -4551,10 +4551,10 @@ followed when defining or using media types with [=verifiable credentials=].
         <p>
 There are two media types associated with the core data model, which are
 listed in the Section <a href="#iana-considerations"></a>:
-`application/vc+ld+json` and `application/vp+ld+json`.
+`application/vc` and `application/vp`.
         </p>
         <p>
-The `application/vc+ld+json` and `application/vp+ld+json` media types do not
+The `application/vc` and `application/vp` media types do not
 imply any particular securing mechanism, but are intended to be used in
 conjunction with securing mechanisms. A securing mechanism needs to be applied
 to protect the integrity of these media types. Do not assume security of content
@@ -4583,7 +4583,7 @@ media type of `application/json` and `.jsonld` might result in a media type of
             </li>
             <li>
 A protocol requires a less precise media type for a particular transaction; for
-example, `application/json` instead of `application/vp+ld+json`,
+example, `application/json` instead of `application/vp`,
             </li>
           </ul>
 
@@ -4591,7 +4591,7 @@ example, `application/json` instead of `application/vp+ld+json`,
 Implementers are urged to not raise errors when it is possible to determine the
 intended media type from a payload, provided that the media type used is
 acceptable in the given protocol. For example, if an application only accepts
-payloads that conform to the rules associated with the `application/vc+ld+json`
+payloads that conform to the rules associated with the `application/vc`
 media type, but the payload is tagged with `application/json` or
 `application/ld+json` instead, the application might perform the following
 steps to determine whether the payload also conforms to the higher precision
@@ -4607,14 +4607,14 @@ Ensure that the first element of the `@context` field matches
 `https://www.w3.org/2018/credentials/v2`.
             </li>
             <li>
-Assume an `application/vp+ld+json` media type if the JSON document contains a
+Assume an `application/vp` media type if the JSON document contains a
 top-level `type` field containing a `VerifiablePresentation` element. Additional
 subsequent checks are still expected to be performed (according to this
 specification) to ensure the payload expresses a conformant Verifiable
 Presentation.
             </li>
             <li>
-Assume an `application/vc+ld+json` media type if the JSON document contains a
+Assume an `application/vc` media type if the JSON document contains a
 top-level `type` field containing a `VerifiableCredential` element. Additional
 subsequent checks are still expected to be performed (according to this
 specification) to ensure the payload expresses a conformant Verifiable
@@ -7399,8 +7399,8 @@ Diagram with, on the left, a box, labeled as 'JWT (Decoded)', and with
 three textual labels stacked vertically, namely 'Header', 'Payload', and
 'Signature'. The 'Header' label is connected, with an arrow, to a
 separate rectangle on the right hand side containing six text fields:
-'kid: aB8J-_Z', 'alg: ES384', and 'cty: vc+ld+json', iss:
-https://example.com, iat: 1704690029, and typ: vp+ld+json+sd-jwt The
+'kid: aB8J-_Z', 'alg: ES384', and 'cty: vc', iss:
+https://example.com, iat: 1704690029, and typ: vp+sd-jwt The
 'Payload' label of the left side is connected, with an arrow, to a
 separate rectangle, consisting of three related graphs (stacked
 vertically) connected by two arrows labeled 'verifiableCredential'
@@ -7411,10 +7411,10 @@ credential graph (serialized in JSON)'. The top graph in the rectangle
 has and object 'Presentation ABC' with 3 properties: 'type' of value
 VerifiablePresentation, 'termsOfUse' of value 'Do Not Archive'. One of
 the the bottom graphs includes
-'data:application/vc+ld+json+sd-jwt;QzVjV...RMjU' as a subject with a
+'data:application/vc+sd-jwt;QzVjV...RMjU' as a subject with a
 single property: 'type' of value `EnvelopedVerifiableCredential`. The
 last bottom graph is identical other, except for the subject which is
-labeled as 'data:application/vc+ld+json+sd-jwt;RkOyT...KjOl'. Finally,
+labeled as 'data:application/vc+sd-jwt;RkOyT...KjOl'. Finally,
 the 'Signature' label on the left side is connected, with an arrow, to a
 separate rectangle, containing a single text field:
 'cYjaSdfIoJH45NIqw3MYnasGIba...'.
@@ -7564,7 +7564,7 @@ Add `termsOfUse` to presentations in v2 context.
 Add default vocabulary for undefined terms to v2 context.
         </li>
         <li>
-Add media types for `application/vc+ld+json` and `application/vp+ld+json`.
+Add media types for `application/vc` and `application/vp`.
         </li>
         <li>
 Provide guidance on converting to and from conforming documents from other


### PR DESCRIPTION
This PR is an attempt to address issue #1462 by setting the media types to something that would be uncontroversial from an IANA Media Types perspective. This PR changes the media type for a VC to "application/vc", and the media type for a VP to "application/vp".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1478.html" title="Last updated on Jun 14, 2024, 2:44 PM UTC (5d9b9b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1478/952ff1b...5d9b9b5.html" title="Last updated on Jun 14, 2024, 2:44 PM UTC (5d9b9b5)">Diff</a>