### PR TITLE
Rework content integrity section based on @jyasskin's feedback.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3180,16 +3180,10 @@ IANA Media Types</a> registry.
 One or more cryptographic digests, as defined in [[[SRI]]].
                   </td>
                 </tr>
-                <tr>
-                  <td>`digestMultibase`</td>
-                  <td>
-One or more cryptographic digests, as defined in [[[VC-DATA-INTEGRITY]]].
-                  </td>
-                </tr>
               </tbody>
             </table>
 Each object associated with `relatedResource` MUST contain at least a
-`digestSRI` or `digestMultibase` value.
+`digestSRI` value.
           </dd>
         </dl>
 
@@ -3217,7 +3211,7 @@ media type.
         <p>
 Any object in the [=verifiable credential=] that contains an `id`
 property MAY be annotated with integrity information by adding the
-`digestSRI` or `digestMultibase` and `mediaType` properties.
+`digestSRI` and `mediaType` properties.
         </p>
 
         <p>
@@ -3273,18 +3267,6 @@ An example of an object in a `credentialSubject` that is refering to an
 integrity protected image.
         </p>
 
-        <pre class="example nohighlight"
-          title="An integrity-protected image that is associated with a credentialSubject">
-"credentialSubject": {
-  "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-  "image": {
-    "id": "https://university.example.org/images/58473",
-    "mediaType": "application/svg+xml",
-    "digestMultibase": "zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
-  },
-  ...
-}
-        </pre>
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -3193,7 +3193,7 @@ Each object associated with `relatedResource` MUST contain at least a
           </dd>
         </dl>
 
-        <p class="issue" title="Unification of cryptographic hash expression formats are under discussion">
+        <p class="issue" data-number="1489">
 The Working Group is currently attempting to determine whether cryptographic hash
 expression formats can be unified across all of the VCWG core specifications.
 Candidates for this mechanism include `digestSRI` and `digestMultibase`. There

--- a/index.html
+++ b/index.html
@@ -3265,11 +3265,6 @@ An example of a related resource integrity object referencing JSON-LD contexts.
 }]
         </pre>
 
-        <p>
-An example of an object in a `credentialSubject` that is refering to an
-integrity protected image.
-        </p>
-
       </section>
 
       <section>

--- a/index.html
+++ b/index.html
@@ -3127,16 +3127,16 @@ interoperability.
         <h2>Integrity of Related Resources</h2>
         <p>
 When including a link to an external resource in a [=verifiable credential=], it
-is desirable to know whether the resource has been modified after the
+is desirable to know whether the resource has been modified since the
 [=verifiable credential=] was issued. This applies to cases where there is an
 external resource that is remotely retrieved, as well as to cases where the
-[=issuer=] and/or [=verifier=] might have local cached copies of a resource. It
-is also desirable to know that the contents of the JSON-LD context(s) used in
-the [=verifiable credential=] are the same when used by both the [=issuer=] and
-[=verifier=].
+[=issuer=] and/or [=verifier=] might have locally cached copies of a resource.
+It is also desirable to know that the contents of the JSON-LD context(s) used
+in the [=verifiable credential=] are the same when used by the [=verifier=] as
+they were when used by the [=issuer=].
         </p>
 
-        <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
+        <p class="issue" title="Mandatory listing of contexts in `relatedResource` is under debate.">
 The requirement that contexts be listed in `relatedResource` is currently being
 debated in the VCWG. This requirement might be removed in future iterations of
 the specification.
@@ -3244,7 +3244,11 @@ implementers.
         <p class="issue">
 The working group is discussing if we will adopt more aspects of subresource
 integrity as defined in [[SRI]] is adopted into the [[JSON-LD11]] specification as
-noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security">
+noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security"> 
+current security considerations</a> of that specification, the
+approach described in this section can serve as an additional check towards
+ensuring that a cached context used when issuing
+a [=verifiable credential=] matches the remote resource.
 current security considerations</a> of that specification, the
 approach described in this section can serve as an additional check towards
 ensuring that a cached context used when issuing

--- a/index.html
+++ b/index.html
@@ -3202,7 +3202,7 @@ are arguments for and against unification that the WG is currently debating.
 
         <p>
 If a `mediaType` is listed, implementations that retrieve the resource
-using [[[?RFC9110]]] SHOULD:
+identified by the `id` property using [[[?RFC9110]]] SHOULD:
         </p>
         <ul>
           <li>
@@ -3244,7 +3244,7 @@ implementers.
         <p class="issue">
 The working group is discussing if we will adopt more aspects of subresource
 integrity as defined in [[SRI]] is adopted into the [[JSON-LD11]] specification as
-noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security"> 
+noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security">
 current security considerations</a> of that specification, the
 approach described in this section can serve as an additional check towards
 ensuring that a cached context used when issuing

--- a/index.html
+++ b/index.html
@@ -3150,8 +3150,8 @@ To extend integrity protection to a related resource, an [=issuer=] of a
         <dl>
           <dt id="defn-relatedResource">relatedResource</dt>
           <dd>
-The value of the `relatedResource` property MUST be associated with one or
-more objects of the following form:
+The value of the `relatedResource` property MUST be one or more objects of the
+following form:
             <table class="simple">
               <thead>
                 <th>Property</th>

--- a/index.html
+++ b/index.html
@@ -3177,7 +3177,10 @@ IANA Media Types</a> registry.
                 <tr>
                   <td>`digestSRI`</td>
                   <td>
-One or more cryptographic digests, as defined in [[[SRI]]].
+One or more cryptographic digests, as defined by the `hash-expression` ABNF
+grammar defined in the [[[SRI]]] specification,
+<a data-cite="SRI#the-integrity-attribute">Section 3.5: The `integrity`
+attribute</a>.
                   </td>
                 </tr>
               </tbody>

--- a/index.html
+++ b/index.html
@@ -3209,7 +3209,8 @@ identified by the `id` property using [[[?RFC9110]]] SHOULD:
 use the media type in the `Accept` HTTP Header, and
           </li>
           <li>
-use the media type in the `Content-Type` HTTP Header.
+reject the response if it includes a `Content-Type` HTTP Header with a different
+media type.
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -3177,13 +3177,13 @@ IANA Media Types</a> registry.
                 <tr>
                   <td>`digestSRI`</td>
                   <td>
-A cryptographic digest, as defined in [[[SRI]]].
+One or more cryptographic digests, as defined in [[[SRI]]].
                   </td>
                 </tr>
                 <tr>
                   <td>`digestMultibase`</td>
                   <td>
-A cryptographic digest, as defined in [[[VC-DATA-INTEGRITY]]].
+One or more cryptographic digests, as defined in [[[VC-DATA-INTEGRITY]]].
                   </td>
                 </tr>
               </tbody>

--- a/index.html
+++ b/index.html
@@ -3250,10 +3250,6 @@ current security considerations</a> of that specification, the
 approach described in this section can serve as an additional check towards
 ensuring that a cached context used when issuing
 a [=verifiable credential=] matches the remote resource.
-current security considerations</a> of that specification, the
-approach described in this section can serve as an additional check towards
-ensuring that a cached context used when issuing
-a [=verifiable credential=] matches the remote resource.
         </p>
         <p>
 An example of a related resource integrity object referencing JSON-LD contexts.

--- a/index.html
+++ b/index.html
@@ -3216,8 +3216,8 @@ media type.
 
         <p>
 Any object in the [=verifiable credential=] that contains an `id`
-property MAY be annotated with integrity information as specified in this
-section.
+property MAY be annotated with integrity information by adding the
+`digestSRI` or `digestMultibase` and `mediaType` properties.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3126,85 +3126,110 @@ interoperability.
       <section>
         <h2>Integrity of Related Resources</h2>
         <p>
-When including a link to an external resource in a [=verifiable credential=],
-it is desirable to know whether the resource that is pointed to is the same at
-signing time as it is at verification time. This applies to cases where there is
-an external resource that is remotely retrieved as well as to cases where the
-[=issuer=] and/or [=verifier=] may have local cached copies of a resource.
+When including a link to an external resource in a [=verifiable credential=], it
+is desirable to know whether the resource has been modified after the
+[=verifiable credential=] was issued. This applies to cases where there is an
+external resource that is remotely retrieved, as well as to cases where the
+[=issuer=] and/or [=verifier=] might have local cached copies of a resource. It
+is also desirable to know that the contents of the JSON-LD context(s) used in
+the [=verifiable credential=] are the same when used by both the [=issuer=] and
+[=verifier=].
         </p>
-        <p>
-It is also desirable to know that the contents of the JSON-LD context(s) used in
-the [=verifiable credential=] are the same when used by both the
-[=issuer=] and [=verifier=].
-        </p>
-        <p>
-To validate that a resource referenced by a [=verifiable credential=] is the
-same at verification time as it is at issuing time, an implementer MAY include a
-property named <code id="defn-relatedResource">relatedResource</code> that
-stores an array of objects that describe additional integrity metadata about
-each resource referenced by the [=verifiable credential=]. If
-`relatedResource` is present, there MUST be an object in the array
-for each remote resource for each context used in the verifiable credential.
-        </p>
+
         <p class="issue" title="Mandatory listing of contexts in relatedResouce are under debate.">
 The requirement that contexts be listed in `relatedResource` is currently being
 debated in the VCWG. This requirement might be removed in future iterations of
 the specification.
         </p>
+
         <p>
-Each object in the `relatedResource` array MUST contain the
-following: the [[URL]] to the resource named `id` and the
-<code id="defn-digestSRI">digestSRI</code> information for the resource
-constructed using the method specified in
-<a href="https://www.w3.org/TR/SRI/#integrity-metadata">Subresource Integrity</a>.
+To extend integrity protection to a related resource, an [=issuer=] of a
+[=verifiable credential=] MAY include the `relatedResource` property:
         </p>
+
+        <dl>
+          <dt id="defn-relatedResource">relatedResource</dt>
+          <dd>
+The value of the `relatedResource` property MUST be associated with one or
+more objects of the following form:
+            <table class="simple">
+              <thead>
+                <th>Property</th>
+                <th>Description</th>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>`id`</td>
+                  <td>
+The identifier for the resource is REQUIRED and conforms to the format defined
+in Section [[[#identifiers]]]. The value MUST be unique among the list of
+related resource objects.
+                  </td>
+                </tr>
+                <tr>
+                  <td>`mediaType`</td>
+                  <td>
+An OPTIONAL valid media type as listed in the
+<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
+IANA Media Types</a> registry.
+                  </td>
+                </tr>
+                <tr>
+                  <td>`digestSRI`</td>
+                  <td>
+A cryptographic digest, as defined in [[[SRI]]].
+                  </td>
+                </tr>
+                <tr>
+                  <td>`digestMultibase`</td>
+                  <td>
+A cryptographic digest, as defined in [[[VC-DATA-INTEGRITY]]].
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+Each object associated with `relatedResource` MUST contain at least a
+`digestSRI` or `digestMultibase` value.
+          </dd>
+        </dl>
+
         <p class="issue" title="Unification of cryptographic hash expression formats are under discussion">
 The Working Group is currently attempting to determine whether cryptographic hash
 expression formats can be unified across all of the VCWG core specifications.
 Candidates for this mechanism include `digestSRI` and `digestMultibase`. There
 are arguments for and against unification that the WG is currently debating.
         </p>
+
         <p>
-There MUST NOT be more than one object in the `relatedResource` per
-`id`.
-        </p>
-        <p>
-An object in the `relatedResource` array MAY contain a property named
-`mediaType` that indicates the expected media type for the indicated
-`resource`. If a `mediaType` is included, its value
-SHOULD:
+If a `mediaType` is listed, implementations that retrieve the resource
+using [[[?RFC9110]]] SHOULD:
         </p>
         <ul>
           <li>
-be a valid media type as listed in the
-<a href="https://www.iana.org/assignments/media-types/media-types.xhtml">
-IANA Media Types</a> registry
+use the media type in the `Accept` HTTP Header, and
           </li>
           <li>
-be used when retrieving the content, such as via the `Accept` HTTP Header
-          </li>
-          <li>
-match the retrieved content media type, such as via the `Content-Type` HTTP
-Header.
+use the media type in the `Content-Type` HTTP Header.
           </li>
         </ul>
 
         <p>
-Any object in the [=verifiable credential=] that contains an `id` [[URL]]
+Any object in the [=verifiable credential=] that contains an `id`
 property MAY be annotated with integrity information as specified in this
-section by inclusion of `digestSRI`
-in the object.
+section.
         </p>
+
         <p>
-Any objects for which selective disclosure is desired SHOULD NOT be included as
-an object in the `relatedResource` array.
+Any objects for which selective disclosure or unlinkable disclosure is desired
+SHOULD NOT be included as an object in the `relatedResource` array.
         </p>
+
         <p>
 Specification authors that write algorithms that fetch a resource based on the
 `id` of an object inside a [=conforming document=] need to consider whether
 that resource's content is vital to the validity of that document. If it is, the
-specification MUST produce a validation error unless the resource has the
-expected media type and its bytes hash to the expected digest.
+specification MUST produce a validation error unless the resource matches the
+expected media type and cryptographic digest.
         </p>
         <p>
 Implementers are urged to consult appropriate sources, such as the
@@ -3212,7 +3237,7 @@ Implementers are urged to consult appropriate sources, such as the
 FIPS 180-4 Secure Hash Standard</a> and the
 <a href="https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF">
 Commercial National Security Algorithm Suite 2.0</a> to ensure that they are
-chosing a current and reliable hash algorithm. At the time of this writing
+choosing a current and reliable hash algorithm. At the time of this writing
 `sha384` SHOULD be considered the minimum strength hash algorithm for use by
 implementers.
         </p>
@@ -3220,16 +3245,17 @@ implementers.
 The working group is discussing if we will adopt more aspects of subresource
 integrity as defined in [[SRI]] is adopted into the [[JSON-LD11]] specification as
 noted in that specifications <a href="https://www.w3.org/TR/json-ld11/#security">
-current security considerations</a> of that specification, this hash in the VC
-can serve as an additional check towards ensuring that a cached context used
-when issuing the VC matches the remote resource.
+current security considerations</a> of that specification, the
+approach described in this section can serve as an additional check towards
+ensuring that a cached context used when issuing
+a [=verifiable credential=] matches the remote resource.
         </p>
         <p>
 An example of a related resource integrity object referencing JSON-LD contexts.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the relatedResource property">
+          title="Usage of the relatedResource and digestSRI property">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestSRI":
@@ -3252,9 +3278,8 @@ integrity protected image.
   "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
   "image": {
     "id": "https://university.example.org/images/58473",
-    "digestSRI":
-      "sha384-ZfAwuJmMgoX3s86L7x9XSPi3AEbiz6S/5SyGHJPCxWHs5NEth/c5S9QoS1zZft+J",
     "mediaType": "application/svg+xml",
+    "digestMultibase": "zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"
   },
   ...
 }


### PR DESCRIPTION
This PR is an attempt to partially address issue #1348 by reworking the content integrity section in the specification based on feedback from @jyasskin. 

NOTE: It contains content that was objected to by @selfissued in PR #1464 and is, thus, not mergeable in its current state. This PR will be used to drive the discussion and come to consensus on what can be merged by consensus of the group.

Specifically:

#### 5.4 Integrity of Related Resources

- [x] Editorial clean-up and simplification of normative statements to match other sections. Fixed in b3ac23cafe92eb92980b8c2d4612d0cdd9908b96 and e0c09880ba284d9da44d23b5c151fdf4bf113f7b and re-applied in 692947e2febafad5b5e9ae55bf181d5ab02e245d.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1484.html" title="Last updated on May 27, 2024, 6:57 PM UTC (cc8b0e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1484/b11eec7...cc8b0e3.html" title="Last updated on May 27, 2024, 6:57 PM UTC (cc8b0e3)">Diff</a>