### PR TITLE
Use digestMultibase with base64-url-nopad encoding for integrity.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3241,27 +3241,21 @@ IANA Media Types</a> registry.
                   </td>
                 </tr>
                 <tr>
-                  <td>`digestSRI`</td>
+                  <td>`digestMultibase`</td>
                   <td>
-One or more cryptographic digests, as defined by the `hash-expression` ABNF
-grammar defined in the [[[SRI]]] specification,
-<a data-cite="SRI#the-integrity-attribute">Section 3.5: The `integrity`
-attribute</a>.
+One or more cryptographic digests, as defined by the `digestMultibase`
+property in the [[[VC-DATA-INTEGRITY]]]
+specification, <a data-cite="VC-DATA-INTEGRITY#resource-integrity">
+Section 2.6: Resource Integrity</a>. The Multibase encoding MUST use the
+base64-url-nopad (`u`) option.
                   </td>
                 </tr>
               </tbody>
             </table>
 Each object associated with `relatedResource` MUST contain at least a
-`digestSRI` value.
+`digestMultibase` value.
           </dd>
         </dl>
-
-        <p class="issue atrisk" data-number="1489">
-The Working Group is currently attempting to determine whether cryptographic hash
-expression formats can be unified across all of the VCWG core specifications.
-Candidates for this mechanism include `digestSRI` and `digestMultibase`. There
-are arguments for and against unification that the WG is currently debating.
-        </p>
 
         <p>
 If a `mediaType` is listed, implementations that retrieve the resource
@@ -3279,8 +3273,8 @@ media type.
 
         <p>
 Any object in the [=verifiable credential=] that contains an `id`
-property MAY be annotated with integrity information by adding the
-`digestSRI` and `mediaType` properties.
+property MAY be annotated with integrity information by adding
+`digestMultibase` and, optionally, the `mediaType` property.
         </p>
 
         <p>
@@ -3319,15 +3313,13 @@ An example of a related resource integrity object referencing JSON-LD contexts.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the relatedResource and digestSRI property">
+          title="Usage of the relatedResource and digestMultibase property">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
-  "digestSRI":
-    "sha384-lHKDHh0msc6pRx8PhDOMkNtSI8bOfsp4giNbUrw71nXXLf13nTqNJoRp3Nx+ArVK",
+  "digestMultibase": "uEres1usWcWCmW7uolIW2uA0CjQ8iRV14eGaZStJL73Vz",
 },{
   "id": "https://www.w3.org/ns/credentials/examples/v2",
-  "digestSRI":
-    "sha384-zNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26",
+  "digestMultibase": "uElc5P7xp1u-5ubXcnLa5iAsJRDYKv-Lq9FnJ5YzyJ518",
 }]
         </pre>
 
@@ -3718,7 +3710,7 @@ Verifiable Credentials Implementation Guidelines [[VC-IMP-GUIDE]] document.
       "name": "Talk-aloud video of double espresso preparation",
       "description": "This is a talk-aloud video of Alice demonstrating preparation of a double espresso drink.",
       <span class='comment'>// digest hash of the mp4 video file</span>
-      "digestSRI": "sha384-zNNbQTWCSUSi0bbz7dbua...OHdzwELMYO9Mz68M26"
+      "digestMultibase": "uEkrjQf4CMji1ROmEixJsv3qeeDP8Zd0SkClxtCU_GiB0"
     }
   ]
 }


### PR DESCRIPTION
This PR is an attempt to address issue #1489 by choosing a specific digest mechanism (Multihash locked to SHA2 and SHA3) with a specific base encoding format (Multibase locked to base64-url-nopad). IOW, the WG could not come to consensus on [Option C](https://github.com/w3c/vc-data-model/issues/1489#issuecomment-2134164168), the current spec implements [Option A](https://github.com/w3c/vc-data-model/issues/1489#issuecomment-2134164168) (which does not have consensus), and this PR implements [Option B](https://github.com/w3c/vc-data-model/issues/1489#issuecomment-2134164168).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1490.html" title="Last updated on Jun 1, 2024, 4:42 PM UTC (0014b6d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1490/03ce39d...0014b6d.html" title="Last updated on Jun 1, 2024, 4:42 PM UTC (0014b6d)">Diff</a>