### PR TITLE
Remove issue marker for mandatory use of `resourceIntegrity` for contexts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3209,12 +3209,6 @@ in the [=verifiable credential=] are the same when used by the [=verifier=] as
 they were when used by the [=issuer=].
         </p>
 
-        <p class="issue" title="Mandatory listing of contexts in `relatedResource` is under debate.">
-The requirement that contexts be listed in `relatedResource` is currently being
-debated in the VCWG. This requirement might be removed in future iterations of
-the specification.
-        </p>
-
         <p>
 To extend integrity protection to a related resource, an [=issuer=] of a
 [=verifiable credential=] MAY include the `relatedResource` property:


### PR DESCRIPTION
This PR removes an issue marker noting that the WG is debating mandatory resource integrity entries for JSON-LD Context files. 

It is highly unlikely that the WG will come to consensus on making the use of `resourceIntegrity` for expressing digest values for JSON-LD Contexts mandatory because 1) there are other mechanisms to do so, 2) it creates complexities for selective disclosure, 3) it's unnecessary when using alternative integrity mechanisms (like static application contexts, known good hashes, hashlinks, etc.).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1493.html" title="Last updated on Jun 1, 2024, 7:30 PM UTC (6667695)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1493/5abaeed...6667695.html" title="Last updated on Jun 1, 2024, 7:30 PM UTC (6667695)">Diff</a>