### PR TITLE
Remove issue marker for "determining" language.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4813,16 +4813,6 @@ the [[[?VC-SPECS]]] [[?VC-SPECS]], or other mechanisms known to the
 implementation, to determine the cryptographic suite to use when verifying
 the securing mechanism. The |verifyProof| function MUST implement the interface
 described in <a href="#securing-mechanisms"></a>.
-                <div class="issue"
-                     title="Mechanism for 'determining' is being detailed">
-At present, the Working Group is concerned that the algorithm for "determining"
-might need to be more formally defined. At present, no implementation has
-had an issue determining the proper |verifyProof| algorithm to use, but the
-Working Group is attempting to see if saying more here would be worthwhile.
-Additional example language could be added that says that an implementation
-might have an allow list of acceptable cryptosuites — and these will be used as
-inputs for finding matching proofs to be verified.
-                </div>
               </li>
               <li>
 Set |result| to the result of passing |inputBytes| and


### PR DESCRIPTION
This PR removes an issue marker that requested feedback from implementers on whether or not the WG should elaborate on what we mean by "determining". The WG has not received feedback from implementers stating that we need to define what "determining" means and we have multiple interoperable implementations that perform verification. Therefore, this PR removes the issue marker.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1494.html" title="Last updated on Jun 1, 2024, 7:48 PM UTC (b3bf905)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1494/5abaeed...b3bf905.html" title="Last updated on Jun 1, 2024, 7:48 PM UTC (b3bf905)">Diff</a>