### PR TITLE
Reserve `confidenceMethod` and `renderMethod`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3976,18 +3976,8 @@ see Section <a href="#types"></a>.
               <td>
 A property used for specifying one or more methods that a verifier might use to
 increase their confidence that the value of a property in or of a verifiable
-credential or verifiable presentation is accurate, including but not limited to
-properties such as `initialRecipient` (a/k/a `issuee`), `presenter`,
-`authorizedPresenter`, `holder`, etc. The associated vocabulary URL MUST be
-`https://www.w3.org/2018/credentials#confidenceMethod`.
-                <p class="issue atrisk" data-number="1437" title="Reservation depends on implementations">
-This property reservation might be deleted in favor of an existing section
-in the specification if at least one specification with two independent
-implementations are demonstrated by the end of the Candidate Recommendation
-Phase. If that does not occur, this reservation will remain, but the existing
-section in the specification will be removed.
-See <a href="https://w3c-ccg.github.io/confidence-method-spec/">Verifiable Credential Confidence Methods</a>.
-                </p>
+credential or verifiable presentation is accurate. The associated vocabulary
+URL MUST be `https://www.w3.org/2018/credentials#confidenceMethod`.
               </td>
             </tr>
             <tr>
@@ -4023,15 +4013,9 @@ section in the specification will be removed.
             <tr>
               <td>`renderMethod`</td>
               <td>
-A property used for specifying one or more methods to render a credential into a visual,
-auditory, or haptic format. The associated vocabulary URL MUST be
+A property used for specifying one or more methods to render a credential into a
+visual, auditory, or haptic format. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#renderMethod`.
-                <p class="issue atrisk" data-number="1437" title="Reservation depends on implementations">
-This reserved property is at risk and will be removed from the
-specification if at least one specification with two independent implementations
-are not demonstrated by the end of the Candidate Recommendation Phase.
-See <a href="https://w3c-ccg.github.io/vc-render-method/">Verifiable Credential Rendering Methods</a>.
-                </p>
               </td>
             </tr>
             <tr>
@@ -7025,10 +7009,6 @@ the <a href="#status">credentialStatus</a> property.
               <td>
 Serves as a superclass for specific confidence method types that are placed into
 the `confidenceMethod` property.
-<span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the superclass are not identified
-by the end of the Candidate Recommendation phase.
-</span>
               </td>
             </tr>
             <tr id="bc-refresh-service">
@@ -7051,10 +7031,6 @@ by the end of the Candidate Recommendation phase.
               <td>
 Serves as a superclass for specific render method types that are placed into
 the `renderMethod` property.
-<span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the superclass are not identified
-by the end of the Candidate Recommendation phase.
-</span>
               </td>
             </tr>
             <tr id="bc-terms-of-use">


### PR DESCRIPTION
This PR is an attempt to partially address issue #1437 by reserving the `confidenceMethod` and `renderMethod` properties. The VCWG is unlikely to define, implement, and test either feature in the next several months and is reserving both properties in order to advance them during a future Working Group.