### PR TITLE
Remove at risk marker for `refreshService` property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3378,15 +3378,6 @@ An example of a related resource integrity object referencing JSON-LD contexts.
       <section>
         <h3>Refreshing</h3>
 
-        <p class="issue atrisk" data-number="1437" title="Feature depends on demonstration of independent implementations">
-This feature is at risk and will be removed from the specification if at least
-two independent, interoperable implementations are not demonstrated for a
-single extension type by the end of the Candidate Recommendation Phase. If
-this feature is removed, the property will be included in Section
-<a href="#reserved-extension-points"></a>, in anticipation of future
-implementation and inclusion in the specification.
-        </p>
-
         <p>
 It is useful for systems to enable the manual or automatic refresh of an expired
 [=verifiable credential=]. For more information about validity periods for
@@ -3413,14 +3404,6 @@ The refresh service is only expected to be used when either the
 that does not contain public information or whose refresh service is not
 protected in some way.
         </p>
-        <p class="note"
-           title="Non-authenticated credential refresh">
-Placing a `refreshService` [=property=] in a
-[=verifiable credential=] so that it is available to [=verifiers=] can
-remove control and consent from the [=holder=] and allow the
-[=verifiable credential=] to be issued directly to the [=verifier=],
-thereby bypassing the [=holder=].
-        </p>
 
         <dl>
           <dt><var id="defn-refreshService">refreshService</var></dt>
@@ -3438,34 +3421,40 @@ definition.
           title="Usage of the refreshService property by an issuer">
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2",
-    "https://w3id.org/vc-refresh-service/v1"
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/age/v1",
+    "https://w3id.org/security/suites/ed25519-2020/v1"
   ],
-  "id": "http://university.example/credentials/3732",
-  "type": ["VerifiableCredential", "ExampleDegreeCredential"],
-  "issuer": "https://university.example/issuers/14",
-  "validFrom": "2020-01-01T19:23:24Z",
+  "type": ["VerifiableCredential", "AgeVerificationCredential"],
+  "issuer": "did:key:z6MksFxi8wnHkNq4zgEskSZF45SuWQ4HndWSAVYRRGe9qDks",
+  "issuanceDate": "2024-04-03T00:00:00.000Z",
+  "expirationDate": "2024-12-15T00:00:00.000Z",
+  "name": "Age Verification Credential",
   "credentialSubject": {
-    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
-    "degree": {
-      "type": "ExampleBachelorDegree",
-      "name": "Bachelor of Science and Arts"
-    }
+    "overAge": 21
   },
   <span class="highlight">"refreshService": {
     "type": "VerifiableCredentialRefreshService2021",
-    "url": "https://university.example/workflows/refresh-degree",
-    "validFrom": "2021-09-01T19:23:24Z",
-    "validUntil": "2022-02-01T19:23:24Z"
+    "url": "https://registration.provider.example/flows/reissue-age-token",
+    "refreshToken": "z2BJYfNtmWRiouWhDrbDQmC2zicUPBxsPg"
   }</span>
 }
         </pre>
 
         <p>
 In the example above, the [=issuer=] specifies an automatic
-`refreshService` that can be used by directing the [=holder=] to
-`https://university.example/workflows/refresh-degree`.
+`refreshService` that can be used by POSTing the [=verifiable credential=] to
+the refresh service `url`. Note that this particular verifiable credential is
+not intended to be shared with anyone except for the original issuer.
+        </p>
+
+        <p class="note"
+           title="Non-authenticated credential refresh">
+Placing a `refreshService` [=property=] in a
+[=verifiable credential=] so that it is available to [=verifiers=] can
+remove control and consent from the [=holder=] and allow the
+[=verifiable credential=] to be issued directly to the [=verifier=],
+thereby bypassing the [=holder=].
         </p>
 
       </section>
@@ -4184,7 +4173,7 @@ can achieve this protection are discussed in Section
         <p>
 A securing mechanism specification that creates a new type of [=embedded proof=]
 MUST specify a [=property=] that relates the [=verifiable credential=] or [=verifiable
-presentation=] to a [=proof graph=]. 
+presentation=] to a [=proof graph=].
 The requirements on the securing mechanism are as follow:
         </p>
         <ul>
@@ -4195,15 +4184,15 @@ in the same manner as they are utilized by this specification.
           </li>
           <li>
 The securing mechanism MUST secure all graphs in the [=verifiable credential=] or the [=verifiable
-presentation=], except for any [=proof graphs=] securing the [=verifiable credential=] 
+presentation=], except for any [=proof graphs=] securing the [=verifiable credential=]
 or the [=verifiable presentation=] itself.
           </li>
 
         </ul>
 
       <p class="note">
-The last requirement means that the securing mechanism secures the [=default graph=] and, 
-for [=verifiable presentations=], each [=verifiable credential=] of the presentation, together with 
+The last requirement means that the securing mechanism secures the [=default graph=] and,
+for [=verifiable presentations=], each [=verifiable credential=] of the presentation, together with
 their respective [=proof graphs=].
 See also <a href="#info-graph-vp"></a> or <a href="#info-graph-vp-mult-creds"></a>.
       </p>
@@ -6789,7 +6778,7 @@ franchise. Policy information expressed by the [=issuer=] in the
 Systems using what is today commonly referred to as "artificial intelligence" and/or "machine learning" might be capable of performing
 complex tasks at a level that meets or exceeds human performance.
 This might include tasks such as the acquisition and use of
-[=verifiable credentials=]. 
+[=verifiable credentials=].
 Using such tasks to distinguish between human and automated "bot" activity, as is
 commonly done today with a <a href="https://en.wikipedia.org/wiki/CAPTCHA">CAPTCHA</a>,
 for instance, might thereby cease to provide adequate or acceptable protection.
@@ -7025,10 +7014,6 @@ the `confidenceMethod` property.
               <td>
 Serves as a superclass for specific refresh service types that are placed into
 the <a href="#refreshing">credentialRefresh</a> property.
-<span class="issue atrisk">This superclass is at risk and will be removed if
-at least two independent implementations for the superclass are not identified
-by the end of the Candidate Recommendation phase.
-</span>
               </td>
             </tr>
             <tr id="bc-render-method">


### PR DESCRIPTION
This PR is an attempt to partially address issue #1437 by removing the at risk issue marker for the `refreshService` property.

There are [two registered specifications](https://w3c.github.io/vc-specs-dir/#refresh-service) in the VC Specifications Directory that use the extension point. The 1EdTech VC Refresh v1.0 specification uses the extension point. The Conexxus Age Verification v1.0 standard uses the extension point, which has been implemented by (at least) Spruce (California DMV), TruAge, and Digital Bazaar.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1497.html" title="Last updated on Jul 17, 2024, 8:24 PM UTC (45f87c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1497/b29c107...45f87c3.html" title="Last updated on Jul 17, 2024, 8:24 PM UTC (45f87c3)">Diff</a>