### PR TITLE
Add reference to JAdES standard in Ecosystem Compatability.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3313,7 +3313,7 @@ media type.
         <p>
 Any object in the [=verifiable credential=] that contains an `id`
 property MAY be annotated with integrity information by adding either the
-`digestSRI` or `digestMultibase` property, either of which MAY be 
+`digestSRI` or `digestMultibase` property, either of which MAY be
 accompanied by the additionally optional `mediaType` property.
         </p>
 
@@ -4083,6 +4083,8 @@ credential formats include
 JSON Web Tokens</a> (JWTs),
 <a href="https://www.rfc-editor.org/rfc/rfc8392.html">
 CBOR Web Tokens</a> (CWTs),
+<a href="https://www.etsi.org/deliver/etsi_ts/119100_119199/11918201/01.01.01_60/ts_11918201v010101p.pdf">
+JSON Advanced Electronic Signature</a> (JAdES),
 <a href="https://www.iso.org/standard/69084.html">ISO-18013-5:2021</a>
 (mDLs),
 <a href="https://hyperledger.github.io/anoncreds-spec/">


### PR DESCRIPTION
This PR is an attempt to address issue #1481 by adding a reference to the JAdES standard in the Ecosystem Compatability section.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1501.html" title="Last updated on Jun 9, 2024, 2:55 PM UTC (9a4ab65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1501/171590d...9a4ab65.html" title="Last updated on Jun 9, 2024, 2:55 PM UTC (9a4ab65)">Diff</a>