### PR TITLE
Added `@json` type to `_sd` property in v2 context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -60,7 +60,8 @@
       "@id": "https://www.iana.org/assignments/jwt#_sd_alg"
     },
     "_sd": {
-      "@id": "https://www.iana.org/assignments/jwt#_sd"
+      "@id": "https://www.iana.org/assignments/jwt#_sd",
+      "@type": "@json"
     },
     "...": {
       "@id": "https://www.iana.org/assignments/jwt#..."


### PR DESCRIPTION
This PR is an attempt to address issue #1503 by ensuring that the `_sd` property's JSON values remain as JSON.

I did check the `_sd_alg` and `...` properties and both are always string values (so didn't use the `@json` type for those).