### PR TITLE
Fix `jsonSchema` context URL.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -191,7 +191,7 @@
         "type": "@type",
 
         "jsonSchema": {
-          "@id": "https://w3.org/2018/credentials#jsonSchema",
+          "@id": "https://www.w3.org/2018/credentials#jsonSchema",
           "@type": "@json"
         }
       }

--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -219,8 +219,8 @@
           "@type": "@id"
         },
         "statusSize": {
-            "@id": "https://www.w3.org/ns/credentials/status#statusSize",
-            "@type": "https://www.w3.org/2001/XMLSchema#positiveInteger"
+          "@id": "https://www.w3.org/ns/credentials/status#statusSize",
+          "@type": "https://www.w3.org/2001/XMLSchema#positiveInteger"
         },
         "statusMessage": {
           "@id": "https://www.w3.org/ns/credentials/status#statusMessage",


### PR DESCRIPTION
- Use correct URL host as defined and used elsewhere.
- This change was previously made and reverted by mistake.
  - Original fix: https://github.com/w3c/vc-data-model/pull/1427
  - A bad merge commit reverted part of one line: https://github.com/w3c/vc-data-model/pull/1428
- Fix another indent style issue.