### PR TITLE
Organize v2 context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -6,46 +6,25 @@
     "id": "@id",
     "type": "@type",
 
-    "kid": {
-      "@id": "https://www.iana.org/assignments/jose#kid",
-      "@type": "@id"
+    "...": {
+      "@id": "https://www.iana.org/assignments/jwt#..."
     },
-    "iss": {
-      "@id": "https://www.iana.org/assignments/jose#iss",
-      "@type": "@id"
+    "_sd": {
+      "@id": "https://www.iana.org/assignments/jwt#_sd",
+      "@type": "@json"
     },
-    "sub": {
-      "@id": "https://www.iana.org/assignments/jose#sub",
-      "@type": "@id"
-    },
-    "jku": {
-      "@id": "https://www.iana.org/assignments/jose#jku",
-      "@type": "@id"
-    },
-    "x5u": {
-      "@id": "https://www.iana.org/assignments/jose#x5u",
-      "@type": "@id"
+    "_sd_alg": {
+      "@id": "https://www.iana.org/assignments/jwt#_sd_alg"
     },
     "aud": {
       "@id": "https://www.iana.org/assignments/jwt#aud",
       "@type": "@id"
     },
-    "exp": {
-      "@id": "https://www.iana.org/assignments/jwt#exp",
-      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "nbf": {
-      "@id": "https://www.iana.org/assignments/jwt#nbf",
-      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "iat": {
-      "@id": "https://www.iana.org/assignments/jwt#iat",
-      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
     "cnf": {
       "@id": "https://www.iana.org/assignments/jwt#cnf",
       "@context": {
         "@protected": true,
+
         "kid": {
           "@id": "https://www.iana.org/assignments/jwt#kid",
           "@type": "@id"
@@ -56,38 +35,212 @@
         }
       }
     },
-    "_sd_alg": {
-      "@id": "https://www.iana.org/assignments/jwt#_sd_alg"
+    "exp": {
+      "@id": "https://www.iana.org/assignments/jwt#exp",
+      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
-    "_sd": {
-      "@id": "https://www.iana.org/assignments/jwt#_sd",
-      "@type": "@json"
+    "iat": {
+      "@id": "https://www.iana.org/assignments/jwt#iat",
+      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
-    "...": {
-      "@id": "https://www.iana.org/assignments/jwt#..."
+    "iss": {
+      "@id": "https://www.iana.org/assignments/jose#iss",
+      "@type": "@id"
+    },
+    "jku": {
+      "@id": "https://www.iana.org/assignments/jose#jku",
+      "@type": "@id"
+    },
+    "kid": {
+      "@id": "https://www.iana.org/assignments/jose#kid",
+      "@type": "@id"
+    },
+    "nbf": {
+      "@id": "https://www.iana.org/assignments/jwt#nbf",
+      "@type": "https://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "sub": {
+      "@id": "https://www.iana.org/assignments/jose#sub",
+      "@type": "@id"
+    },
+    "x5u": {
+      "@id": "https://www.iana.org/assignments/jose#x5u",
+      "@type": "@id"
     },
 
-    "digestSRI": {
-      "@id": "https://www.w3.org/2018/credentials#digestSRI",
-      "@type": "https://www.w3.org/2018/credentials#sriString"
-    },
+    "description": "https://schema.org/description",
     "digestMultibase": {
       "@id": "https://w3id.org/security#digestMultibase",
       "@type": "https://w3id.org/security#multibase"
     },
-
+    "digestSRI": {
+      "@id": "https://www.w3.org/2018/credentials#digestSRI",
+      "@type": "https://www.w3.org/2018/credentials#sriString"
+    },
     "mediaType": {
       "@id": "https://schema.org/encodingFormat"
     },
-
-    "description": "https://schema.org/description",
     "name": "https://schema.org/name",
+
+    "BitstringStatusListCredential":
+      "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
+
+    "BitstringStatusList": {
+      "@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "encodedList": {
+          "@id": "https://www.w3.org/ns/credentials/status#encodedList",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "statusMessage": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "message": "https://www.w3.org/ns/credentials/status#message",
+            "status": "https://www.w3.org/ns/credentials/status#status"
+          }
+        },
+        "statusPurpose":
+          "https://www.w3.org/ns/credentials/status#statusPurpose",
+        "statusReference": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusReference",
+          "@type": "@id"
+        },
+        "statusSize": {
+          "@id": "https://www.w3.org/ns/credentials/status#statusSize",
+          "@type": "https://www.w3.org/2001/XMLSchema#positiveInteger"
+        },
+        "ttl": "https://www.w3.org/ns/credentials/status#ttl"
+      }
+    },
+
+    "BitstringStatusListEntry": {
+      "@id":
+        "https://www.w3.org/ns/credentials/status#BitstringStatusListEntry",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "statusListCredential": {
+          "@id":
+            "https://www.w3.org/ns/credentials/status#statusListCredential",
+          "@type": "@id"
+        },
+        "statusListIndex":
+          "https://www.w3.org/ns/credentials/status#statusListIndex",
+        "statusPurpose":
+          "https://www.w3.org/ns/credentials/status#statusPurpose"
+      }
+    },
+
+    "DataIntegrityProof": {
+      "@id": "https://w3id.org/security#DataIntegrityProof",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "challenge": "https://w3id.org/security#challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "cryptosuite": {
+          "@id": "https://w3id.org/security#cryptosuite",
+          "@type": "https://w3id.org/security#cryptosuiteString"
+        },
+        "domain": "https://w3id.org/security#domain",
+        "expires": {
+          "@id": "https://w3id.org/security#expiration",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "nonce": "https://w3id.org/security#nonce",
+        "previousProof": {
+          "@id": "https://w3id.org/security#previousProof",
+          "@type": "@id"
+        },
+        "proofPurpose": {
+          "@id": "https://w3id.org/security#proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "assertionMethod": {
+              "@id": "https://w3id.org/security#assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "https://w3id.org/security#authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityDelegation": {
+              "@id": "https://w3id.org/security#capabilityDelegationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "capabilityInvocation": {
+              "@id": "https://w3id.org/security#capabilityInvocationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "keyAgreement": {
+              "@id": "https://w3id.org/security#keyAgreementMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": {
+          "@id": "https://w3id.org/security#proofValue",
+          "@type": "https://w3id.org/security#multibase"
+        },
+        "verificationMethod": {
+          "@id": "https://w3id.org/security#verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
 
     "EnvelopedVerifiableCredential":
       "https://www.w3.org/2018/credentials#EnvelopedVerifiableCredential",
 
     "EnvelopedVerifiablePresentation":
       "https://www.w3.org/2018/credentials#EnvelopedVerifiablePresentation",
+
+    "JsonSchemaCredential":
+      "https://www.w3.org/2018/credentials#JsonSchemaCredential",
+
+    "JsonSchema": {
+      "@id": "https://www.w3.org/2018/credentials#JsonSchema",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "jsonSchema": {
+          "@id": "https://www.w3.org/2018/credentials#jsonSchema",
+          "@type": "@json"
+        }
+      }
+    },
 
     "VerifiableCredential": {
       "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
@@ -97,6 +250,10 @@
         "id": "@id",
         "type": "@type",
 
+        "confidenceMethod": {
+          "@id": "https://www.w3.org/2018/credentials#confidenceMethod",
+          "@type": "@id"
+        },
         "credentialSchema": {
           "@id": "https://www.w3.org/2018/credentials#credentialSchema",
           "@type": "@id"
@@ -114,14 +271,6 @@
           "@id": "https://www.w3.org/2018/credentials#evidence",
           "@type": "@id"
         },
-        "validFrom": {
-          "@id": "https://www.w3.org/2018/credentials#validFrom",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "validUntil": {
-          "@id": "https://www.w3.org/2018/credentials#validUntil",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
         "issuer": {
           "@id": "https://www.w3.org/2018/credentials#issuer",
           "@type": "@id"
@@ -136,17 +285,21 @@
           "@id": "https://www.w3.org/2018/credentials#refreshService",
           "@type": "@id"
         },
+        "relatedResource": {
+          "@id": "https://www.w3.org/2018/credentials#relatedResource",
+          "@type": "@id"
+        },
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
           "@type": "@id"
         },
-        "confidenceMethod": {
-          "@id": "https://www.w3.org/2018/credentials#confidenceMethod",
-          "@type": "@id"
+        "validFrom": {
+          "@id": "https://www.w3.org/2018/credentials#validFrom",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
         },
-        "relatedResource": {
-          "@id": "https://www.w3.org/2018/credentials#relatedResource",
-          "@type": "@id"
+        "validUntil": {
+          "@id": "https://www.w3.org/2018/credentials#validUntil",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
         }
       }
     },
@@ -168,163 +321,15 @@
           "@type": "@id",
           "@container": "@graph"
         },
+        "termsOfUse": {
+          "@id": "https://www.w3.org/2018/credentials#termsOfUse",
+          "@type": "@id"
+        },
         "verifiableCredential": {
           "@id": "https://www.w3.org/2018/credentials#verifiableCredential",
           "@type": "@id",
           "@container": "@graph",
           "@context": null
-        },
-        "termsOfUse": {
-          "@id": "https://www.w3.org/2018/credentials#termsOfUse",
-          "@type": "@id"
-        }
-      }
-    },
-
-    "JsonSchemaCredential": "https://www.w3.org/2018/credentials#JsonSchemaCredential",
-
-    "JsonSchema": {
-      "@id": "https://www.w3.org/2018/credentials#JsonSchema",
-      "@context": {
-        "@protected": true,
-
-        "id": "@id",
-        "type": "@type",
-
-        "jsonSchema": {
-          "@id": "https://www.w3.org/2018/credentials#jsonSchema",
-          "@type": "@json"
-        }
-      }
-    },
-
-    "BitstringStatusListCredential": "https://www.w3.org/ns/credentials/status#BitstringStatusListCredential",
-
-    "BitstringStatusList": {
-      "@id": "https://www.w3.org/ns/credentials/status#BitstringStatusList",
-      "@context": {
-        "@protected": true,
-
-        "id": "@id",
-        "type": "@type",
-
-        "statusPurpose":
-          "https://www.w3.org/ns/credentials/status#statusPurpose",
-        "encodedList": {
-          "@id": "https://www.w3.org/ns/credentials/status#encodedList",
-          "@type": "https://w3id.org/security#multibase"
-        },
-        "ttl": "https://www.w3.org/ns/credentials/status#ttl",
-        "statusReference": {
-          "@id": "https://www.w3.org/ns/credentials/status#statusReference",
-          "@type": "@id"
-        },
-        "statusSize": {
-          "@id": "https://www.w3.org/ns/credentials/status#statusSize",
-          "@type": "https://www.w3.org/2001/XMLSchema#positiveInteger"
-        },
-        "statusMessage": {
-          "@id": "https://www.w3.org/ns/credentials/status#statusMessage",
-          "@context": {
-            "@protected": true,
-
-            "id": "@id",
-            "type": "@type",
-
-            "status": "https://www.w3.org/ns/credentials/status#status",
-            "message": "https://www.w3.org/ns/credentials/status#message"
-          }
-        }
-      }
-    },
-
-    "BitstringStatusListEntry": {
-      "@id":
-        "https://www.w3.org/ns/credentials/status#BitstringStatusListEntry",
-      "@context": {
-        "@protected": true,
-
-        "id": "@id",
-        "type": "@type",
-
-        "statusPurpose":
-          "https://www.w3.org/ns/credentials/status#statusPurpose",
-        "statusListIndex":
-          "https://www.w3.org/ns/credentials/status#statusListIndex",
-        "statusListCredential": {
-          "@id":
-            "https://www.w3.org/ns/credentials/status#statusListCredential",
-          "@type": "@id"
-        }
-      }
-    },
-
-    "DataIntegrityProof": {
-      "@id": "https://w3id.org/security#DataIntegrityProof",
-      "@context": {
-        "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "challenge": "https://w3id.org/security#challenge",
-        "created": {
-          "@id": "http://purl.org/dc/terms/created",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "domain": "https://w3id.org/security#domain",
-        "expires": {
-          "@id": "https://w3id.org/security#expiration",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "nonce": "https://w3id.org/security#nonce",
-        "previousProof": {
-          "@id": "https://w3id.org/security#previousProof",
-          "@type": "@id"
-        },
-        "proofPurpose": {
-          "@id": "https://w3id.org/security#proofPurpose",
-          "@type": "@vocab",
-          "@context": {
-            "@protected": true,
-            "id": "@id",
-            "type": "@type",
-            "assertionMethod": {
-              "@id": "https://w3id.org/security#assertionMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "authentication": {
-              "@id": "https://w3id.org/security#authenticationMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "capabilityInvocation": {
-              "@id": "https://w3id.org/security#capabilityInvocationMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "capabilityDelegation": {
-              "@id": "https://w3id.org/security#capabilityDelegationMethod",
-              "@type": "@id",
-              "@container": "@set"
-            },
-            "keyAgreement": {
-              "@id": "https://w3id.org/security#keyAgreementMethod",
-              "@type": "@id",
-              "@container": "@set"
-            }
-          }
-        },
-        "cryptosuite": {
-          "@id": "https://w3id.org/security#cryptosuite",
-          "@type": "https://w3id.org/security#cryptosuiteString"
-        },
-        "proofValue": {
-          "@id": "https://w3id.org/security#proofValue",
-          "@type": "https://w3id.org/security#multibase"
-        },
-        "verificationMethod": {
-          "@id": "https://w3id.org/security#verificationMethod",
-          "@type": "@id"
         }
       }
     }


### PR DESCRIPTION
The v2 context has been written and updated by hand over time and some of the ordering and formatting was not following a strict pattern.  This attempts to clean it up to be easier to read.  The format here is somewhat arbitrary, and other formats are possible, but this seems easy to work with.  This organization was done by hand.

- Opinionated but consistent organization and sorting.
- Semantically equivalent to data in previous style.
- Order is recursive and roughly follows a pattern:
  - JSON-LD keywords
  - blank line
  - id/type terms
  - blank line
  - jose/jwt property terms
    - sorted
  - blank line
  - other property terms
    - sorted
  - blank line
  - type terms
    - sorted
    - for TypeCredential/Type pairs, put TypeCredential first
    - blank line between each
- Drop down and indent values to try and be under 80 chars per line.

~~(Note this includes commits from https://github.com/w3c/vc-data-model/pull/1510 due to github limitations and will be rebased if/when that is merged.)~~ (Branch was rebased.)