### PR TITLE
Add `renderMethod` to reserved terms in context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -289,6 +289,10 @@
           "@id": "https://www.w3.org/2018/credentials#relatedResource",
           "@type": "@id"
         },
+        "renderMethod": {
+          "@id": "https://www.w3.org/2018/credentials#renderMethod",
+          "@type": "@id"
+        },
         "termsOfUse": {
           "@id": "https://www.w3.org/2018/credentials#termsOfUse",
           "@type": "@id"


### PR DESCRIPTION
This PR is an attempt to address issue #1506 by adding `renderMethod` to the list of reserved terms in the v2 context. Not having done this to date has been an oversight. I also made a pass through all other reserved terms and ensured that they have entries in the v2 context.