### PR TITLE
Change on what exactly must be secured in a presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -4266,10 +4266,9 @@ In a [=verifiable credential=], the property MUST secure the
 [=default graph=].
           </li>
           <li>
-In a [=verifiable presentation=], the property MUST secure the 
-[=default graph=] of the [=presentation=], and each 
-[=verifiable credential=], as well as its related [=proof graph=], in the 
-[=presentation=].
+In a [=verifiable presentation=], the property MUST secure all
+graphs in the [=presentation=] not referred to by the property itself,
+including each [=verifiable credential=] and any of its related [=proof graphs=].
           </li>
           <li>
 The `proof` property as defined in [[VC-DATA-INTEGRITY]] MAY be used by the

--- a/index.html
+++ b/index.html
@@ -4266,9 +4266,10 @@ In a [=verifiable credential=], the property MUST secure the
 [=default graph=].
           </li>
           <li>
-In a [=verifiable presentation=], the property MUST secure the
-[=default graph=] of the [=presentation=] as well as every [=proof graph=]
-related to each [=verifiable credential=] in the [=presentation=].
+In a [=verifiable presentation=], the property MUST secure the 
+[=default graph=] of the [=presentation=], and each 
+[=verifiable credential=], as well as its related [=proof graph=], in the 
+[=presentation=].
           </li>
           <li>
 The `proof` property as defined in [[VC-DATA-INTEGRITY]] MAY be used by the


### PR DESCRIPTION
This is to answer to the issue raised in #1512


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1515.html" title="Last updated on Jul 2, 2024, 9:25 AM UTC (501eb24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1515/5dd94d3...501eb24.html" title="Last updated on Jul 2, 2024, 9:25 AM UTC (501eb24)">Diff</a>