### PR TITLE
Fix link to section containing the securing mechanism interface.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4836,7 +4836,7 @@ Set the |verifyProof| function by using the |inputMediaType| and the
 the [[[?VC-SPECS]]] [[?VC-SPECS]], or other mechanisms known to the
 implementation, to determine the cryptographic suite to use when verifying
 the securing mechanism. The |verifyProof| function MUST implement the interface
-described in <a href="#securing-mechanisms"></a>.
+described in <a href="#securing-mechanism-specifications"></a>.
               </li>
               <li>
 Set |result| to the result of passing |inputBytes| and


### PR DESCRIPTION
The old link target doesn't actually contain an interface for securing mechanisms.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/vc-data-model/pull/1516.html" title="Last updated on Jul 1, 2024, 4:30 PM UTC (a7d89e7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1516/5dd94d3...jyasskin:a7d89e7.html" title="Last updated on Jul 1, 2024, 4:30 PM UTC (a7d89e7)">Diff</a>