### PR TITLE
Remove `@vocab` from the base context.

### DIFF
--- a/contexts/credentials/v2
+++ b/contexts/credentials/v2
@@ -1,7 +1,6 @@
 {
   "@context": {
     "@protected": true,
-    "@vocab": "https://www.w3.org/ns/credentials/issuer-dependent#",
 
     "id": "@id",
     "type": "@type",

--- a/index.html
+++ b/index.html
@@ -3216,10 +3216,15 @@ keyword in the JSON-LD 1.1 specification.
           </p>
 
           <p>
-Developers SHOULD NOT use the <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> feature in production as it can lead to
-JSON term clashes, resulting in semantic ambiguities with other applications. Instead,
-to achieve proper interoperability, developers SHOULD define all terms used by their
-applications, as described earlier in Section [[[#extensibility]]].
+A [=conforming document=] SHOULD NOT use the
+<a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> feature in production
+as it can lead to JSON term clashes, resulting in semantic ambiguities with
+other applications. Instead, to achieve proper interoperability, a [=conforming
+document=] SHOULD use JSON-LD Contexts that define all terms used by their
+applications, as described earlier in Section [[[#extensibility]]]. If a
+[=conforming document=] does not use JSON-LD Contexts that define all terms
+used, it MUST include the `https://www.w3.org/ns/credentials/undefined-terms/v2`
+as the last value in the `@context` property.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -3216,17 +3216,10 @@ keyword in the JSON-LD 1.1 specification.
           </p>
 
           <p>
-The base JSON-LD Context file for this specification also includes an extra
-feature, using the <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a>
-keyword, which ensures that any undefined term in a [=verifiable credential=] or
-a [=verifiable presentation=] is automatically mapped to a URL prefixed with
-`https://www.w3.org/ns/credentials/issuer-dependent#`. This is to allow early
-experimentation with terms during the development phase, without requiring a
-formal definition in every cycle of that experimentation. Note that developers
-SHOULD NOT use this feature in production; this could lead to name clashes,
-yielding semantic ambiguities with other applications. Instead, they SHOULD
-define all the terms, as described earlier in this section, to achieve proper
-interoperability.
+Developers SHOULD NOT use the `@vocab` feature in production as it can lead to
+name clashes, yielding semantic ambiguities with other applications. Instead,
+they SHOULD define all the terms, as described earlier in this section, to
+achieve proper interoperability.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -3216,7 +3216,7 @@ keyword in the JSON-LD 1.1 specification.
           </p>
 
           <p>
-Developers SHOULD NOT use the `@vocab` feature in production as it can lead to
+Developers SHOULD NOT use the <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> feature in production as it can lead to
 name clashes, yielding semantic ambiguities with other applications. Instead,
 they SHOULD define all the terms, as described earlier in this section, to
 achieve proper interoperability.

--- a/index.html
+++ b/index.html
@@ -3217,9 +3217,9 @@ keyword in the JSON-LD 1.1 specification.
 
           <p>
 Developers SHOULD NOT use the <a data-cite="JSON-LD11/#default-vocabulary">`@vocab`</a> feature in production as it can lead to
-name clashes, yielding semantic ambiguities with other applications. Instead,
-they SHOULD define all the terms, as described earlier in this section, to
-achieve proper interoperability.
+JSON term clashes, resulting in semantic ambiguities with other applications. Instead,
+to achieve proper interoperability, developers SHOULD define all terms used by their
+applications, as described earlier in Section [[[#extensibility]]].
           </p>
         </section>
       </section>


### PR DESCRIPTION
This PR is a partial attempt to address issue #1514 by removing `@vocab` from the base context because we no longer have WG support for this specific usage of the feature. 

Other forthcoming PRs will provide new guidance on when and how to use `@vocab` safely.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1520.html" title="Last updated on Jul 17, 2024, 8:47 PM UTC (e6868e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1520/97f7b90...e6868e8.html" title="Last updated on Jul 17, 2024, 8:47 PM UTC (e6868e8)">Diff</a>