### PR TITLE
Clarify input type of verification algorithms.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4122,16 +4122,16 @@ algorithms MAY be general in nature and MAY be used to secure data other than
 
         <p>
 Securing mechanism specifications MUST provide a verification algorithm that
-returns only the information in the [=conforming document=] that has been
-secured, without any securing mechanism information included, such as `proof` or
+returns the information in the [=conforming document=] that has been
+secured in isolation, without any securing mechanism information included, such as `proof` or
 JOSE/COSE header parameters and signatures. Verification algorithms MAY return
 additional information that might be helpful (for example, during validation or
 for debugging purposes), such as securing mechanism details. A verification
 algorithm MUST provide an interface that receives a media type ([=string=]
-|inputMediaType|) and secured data ([=byte sequence=] or [=map=] |securedData|).
-If the verification algorithm expects a [=byte sequence=], provide |securedData|
+|inputMediaType|) and input data ([=byte sequence=] or [=map=] |inputData|).
+If the verification algorithm expects a [=byte sequence=], provide |inputData|
 to the algorithm. If the verification algorithm expects a [=map=], provide the
-result of [=parsing JSON bytes to an Infra value=] given |securedData|. Securing
+result of [=parsing JSON bytes to an Infra value=] given |inputData|. Securing
 mechanism specifications MAY provide additional algorithms and interfaces to the
 ones specified in this document. The verification algorithm returns a
 verification result with at least the following [=struct/items=]:

--- a/index.html
+++ b/index.html
@@ -4129,12 +4129,9 @@ additional information that might be helpful (for example, during validation or
 for debugging purposes), such as details of the securing mechanism. A verification
 algorithm MUST provide an interface that receives a media type ([=string=]
 |inputMediaType|) and input data ([=byte sequence=] or [=map=] |inputData|).
-If the verification algorithm expects a [=byte sequence=], provide |inputData|
-to the algorithm. If the verification algorithm expects a [=map=], provide the
-result of [=parsing JSON bytes to an Infra value=] given |inputData|. Securing
-mechanism specifications MAY provide algorithms and interfaces in addition to the
-ones specified in this document. The verification algorithm returns a
-verification result with at least the following [=struct/items=]:
+Securing mechanism specifications MAY provide algorithms and interfaces in
+addition to the ones specified in this document. The verification algorithm
+returns a verification result with at least the following [=struct/items=]:
         </p>
 
         <dl>
@@ -4736,11 +4733,10 @@ versions of this specification.
         <h3>Verification</h3>
 
         <p>
-This section contains an algorithm that [=conforming verifier
-implementations=] MUST run when verifying a [=verifiable credential=] or a
-[=verifiable presentation=]. This algorithm takes a media
-type ([=string=] |inputMediaType|) and secured data
-([=byte sequence=] or [=map=] |inputData|) and returns a [=map=] that
+This section contains an algorithm that [=conforming verifier implementations=]
+MUST run when verifying a [=verifiable credential=] or a [=verifiable
+presentation=]. This algorithm takes a media type ([=string=] |inputMediaType|)
+and secured data ([=byte sequence=] |inputData|) and returns a [=map=] that
 contains the following:
         </p>
 
@@ -4788,10 +4784,13 @@ the securing mechanism. The |verifyProof| function MUST implement the interface
 described in <a href="#securing-mechanism-specifications"></a>.
               </li>
               <li>
-Set |result| to the result of passing |inputMediaType| and |inputData| to
-the |verifyProof| function. If the call was successful, |result| will contain
-the |status|, |document|, |mediaType|, |controller|, |controllerDocument|,
-|warnings|, and |errors| properties.
+If the |verifyProof| function expects a [=byte sequence=], provide
+|inputMediaType| and |inputData| to the algorithm. If the |verifyProof| function
+expects a [=map=], provide |inputMediaType| and the result of [=parsing JSON
+bytes to an Infra value=] given |inputData|. Set |result| to the result of the
+call to the |verifyProof| function. If the call was successful, |result| will
+contain the |status|, |document|, |mediaType|, |controller|,
+|controllerDocument|, |warnings|, and |errors| properties.
               </li>
               <li>
 If |result|.|status| is set to `false`, add a

--- a/index.html
+++ b/index.html
@@ -4122,17 +4122,17 @@ algorithms MAY be general in nature and MAY be used to secure data other than
 
         <p>
 Securing mechanism specifications MUST provide a verification algorithm that
-returns the information in the [=conforming document=] that has been
-secured in isolation, without any securing mechanism information included, such as `proof` or
+returns the information in the [=conforming document=] that has been secured, in
+isolation, without including any securing mechanism information, such as `proof` or
 JOSE/COSE header parameters and signatures. Verification algorithms MAY return
 additional information that might be helpful (for example, during validation or
-for debugging purposes), such as securing mechanism details. A verification
+for debugging purposes), such as details of the securing mechanism. A verification
 algorithm MUST provide an interface that receives a media type ([=string=]
 |inputMediaType|) and input data ([=byte sequence=] or [=map=] |inputData|).
 If the verification algorithm expects a [=byte sequence=], provide |inputData|
 to the algorithm. If the verification algorithm expects a [=map=], provide the
 result of [=parsing JSON bytes to an Infra value=] given |inputData|. Securing
-mechanism specifications MAY provide additional algorithms and interfaces to the
+mechanism specifications MAY provide algorithms and interfaces in addition to the
 ones specified in this document. The verification algorithm returns a
 verification result with at least the following [=struct/items=]:
         </p>

--- a/index.html
+++ b/index.html
@@ -4121,16 +4121,20 @@ algorithms MAY be general in nature and MAY be used to secure data other than
         </p>
 
         <p>
-Securing mechanism specifications MUST provide a verification mechanism that
+Securing mechanism specifications MUST provide a verification algorithm that
 returns only the information in the [=conforming document=] that has been
 secured, without any securing mechanism information included, such as `proof` or
-JOSE/COSE header parameters and signatures. Specifications MAY provide additional mechanisms to convey
-other information that might be helpful (for example, during validation or for
-debugging purposes), such as securing mechanism data. A securing mechanism's
-verification algorithm MUST provide an interface that receives inputs of a media
-type ([=string=] |inputMediaType|) paired with either a sequence of bytes
-([=byte sequence=] |inputBytes|) or a document ([=map=] |inputDocument|), and
-returns a verification result with at least the following [=struct/items=]:
+JOSE/COSE header parameters and signatures. Verification algorithms MAY return
+additional information that might be helpful (for example, during validation or
+for debugging purposes), such as securing mechanism details. A verification
+algorithm MUST provide an interface that receives a media type ([=string=]
+|inputMediaType|) and secured data ([=byte sequence=] or [=map=] |securedData|).
+If the verification algorithm expects a [=byte sequence=], provide |securedData|
+to the algorithm. If the verification algorithm expects a [=map=], provide the
+result of [=parsing JSON bytes to an Infra value=] given |securedData|. Securing
+mechanism specifications MAY provide additional algorithms and interfaces to the
+ones specified in this document. The verification algorithm returns a
+verification result with at least the following [=struct/items=]:
         </p>
 
         <dl>


### PR DESCRIPTION
This PR is an attempt to address issue #1517 by clarifying the language around input types to verification algorithms.

/cc @jyasskin @PatStLouis @filip @silverpill @flechtner


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1522.html" title="Last updated on Jul 21, 2024, 7:55 PM UTC (c90b313)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1522/ccbe460...c90b313.html" title="Last updated on Jul 21, 2024, 7:55 PM UTC (c90b313)">Diff</a>