### PR TITLE
Add warnings related to `@vocab` usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1172,7 +1172,7 @@ document.
 
         <p>
 This specification is designed to ease the prototyping of new types of
-[=verifiable credentials=]. Developers can copy the template below and paste it
+[=verifiable credential=]. Developers can copy the template below and paste it
 into common [=verifiable credential=] tooling to start issuing, holding, and
 verifying prototype credentials.
         </p>
@@ -1183,7 +1183,7 @@ they would like to create. Since [=verifiable credentials=] talk about subjects,
 each property-value pair in the `credentialSubject` object expresses a
 particular property of the credential subject. Once a developer has added a
 number of these property-value combinations, the modified object can be sent to
-the [=verifiable credential=] issuer software and a [=verifiable credential=]
+the [=verifiable credential=] issuer software, and a [=verifiable credential=]
 will be created for the developer. From a prototyping standpoint, that is all a
 developer needs to do.
         </p>
@@ -1206,9 +1206,9 @@ developer needs to do.
 Once a developer has prototyped their credential to a point where they believe
 all of the credential properties are stable, it is advised that they generate
 vocabulary and context files for their application and publish them at stable
-URLs so that other developers can use the same vocabulary and context to achieve
+URLs, so that other developers can use the same vocabulary and context to achieve
 interoperability. The `https://www.w3.org/ns/credentials/examples/v2` URL above
-will then be replaced with the URL to an application-specific context. This
+would then be replaced with the URL of an application-specific context. This
 process is covered in Section <a href="#extensibility"></a>. Alternatively,
 developers can reuse existing vocabulary and context files that happen to fit
 their use case. They can explore the [[[VC-SPECS]]] [[VC-SPECS]] for reusable
@@ -4406,10 +4406,10 @@ might not perform generalized JSON-LD processing. Authors of [=conforming
 documents=] are advised that interoperability might be reduced if JSON-LD
 keywords in the `@context` value are used to globally affect values in a
 [=verifiable credential=] or [=verifiable presentation=], such as by
-setting the `@base` or `@vocab` keyword. For example, setting these values
-might trigger a failure in a mis-implemented JSON Schema check on the `@context`
+setting either or both of the `@base` or `@vocab` keywords. For example, setting these values
+might trigger a failure in a mis-implemented JSON Schema test of the `@context`
 value in an implementation that is performing [=type-specific credential
-processing=] and not expecting the `@base` value or `@vocab` value to be
+processing=] and not expecting the `@base` and/or `@vocab` value to be
 expressed in the `@context` value.
         </p>
 
@@ -4422,14 +4422,14 @@ urged to not use JSON-LD features that are not easily detected when performing
         <ul>
           <li>
 In-line declaration of JSON-LD keywords in the `@context` value that globally
-modify document term and value processing, such as setting `@base` or `@vocab`,
+modify document term and value processing, such as setting `@base` or `@vocab`
           </li>
           <li>
 Use of JSON-LD contexts that override declarations in previous contexts, such as
-resetting `@vocab`,
+resetting `@vocab`
           </li>
           <li>
-In-line declaration of JSON-LD contexts in the `@context` property, and
+In-line declaration of JSON-LD contexts in the `@context` property
           </li>
           <li>
 Use of full URLs for JSON-LD terms and types (e.g.,
@@ -4437,21 +4437,21 @@ Use of full URLs for JSON-LD terms and types (e.g.,
 `https://vocab.example/myvocab#SomeNewType`) instead of the short forms of
 any such values (e.g., `VerifiableCredential` or `SomeNewType`) that are
 explicitly defined as JSON-LD `@context` mappings (e.g.,
-`https://www.w3.org/ns/credentials/v2`).
+`https://www.w3.org/ns/credentials/v2`)
           </li>
         </ul>
 
         <p>
-While this specification warns against the usage of `@vocab`, there are
-legitimate usages of the feature, such as to ease experimentation, development,
-and localized deployment. If an application developer desires to use `@vocab` in
-production, which is strongly advised against, they are urged to understand that
-any usage of `@vocab` will disable undefined term error reporting, and
-subsequent usage will override previous `@vocab` declarations. Subsequent usage
-of `@vocab` changes the semantics of the information contained in the document
-and so it is important to understand how these changes will affect the
+While this specification cautions against the use of `@vocab`, there are
+legitimate uses of the feature, such as to ease experimentation, development,
+and localized deployment. If an application developer wants to use `@vocab` in
+production — even though strongly advised against — they are urged to understand that
+any use of `@vocab` will disable reporting of "undefined term" errors, and
+later use(s) will override any previous `@vocab` declaration(s). Different values
+of `@vocab` can change the semantics of the information contained in the document,
+so it is important to understand whether and how these changes will affect the
 application being developed. Application developers MUST understand every
-JSON-LD context used by their application to the extent that it affects
+JSON-LD context used by their application, at least to the extent that it affects
 the semantics of the terms that are used by their application.
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1208,7 +1208,7 @@ all of the credential properties are stable, it is advised that they generate
 vocabulary and context files for their application and publish them at stable
 URLs, so that other developers can use the same vocabulary and context to achieve
 interoperability. The `https://www.w3.org/ns/credentials/examples/v2` URL above
-would then be replaced with the URL of an application-specific context. This
+would then be replaced with the URL of a use-case-specific context. This
 process is covered in Section <a href="#extensibility"></a>. Alternatively,
 developers can reuse existing vocabulary and context files that happen to fit
 their use case. They can explore the [[[VC-SPECS]]] [[VC-SPECS]] for reusable
@@ -4452,7 +4452,10 @@ of `@vocab` can change the semantics of the information contained in the documen
 so it is important to understand whether and how these changes will affect the
 application being developed. Application developers MUST understand every
 JSON-LD context used by their application, at least to the extent that it affects
-the semantics of the terms that are used by their application.
+the semantics of the terms that are used by their application. Applications MAY
+use JSON-LD <a data-cite="JSON-LD11-API#compaction-algorithms">compaction
+algorithms</a> to transform a document that uses an unknown JSON-LD context
+to one that does not, so the new document's terms will match expectations.
         </p>
 
         <section>

--- a/index.html
+++ b/index.html
@@ -4400,11 +4400,11 @@ might not perform generalized JSON-LD processing. Authors of [=conforming
 documents=] are advised that interoperability might be reduced if JSON-LD
 keywords in the `@context` value are used to globally affect values in a
 [=verifiable credential=] or [=verifiable presentation=], such as by
-globally setting the `@base` keyword. For example, globally setting these values
+setting the `@base` or `@vocab` keyword. For example, setting these values
 might trigger a failure in a mis-implemented JSON Schema check on the `@context`
 value in an implementation that is performing [=type-specific credential
-processing=] and not expecting the `@base` value to be expressed in the
-`@context` value.
+processing=] and not expecting the `@base` value or `@vocab` value to be
+expressed in the `@context` value.
         </p>
 
         <p>
@@ -4415,20 +4415,23 @@ urged to not use JSON-LD features that are not easily detected when performing
 
         <ul>
           <li>
-Use of JSON-LD keywords in the `@context` value that globally modify document
-value processing, such as global settings of `@base`
+In-line declaration of JSON-LD keywords in the `@context` value that globally
+modify document term and value processing, such as setting `@base` or `@vocab`,
           </li>
           <li>
-In-line declaration of JSON-LD contexts in the `@context` property.
+Use of JSON-LD contexts that override declarations in previous contexts, such as
+resetting `@vocab`,
+          </li>
+          <li>
+In-line declaration of JSON-LD contexts in the `@context` property, and
           </li>
           <li>
 Use of full URLs for JSON-LD terms and types (e.g.,
 `https://www.w3.org/2018/credentials#VerifiableCredential` or
 `https://vocab.example/myvocab#SomeNewType`) instead of the short forms of
 any such values (e.g., `VerifiableCredential` or `SomeNewType`) that are
-either explicitly defined as JSON-LD `@context` mappings (e.g.,
-`https://www.w3.org/ns/credentials/v2`) or are implicitly defined via the
-`@vocab` feature that applies to all undefined terms.
+explicitly defined as JSON-LD `@context` mappings (e.g.,
+`https://www.w3.org/ns/credentials/v2`).
           </li>
        </ul>
 

--- a/index.html
+++ b/index.html
@@ -1172,9 +1172,9 @@ document.
 
         <p>
 This specification is designed to ease the prototyping of new types of
-[=verifiable credentials=]. Developers can copy the
-template below and paste it into common [=verifiable credential=]
-tooling to start issuing, holding, and verifying prototype credentials.
+[=verifiable credentials=]. Developers can copy the template below and paste it
+into common [=verifiable credential=] tooling to start issuing, holding, and
+verifying prototype credentials.
         </p>
 
         <p>
@@ -1183,14 +1183,18 @@ they would like to create. Since [=verifiable credentials=] talk about subjects,
 each property-value pair in the `credentialSubject` object expresses a
 particular property of the credential subject. Once a developer has added a
 number of these property-value combinations, the modified object can be sent to
-the [=verifiable credential=] issuer software and a [=verifiable credential=] will
-be created for the developer. From a prototyping standpoint, that is all a
+the [=verifiable credential=] issuer software and a [=verifiable credential=]
+will be created for the developer. From a prototyping standpoint, that is all a
 developer needs to do.
         </p>
 
-        <pre class="example nohighlight" title="A template for creating prototype verifiable credentials">
+        <pre class="example nohighlight"
+             title="A template for creating prototype verifiable credentials">
 {
-  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://www.w3.org/ns/credentials/examples/v2"
+  ],
   "type": ["VerifiableCredential", "MyPrototypeCredential"],
   "credentialSubject": {
     "mySubjectProperty": "mySubjectValue"
@@ -1201,12 +1205,14 @@ developer needs to do.
         <p>
 Once a developer has prototyped their credential to a point where they believe
 all of the credential properties are stable, it is advised that they generate
-vocabulary and context files for their application and publish them at stable URLs
-so that other developers can use the same vocabulary and context to achieve
-interoperability. This process is covered in Section
-<a href="#extensibility"></a>. Alternatively, developers can reuse existing vocabulary
-and context files that happen to fit their use case. They can explore the
-[[[VC-SPECS]]] [[VC-SPECS]] for reusable resources.
+vocabulary and context files for their application and publish them at stable
+URLs so that other developers can use the same vocabulary and context to achieve
+interoperability. The `https://www.w3.org/ns/credentials/examples/v2` URL above
+will then be replaced with the URL to an application-specific context. This
+process is covered in Section <a href="#extensibility"></a>. Alternatively,
+developers can reuse existing vocabulary and context files that happen to fit
+their use case. They can explore the [[[VC-SPECS]]] [[VC-SPECS]] for reusable
+resources.
         </p>
 
       </section>

--- a/index.html
+++ b/index.html
@@ -4439,7 +4439,21 @@ any such values (e.g., `VerifiableCredential` or `SomeNewType`) that are
 explicitly defined as JSON-LD `@context` mappings (e.g.,
 `https://www.w3.org/ns/credentials/v2`).
           </li>
-       </ul>
+        </ul>
+
+        <p>
+While this specification warns against the usage of `@vocab`, there are
+legitimate usages of the feature, such as to ease experimentation, development,
+and localized deployment. If an application developer desires to use `@vocab` in
+production, which is strongly advised against, they are urged to understand that
+any usage of `@vocab` will disable undefined term error reporting, and
+subsequent usage will override previous `@vocab` declarations. Subsequent usage
+of `@vocab` changes the semantics of the information contained in the document
+and so it is important to understand how these changes will affect the
+application being developed. Application developers MUST understand every
+JSON-LD context used by their application to the extent that it affects
+the semantics of the terms that are used by their application.
+        </p>
 
         <section>
           <h3>Syntactic Sugar</h3>

--- a/index.html
+++ b/index.html
@@ -4445,8 +4445,9 @@ explicitly defined as JSON-LD `@context` mappings (e.g.,
 While this specification cautions against the use of `@vocab`, there are
 legitimate uses of the feature, such as to ease experimentation, development,
 and localized deployment. If an application developer wants to use `@vocab` in
-production — even though strongly advised against — they are urged to understand that
-any use of `@vocab` will disable reporting of "undefined term" errors, and
+production, which is advised against to reduce term collisions and leverage the benefits
+of semantic interoperability, they are urged to understand that any use of `@vocab` will
+disable reporting of "undefined term" errors, and
 later use(s) will override any previous `@vocab` declaration(s). Different values
 of `@vocab` can change the semantics of the information contained in the document,
 so it is important to understand whether and how these changes will affect the


### PR DESCRIPTION
This PR is a partial attempt to address issue #1514 by warning about the usage of `@vocab`, including guidance on when it might be acceptable to use it.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1524.html" title="Last updated on Jul 15, 2024, 2:29 PM UTC (c4d3da3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1524/8e9ae4e...c4d3da3.html" title="Last updated on Jul 15, 2024, 2:29 PM UTC (c4d3da3)">Diff</a>