### PR TITLE
make incorrect plurals singular

### DIFF
--- a/index.html
+++ b/index.html
@@ -1573,7 +1573,7 @@ the same URL.
 
         <p class="note"
            title="See the Implementation Guide for creating new credential types">
-Explaining how to create new types of [=verifiable credential=] is beyond
+Explaining how to create a new type of [=verifiable credential=] is beyond
 the scope of this specification. Readers that are interested in doing so are
 advised to read the section on
 <a data-cite="?VC-IMP-GUIDE#creating-new-credential-types">
@@ -4245,7 +4245,7 @@ can achieve this protection are discussed in Section
         </p>
 
         <p>
-Securing mechanism specifications that create new types of [=embedded proof=]
+A securing mechanism specification that creates a new type of [=embedded proof=]
 MUST specify a [=property=] that relates the [=verifiable credential=] or [=verifiable
 presentation=] to a [=proof graph=]. 
 The requirements on the securing mechanism are as follow:

--- a/index.html
+++ b/index.html
@@ -1573,7 +1573,7 @@ the same URL.
 
         <p class="note"
            title="See the Implementation Guide for creating new credential types">
-Explaining how to create new types of [=verifiable credentials=] is beyond
+Explaining how to create new types of [=verifiable credential=] is beyond
 the scope of this specification. Readers that are interested in doing so are
 advised to read the section on
 <a data-cite="?VC-IMP-GUIDE#creating-new-credential-types">
@@ -4245,7 +4245,7 @@ can achieve this protection are discussed in Section
         </p>
 
         <p>
-Securing mechanism specifications that create new types of [=embedded proofs=]
+Securing mechanism specifications that create new types of [=embedded proof=]
 MUST specify a [=property=] that relates the [=verifiable credential=] or [=verifiable
 presentation=] to a [=proof graph=]. 
 The requirements on the securing mechanism are as follow:


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1528.html" title="Last updated on Jul 9, 2024, 8:36 PM UTC (a7069a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1528/2e71d8e...a7069a9.html" title="Last updated on Jul 9, 2024, 8:36 PM UTC (a7069a9)">Diff</a>