### PR TITLE
Note that integrity protecting JSON-LD Contexts are allowed.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1282,7 +1282,9 @@ context used by their application, at least to the extent that it affects the
 meaning of the terms that are used by their application. One mechanism for
 doing so is described in the Section on
 <a data-cite="VC-DATA-INTEGRITY#validating-contexts">Validating Contexts</a> in
-the [[[VC-DATA-INTEGRITY]]] specification.
+the [[[VC-DATA-INTEGRITY]]] specification. Specification authors MAY require
+that JSON-LD Contexts are integrity protected by using the `relatedResource`
+feature described in Section [[[#integrity-of-related-resources]]].
         </p>
 
         <dl>

--- a/index.html
+++ b/index.html
@@ -1283,7 +1283,7 @@ meaning of the terms that are used by their application. One mechanism for
 doing so is described in the Section on
 <a data-cite="VC-DATA-INTEGRITY#validating-contexts">Validating Contexts</a> in
 the [[[VC-DATA-INTEGRITY]]] specification. Specification authors MAY require
-that JSON-LD Contexts are integrity protected by using the `relatedResource`
+that JSON-LD Contexts be integrity protected by using the `relatedResource`
 feature described in Section [[[#integrity-of-related-resources]]].
         </p>
 

--- a/index.html
+++ b/index.html
@@ -1282,10 +1282,10 @@ context used by their application, at least to the extent that it affects the
 meaning of the terms that are used by their application. One mechanism for
 doing so is described in the Section on
 <a data-cite="VC-DATA-INTEGRITY#validating-contexts">Validating Contexts</a> in
-the [[[VC-DATA-INTEGRITY]]] specification. Other specifications that profile
-this specification MAY require that JSON-LD contexts be integrity protected
+the [[[VC-DATA-INTEGRITY]]] specification. Other specifications that build
+upon this specification MAY require that JSON-LD contexts be integrity protected
 by using the `relatedResource` feature described in Section
-[[[#integrity-of-related-resources]]].
+[[[#integrity-of-related-resources]]] or any effectively equivalent mechanism.
         </p>
 
         <dl>

--- a/index.html
+++ b/index.html
@@ -1282,9 +1282,10 @@ context used by their application, at least to the extent that it affects the
 meaning of the terms that are used by their application. One mechanism for
 doing so is described in the Section on
 <a data-cite="VC-DATA-INTEGRITY#validating-contexts">Validating Contexts</a> in
-the [[[VC-DATA-INTEGRITY]]] specification. Specification authors MAY require
-that JSON-LD Contexts be integrity protected by using the `relatedResource`
-feature described in Section [[[#integrity-of-related-resources]]].
+the [[[VC-DATA-INTEGRITY]]] specification. Other specifications that profile
+this specification MAY require that JSON-LD contexts be integrity protected
+by using the `relatedResource` feature described in Section
+[[[#integrity-of-related-resources]]].
         </p>
 
         <dl>


### PR DESCRIPTION
This PR is a partial fix for an issue raised in https://github.com/w3c/vc-data-integrity/issues/272 by noting that specification authors may require that JSON-LD Contexts are integrity protected by using the `relatedResource` feature.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1537.html" title="Last updated on Aug 5, 2024, 7:50 PM UTC (88dd37b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1537/85de74e...88dd37b.html" title="Last updated on Aug 5, 2024, 7:50 PM UTC (88dd37b)">Diff</a>