### PR TITLE
Add normative MUST to evidence property.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3464,7 +3464,7 @@ information.
         <dl>
           <dt><dfn id="defn-evidence" class="export">evidence</dfn></dt>
           <dd>
-If present, the value associated with the `evidence` [=property=] is a single
+If present, the value of the `evidence` [=property=] MUST be either a single
 object or a set of one or more objects. The following [=properties=] are defined
 for every evidence object:
             <dl>


### PR DESCRIPTION
Makes this definition closer to termsOfUse and other similar properties.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1544.html" title="Last updated on Aug 14, 2024, 6:34 PM UTC (f9ab0d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1544/4c6005d...f9ab0d7.html" title="Last updated on Aug 14, 2024, 6:34 PM UTC (f9ab0d7)">Diff</a>