### PR TITLE
Tweak media type conformance line.

### DIFF
--- a/index.html
+++ b/index.html
@@ -543,10 +543,9 @@ document that complies with all of the relevant "MUST" statements in this
 specification. Specifically, the relevant normative "MUST" statements in
 Sections [[[#basic-concepts]]], [[[#advanced-concepts]]], and
 [[[#syntaxes]]] of this document MUST be enforced.
-A conforming document MUST be either a [=verifiable credential=] with a
-serialization identified by the `application/vc` media type or a
-[=verifiable presentation=] with a serialization identified by
-`application/vp`. A conforming document MUST be
+A conforming document MUST be either a [=verifiable credential=]
+with a media type of `application/vc` or a [=verifiable presentation=]
+with a media type of `application/vp`. A conforming document MUST be
 secured by at least one securing mechanism as described in Section
 [[[#securing-mechanisms]]].
         </p>

--- a/index.html
+++ b/index.html
@@ -543,10 +543,10 @@ document that complies with all of the relevant "MUST" statements in this
 specification. Specifically, the relevant normative "MUST" statements in
 Sections [[[#basic-concepts]]], [[[#advanced-concepts]]], and
 [[[#syntaxes]]] of this document MUST be enforced.
-A conforming document is either a [=verifiable credential=] that MUST be
-serialized using the `application/vc` media type or a
-[=verifiable presentation=] that MUST be serialized using the
-`application/vp` media type. A conforming document MUST be
+A conforming document MUST be either a [=verifiable credential=] with a
+serialization identified by the `application/vc` media type or a
+[=verifiable presentation=] with a serialization identified by
+`application/vp`. A conforming document MUST be
 secured by at least one securing mechanism as described in Section
 [[[#securing-mechanisms]]].
         </p>


### PR DESCRIPTION
A media type does not itself serialize, but rather identifies or
signals a serialization.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1545.html" title="Last updated on Aug 16, 2024, 4:02 PM UTC (95a6087)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1545/4c6005d...95a6087.html" title="Last updated on Aug 16, 2024, 4:02 PM UTC (95a6087)">Diff</a>