### PR TITLE
Turned some rendered method into regular in the vocabulary

### DIFF
--- a/vocab/credentials/v2/vocabulary.drawio
+++ b/vocab/credentials/v2/vocabulary.drawio
@@ -85,12 +85,12 @@
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;evidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#evidence" id="lZdwYr-LXM3OhQDUA7XR-5">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-876" y="-542" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;refreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#refreshService" id="lZdwYr-LXM3OhQDUA7XR-6">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;" parent="1" vertex="1">
             <mxGeometry x="-876" y="-485" width="171" height="27.21049922799794" as="geometry" />
           </mxCell>
         </UserObject>
@@ -254,12 +254,12 @@
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;CredentialEvidence&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#CredentialEvidence" id="lZdwYr-LXM3OhQDUA7XR-29">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-586" y="-548.0023160061761" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>
         <UserObject label="&lt;i&gt;&lt;font color=&quot;#000000&quot;&gt;RefreshService&lt;/font&gt;&lt;/i&gt;" link="https://www.w3.org/2018/credentials#RefreshService" id="lZdwYr-LXM3OhQDUA7XR-30">
-          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;dashed=1;dashPattern=1 2;" parent="1" vertex="1">
+          <mxCell style="ellipse;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;strokeWidth=2;strokeColor=#336600;" parent="1" vertex="1">
             <mxGeometry x="-586" y="-491.002316006176" width="218" height="39.215131240349976" as="geometry" />
           </mxCell>
         </UserObject>

--- a/vocab/credentials/v2/vocabulary.svg
+++ b/vocab/credentials/v2/vocabulary.svg
@@ -189,7 +189,7 @@
                 </switch>
             </a>
             <a xlink:href="https://www.w3.org/2018/credentials#evidence" data-cell-id="lZdwYr-LXM3OhQDUA7XR-5">
-                <rect width="171" height="27.21" x="742" y="368" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+                <rect width="171" height="27.21" x="742" y="368" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
                 <switch transform="translate(-.5 -.5)">
                     <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:382px;margin-left:743px">
@@ -208,7 +208,7 @@
                 </switch>
             </a>
             <a xlink:href="https://www.w3.org/2018/credentials#refreshService" data-cell-id="lZdwYr-LXM3OhQDUA7XR-6">
-                <rect width="171" height="27.21" x="742" y="425" fill="none" stroke="#000" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
+                <rect width="171" height="27.21" x="742" y="425" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="4.08" ry="4.08"/>
                 <switch transform="translate(-.5 -.5)">
                     <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:169px;height:1px;padding-top:439px;margin-left:743px">
@@ -417,7 +417,7 @@
                 </switch>
             </a>
             <a xlink:href="https://www.w3.org/2018/credentials#CredentialEvidence" data-cell-id="lZdwYr-LXM3OhQDUA7XR-29">
-                <ellipse cx="1141" cy="381.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+                <ellipse cx="1141" cy="381.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
                 <switch transform="translate(-.5 -.5)">
                     <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:382px;margin-left:1033px">
@@ -436,7 +436,7 @@
                 </switch>
             </a>
             <a xlink:href="https://www.w3.org/2018/credentials#RefreshService" data-cell-id="lZdwYr-LXM3OhQDUA7XR-30">
-                <ellipse cx="1141" cy="438.61" fill="none" stroke="#360" stroke-dasharray="2 4" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
+                <ellipse cx="1141" cy="438.61" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="109" ry="19.608"/>
                 <switch transform="translate(-.5 -.5)">
                     <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
                         <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:216px;height:1px;padding-top:439px;margin-left:1033px">

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -19,7 +19,6 @@ ontology:
 class:
   - id: CredentialEvidence
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-credential-evidence
-    status: reserved
     context: none
 
   - id: CredentialSchema
@@ -55,7 +54,6 @@ class:
   - id: RefreshService
     label: Refresh service
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#bc-refresh-service
-    status: reserved
     context: none
 
   - id: RenderMethod
@@ -120,7 +118,6 @@ property:
     label: Evidence
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-evidence
     domain: cred:VerifiableCredential
-    status: reserved
     range: cred:CredentialEvidence
 
   - id: expirationDate
@@ -159,7 +156,6 @@ property:
     label: Refresh service
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#defn-refreshService
     domain: cred:VerifiableCredential
-    status: reserved
     range: cred:RefreshService
 
   - id: renderMethod


### PR DESCRIPTION
The spec and the vocabulary were not in sync.

For the records, at the moment, only the following properties are set as reserved: the properties `confidenceMethod` and `renderMethod`, as well as their range classes `ConfidenceMethod` and `RenderMethod`.