### PR TITLE
Change usage to use throughout spec text

### DIFF
--- a/index.html
+++ b/index.html
@@ -4005,7 +4005,7 @@ for additional guidance.
         <p class="note" title="What constitutes a verifiable credential?">
 Readers are advised that a digital credential is only considered compatible with
 the W3C Verifiable Credentials ecosystem if it is a [=conforming document=]
-and it utilizes at least one securing mechanism, as described by their
+and it uses at least one securing mechanism, as described by their
 respective requirements in this specification. While some communities might call
 some digital credential formats that are not [=conforming documents=]
 "verifiable credentials", doing so does NOT make that digital credential
@@ -4546,7 +4546,7 @@ with any other JSON-formatted data.
           </p>
 
           <p>
-<dfn>General JSON-LD processing</dfn> is defined as a mechanism that utilizes a
+<dfn>General JSON-LD processing</dfn> is defined as a mechanism that uses a
 JSON-LD software library to process a [=conforming document=] by performing
 various <a data-cite="?JSON-LD11#forms-of-json-ld">transformations</a>.
 <dfn>Type-specific credential processing</dfn> is defined as a lighter-weight
@@ -4629,7 +4629,7 @@ exchange happens is explicitly stated for both processing mechanisms by using
       <p>
 This section contains algorithms that can be used by implementations to perform
 common operations, such as [=verification=]. Conformance requirements phrased as
-algorithms utilize normative concepts from the [[[INFRA]]] [[INFRA]]. See the
+algorithms use normative concepts from the [[[INFRA]]] [[INFRA]]. See the
 section on <a data-cite="INFRA#algorithm-conformance">Algorithm Conformance</a>
 in the [[[INFRA]]] for more guidance on implementation requirements.
       </p>
@@ -5957,7 +5957,7 @@ that could result in a security issue if the external content changes.
         <p>
 Implementers are urged to understand how links to external machine-readable
 content that are not content-integrity protected could result in successful
-attacks against their applications, and utilize the content integrity protection
+attacks against their applications, and use the content integrity protection
 mechanism provided by this specification if a security issue could occur
 if the external resource is changed.
         </p>
@@ -6797,7 +6797,7 @@ Unix command interface line:
         </p>
         <p>
 It is strongly advised that all JSON-LD Context URLs used by an
-application utilize the same mechanism, or a functionally equivalent mechanism,
+application use the same mechanism, or a functionally equivalent mechanism,
 to ensure end-to-end security. Implementations are expected to throw errors
 if a cryptographic hash value for a resource does not match the expected hash
 value.

--- a/index.html
+++ b/index.html
@@ -5526,7 +5526,7 @@ express this in the [=verifiable presentations=] they transmit.
       </section>
 
       <section class="informative">
-        <h3>Usage Patterns</h3>
+        <h3>Patterns of Use</h3>
 
         <p>
 Despite the best efforts to assure privacy, actually using
@@ -5746,7 +5746,7 @@ that compliance regimes are operating as expected.
         <h3>Frequency of Claim Issuance</h3>
 
         <p>
-As detailed in Section [[[#usage-patterns]]], usage patterns can be
+As detailed in Section [[[#patterns-of-use]]], patterns of use can be
 correlated into certain types of behavior. Part of this correlation is
 mitigated when a [=holder=] uses a [=verifiable credential=] without the
 knowledge of the [=issuer=]. [=Issuers=] can defeat this protection
@@ -5766,7 +5766,7 @@ of the [=holder=] in a way that negatively impacts the [=holder=].
 Organizations providing software to [=holders=] should warn them if they
 repeatedly use [=credentials=] with short lifespans, which could result in
 behavior correlation. [=Issuers=] should avoid issuing [=credentials=] in
-a way that enables them to correlate usage patterns.
+a way that enables them to correlate patterns of use.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@ correlatable identifiers for [=subjects=]. Some registries, such as ones for
 UUIDs and [=verification material=], might just act as namespaces for
 identifiers. Examples of verifiable data registries include trusted databases,
 decentralized databases, government ID databases, and distributed ledgers. Often,
-more than one type of verifiable data registry utilized in an ecosystem.
+more than one type of verifiable data registry used in an ecosystem.
           </dd>
         </dl>
 
@@ -2322,7 +2322,7 @@ in Section [[[#securing-mechanism-specifications]]].
         </p>
 
         <pre class="example nohighlight"
-          title="A verifiable credential utilizing an embedded proof">
+          title="A verifiable credential using an embedded proof">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -3326,7 +3326,7 @@ thereby bypassing the [=holder=].
         <h3>Terms of Use</h3>
 
         <p>
-Terms of use can be utilized by an [=issuer=] or a [=holder=] to
+Terms of use can be used by an [=issuer=] or a [=holder=] to
 communicate the terms under which a [=verifiable credential=] or
 [=verifiable presentation=] was issued. The [=issuer=] places their terms
 of use inside the [=verifiable credential=]. The [=holder=] places their
@@ -3545,7 +3545,7 @@ video of the [=subject=] of the [=credential=] demonstrating the achievement.
         <p class="note"
            title="Evidence has a different purpose from securing mechanisms">
 The `evidence` [=property=] provides information that is different from and
-information to the securing mechanism utilized. The `evidence` [=property=] is
+information to the securing mechanism used. The `evidence` [=property=] is
 used to express supporting information, such as documentary evidence, related to
 the [=verifiable credential=]. In contrast, the securing mechanism is used to
 express machine-verifiable mathematical proofs related to the authenticity of
@@ -3801,7 +3801,7 @@ values that are affected by Daylight Saving/Summer Time.
         <p>
 This specification attempts to increase the number of universally recognized
 combinations of dates and times, and reduce the potential for
-misinterpretation of time values, by utilizing the
+misinterpretation of time values, by using the
 `dateTimeStamp` construction first established by the [<a
 data-cite="XMLSCHEMA11-2#dateTimeStamp">XMLSCHEMA11-2</a>] specification. In
 order to reduce misinterpretations between different time zones, all time values
@@ -3994,7 +3994,7 @@ algorithm to the data model in this specification results in
 a [=conforming document=].
           </li>
           <li>
-SHOULD ensure that all semantics utilized in the transformed
+SHOULD ensure that all semantics used in the transformed
 [=conforming document=] follow best practices for Linked Data. See
 Section [[[#getting-started]]], Section
 [[[#extensibility]]], and Linked Data Best Practices [[?LD-BP]]
@@ -4121,7 +4121,7 @@ The requirements on the securing mechanism are as follow:
           <li>
 The securing mechanism MUST define all terms used by the [=proof graph=]. For example,
 the mechanism could define vocabulary specifications and `@context` files
-in the same manner as they are utilized by this specification.
+in the same manner as they are used by this specification.
           </li>
           <li>
 The securing mechanism MUST secure all graphs in the [=verifiable credential=] or the [=verifiable
@@ -4277,7 +4277,7 @@ all terms understood by users of the data model whether or not they use a
 In order to increase interoperability, this specification restricts the use of
 JSON-LD representations of the data model. JSON-LD <a
 href="https://www.w3.org/TR/json-ld/#compacted-document-form">compacted document
-form</a> MUST be utilized for all representations of the data model using the
+form</a> MUST be used for all representations of the data model using the
 `application/vc` or `application/vp` media type.
           </p>
 
@@ -5948,7 +5948,7 @@ against tampering because the data resides outside of the protection of the
         <p>
 This specification provides an optional mechanism, contained in Section
 [[[#integrity-of-related-resources]]], that is capable of ensuring content
-integrity for external resources. While this mechanism need not be utilized
+integrity for external resources. While this mechanism need not be used
 for external resources that do not affect the security of the
 [=verifiable credential=], it is strongly suggested for external resources
 that could result in a security issue if the external content changes.
@@ -6216,7 +6216,7 @@ It requires some version of an HTML processor, which increases the burden of
 processing language and base direction information.
           </li>
           <li>
-It increases the security attack surface when utilizing this data model, because
+It increases the security attack surface when using this data model, because
 naively processing HTML could result in the execution of a `script` tag that
 an attacker injected at some point during the data production process.
           </li>
@@ -6244,13 +6244,13 @@ implementation of any web standard or protocol, ignoring accessibility issues
 makes this information unusable by a large subset of the population. It is
 important to follow accessibility guidelines and standards, such as [[WCAG21]],
 to ensure that all people, regardless of ability, can make use of this data.
-This is especially important when establishing systems utilizing cryptography,
+This is especially important when establishing systems using cryptography,
 which have historically created problems for assistive technologies.
       </p>
 
       <p>
 This section details the general accessibility considerations to take into
-account when utilizing this data model.
+account when using this data model.
       </p>
 
       <section class="informative">
@@ -6264,7 +6264,7 @@ for people with vision impairments.
         </p>
 
         <p>
-When utilizing this data model to create [=verifiable credentials=], it is
+When using this data model to create [=verifiable credentials=], it is
 suggested that data model designers use a <em>data first</em> approach. For
 example, given the choice of using data or a graphical image to depict a
 [=credential=], designers should express every element of the image, such as
@@ -6302,7 +6302,7 @@ Implementation Guidelines [[VC-IMP-GUIDE]] document.
 
       <p>
 This section outlines general internationalization considerations to take into
-account when utilizing this data model and is intended to highlight specific
+account when using this data model and is intended to highlight specific
 parts of the <em>Strings on the Web: Language and Direction Metadata</em>
 document [[STRING-META]] that implementers might be interested in reading.
       </p>
@@ -6458,7 +6458,7 @@ direction associated with them SHOULD be treated as if the direction value is
 While this specification does not provide conformance criteria for the process
 of the [=validation=] of [=verifiable credentials=] or
 [=verifiable presentations=], readers might be curious about how the
-information in this data model is expected to be utilized by [=verifiers=]
+information in this data model is expected to be used by [=verifiers=]
 during the process of [=validation=]. This section captures a selection of
 conversations held by the Working Group related to the expected use of the
 properties in this specification by [=verifiers=].

--- a/index.html
+++ b/index.html
@@ -1685,7 +1685,7 @@ without having to look through the entirety of the [=claims=].
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Use of the name and description property"
+          title="Use of the name and description properties"
           data-vc-vm="https://university.example/issuers/565049#key-1">
 {
   "@context": [
@@ -1733,7 +1733,7 @@ in the [[[JSON-LD11]]] specification.
         </p>
 
         <pre class="example nohighlight"
-          title="Use of the name and description property">
+          title="Use of the name and description properties">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -1836,7 +1836,7 @@ in a controller document, as defined in [[CONTROLLER-DOCUMENT]], about the
           </dd>
         </dl>
 
-        <pre class="example nohighlight vc" title="Use of issuer property"
+        <pre class="example nohighlight vc" title="Use of the issuer property"
           data-vc-vm="https://university.example/issuers/14#key-1">
 {
   "@context": [
@@ -1863,7 +1863,7 @@ associating an object with the issuer property:
         </p>
 
         <pre class="example nohighlight vc"
-          title="Use of issuer expanded property"
+          title="Expanded use of the issuer property"
           data-vc-vm="did:example:76e12ec712ebc6f1c221ebfeb1f#key-1">
 {
   "@context": [
@@ -2021,7 +2021,7 @@ point in time expressed by the `validFrom` value.
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Use of validFrom and validUntil property"
+          title="Use of the validFrom and validUntil properties"
           data-vc-vm="https://university.example/issuers/14#key-1">
 {
   "@context": [
@@ -2254,7 +2254,7 @@ integrity protection mechanism. The `credentialSchema`
         </p>
 
         <pre class="example nohighlight"
-          title="Use of the credentialSchema property to perform JSON schema validation">
+          title="Using the credentialSchema property to perform JSON schema validation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -3213,7 +3213,7 @@ An example of a related resource integrity object referencing JSON-LD contexts.
         </p>
 
         <pre class="example nohighlight"
-          title="Use of the relatedResource and digestSRI property">
+          title="Use of the relatedResource and digestSRI properties">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestSRI":
@@ -3226,7 +3226,7 @@ An example of a related resource integrity object referencing JSON-LD contexts.
         </pre>
 
         <pre class="example nohighlight"
-          title="Use of the relatedResource and digestMultibase property">
+          title="Use of the relatedResource and digestMultibase properties">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestMultibase": "uEres1usWcWCmW7uolIW2uA0CjQ8iRV14eGaZStJL73Vz"
@@ -5608,11 +5608,11 @@ or even compatible with necessary use. Sometimes correlation is a
 requirement.
         </p>
         <p>
-For example, in some prescription drug monitoring programs, monitoring of use is
-a requirement. Enforcement entities need to be able to confirm that individuals
+For example, in some prescription drug monitoring programs, monitoring prescription
+use is a requirement. Enforcement entities need to be able to confirm that individuals
 are not cheating the system to get multiple prescriptions for controlled
-substances. This statutory or regulatory need to correlate use overrides
-individual privacy concerns.
+substances. This statutory or regulatory need to correlate prescription
+use overrides individual privacy concerns.
         </p>
 
         <p>
@@ -7572,7 +7572,7 @@ Add this revision history section.
         <li>
 Update previous normative references that pointed to RFC3339 for date-time
 details to now normatively reference the date-time details described in
-XMLSCHEMA11-2 which more accurately reflects the use in examples and
+XMLSCHEMA11-2 which more accurately reflect date-time use in examples and
 libraries.
         </li>
 

--- a/index.html
+++ b/index.html
@@ -5624,8 +5624,8 @@ long as each of those services uses the correlation in the expected manner.
         </p>
 
         <p>
-Privacy violations of [=verifiable credential=] use occur when unintended or
-unexpected correlation arises from the presentation of those
+Privacy violations related to the use of [=verifiable credentials=] occur when
+unintended or unexpected correlation arises from the presentation of those
 [=verifiable credentials=].
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -1303,7 +1303,7 @@ Subsequent items in the [=ordered set=] MUST be composed of any combination of
           </dd>
         </dl>
 
-        <pre class="example nohighlight" title="Usage of the @context property">
+        <pre class="example nohighlight" title="Use of the @context property">
 {
   <span class="highlight">"@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -1393,7 +1393,7 @@ in a document containing machine-readable information about the `id`.
           </dd>
         </dl>
 
-        <pre class="example nohighlight vc" title="Usage of the id property"
+        <pre class="example nohighlight vc" title="Use of the id property"
           data-vc-vm="https://university.example/issuers/565049#key-1">
 {
   "@context": [
@@ -1464,7 +1464,7 @@ one value is provided, the order does not matter.
           </dd>
         </dl>
 
-        <pre class="example nohighlight vc" title="Usage of the type property"
+        <pre class="example nohighlight vc" title="Use of the type property"
           data-vc-vm="https://university.example/issuers/565049#key-1">
 {
   "@context": [
@@ -1685,7 +1685,7 @@ without having to look through the entirety of the [=claims=].
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Usage of the name and description property"
+          title="Use of the name and description property"
           data-vc-vm="https://university.example/issuers/565049#key-1">
 {
   "@context": [
@@ -1733,7 +1733,7 @@ in the [[[JSON-LD11]]] specification.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the name and description property">
+          title="Use of the name and description property">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -1836,7 +1836,7 @@ in a controller document, as defined in [[CONTROLLER-DOCUMENT]], about the
           </dd>
         </dl>
 
-        <pre class="example nohighlight vc" title="Usage of issuer property"
+        <pre class="example nohighlight vc" title="Use of issuer property"
           data-vc-vm="https://university.example/issuers/14#key-1">
 {
   "@context": [
@@ -1863,7 +1863,7 @@ associating an object with the issuer property:
         </p>
 
         <pre class="example nohighlight vc"
-          title="Usage of issuer expanded property"
+          title="Use of issuer expanded property"
           data-vc-vm="did:example:76e12ec712ebc6f1c221ebfeb1f#key-1">
 {
   "@context": [
@@ -1922,7 +1922,7 @@ Section [[[#identifiers]]].
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Usage of the credentialSubject property"
+          title="Use of the credentialSubject property"
           data-vc-vm="https://university.example/issuers/565049#key-1">
 {
   "@context": [
@@ -2021,7 +2021,7 @@ point in time expressed by the `validFrom` value.
         </dl>
 
         <pre class="example nohighlight vc"
-          title="Usage of validFrom and validUntil property"
+          title="Use of validFrom and validUntil property"
           data-vc-vm="https://university.example/issuers/14#key-1">
 {
   "@context": [
@@ -2095,7 +2095,7 @@ external document that notes whether the [=credential=] is suspended or revoked.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the status property">
+          title="Use of the status property">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2128,7 +2128,7 @@ with it, such as whether it has been revoked or suspended.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of multiple entries for the status property">
+          title="Use of multiple entries for the status property">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -2254,7 +2254,7 @@ integrity protection mechanism. The `credentialSchema`
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the credentialSchema property to perform JSON schema validation">
+          title="Use of the credentialSchema property to perform JSON schema validation">
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -3213,7 +3213,7 @@ An example of a related resource integrity object referencing JSON-LD contexts.
         </p>
 
         <pre class="example nohighlight"
-          title="Usage of the relatedResource and digestSRI property">
+          title="Use of the relatedResource and digestSRI property">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestSRI":
@@ -3226,7 +3226,7 @@ An example of a related resource integrity object referencing JSON-LD contexts.
         </pre>
 
         <pre class="example nohighlight"
-          title="Usage of the relatedResource and digestMultibase property">
+          title="Use of the relatedResource and digestMultibase property">
 "relatedResource": [{
   "id": "https://www.w3.org/ns/credentials/v2",
   "digestMultibase": "uEres1usWcWCmW7uolIW2uA0CjQ8iRV14eGaZStJL73Vz"
@@ -3281,7 +3281,7 @@ definition.
         </dl>
 
         <pre class="example nohighlight"
-          title="Usage of the refreshService property by an issuer">
+          title="Use of the refreshService property by an issuer">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -3375,7 +3375,7 @@ by the specific `termsOfUse` [=type=] definition.
         </dl>
 
         <pre class="example nohighlight"
-          title="Usage of the termsOfUse property by an issuer">
+          title="Use of the termsOfUse property by an issuer">
 {
   {
     "@context": [
@@ -3433,9 +3433,9 @@ framework, with a specific link to the policy.
         <p>
 This feature is expected to be used by government-issued [=verifiable
 credentials=] to instruct digital wallets to limit their use to similar
-government organizations in an attempt to protect citizens from unexpected usage
+government organizations in an attempt to protect citizens from unexpected use
 of sensitive data. Similarly, some [=verifiable credentials=] issued by private
-industry are expected to limit usage to within departments inside the
+industry are expected to limit use to within departments inside the
 organization, or during business hours. Implementers are urged to read more
 about this evolving feature in the appropriate section of the Verifiable
 Credentials Implementation Guidelines [[?VC-IMP-GUIDE]] document.
@@ -4274,7 +4274,7 @@ all terms understood by users of the data model whether or not they use a
           <h3>Restrictions on JSON-LD</h3>
 
           <p>
-In order to increase interoperability, this specification restricts the usage of
+In order to increase interoperability, this specification restricts the use of
 JSON-LD representations of the data model. JSON-LD <a
 href="https://www.w3.org/TR/json-ld/#compacted-document-form">compacted document
 form</a> MUST be utilized for all representations of the data model using the
@@ -4955,7 +4955,7 @@ to not be in the best interest of the [=holder=] committing the violation,
 but would be in the best interest of the [=verifier=] as well as any
 [=holders=] <em>not</em> committing such a violation. It is strongly advised
 that when software operates in this manner, that it is made clear in whose best
-interest the software is operating through mechanisms such as a website usage
+interest the software is operating through mechanisms such as a website use
 policy.
         </p>
       </section>
@@ -5032,7 +5032,7 @@ and organization-issued identifiers.
 
         <p>
 Similarly, disclosing the [=credential=] identifier (such as in
-[[[#example-usage-of-the-id-property]]]) leads to situations where multiple
+[[[#example-use-of-the-id-property]]]) leads to situations where multiple
 [=verifiers=], or an [=issuer=] and a [=verifier=], can collude to correlate the
 [=holder=].
         </p>
@@ -5260,7 +5260,7 @@ property to be selectively disclosed by the [=holder=]. It could also issue more
 abstract [=verifiable credentials=] (for example, a [=verifiable credential=]
 containing only an `ageOver` property). One possible adaptation would be for
 [=issuers=] to provide secure HTTP endpoints for retrieving single-use [=bearer
-credentials=] that promote the pseudonymous usage of [=verifiable credentials=].
+credentials=] that promote the pseudonymous use of [=verifiable credentials=].
 Implementers that find this impractical or unsafe, might consider using
 [=selective disclosure=] schemes that eliminate dependence on [=issuers=] at
 proving time and reduce temporal correlation risk from [=issuers=].
@@ -5325,7 +5325,7 @@ possible by not specifying the [=subject=] identifier, expressed using the
         </p>
 
         <pre class="example nohighlight vc"
-          title="Usage of issuer properties"
+          title="Use of issuer properties"
           data-vc-vm="https://university.example/issuers/14#keys-1">
 {
   "@context": [
@@ -5568,7 +5568,7 @@ established profile. For more information, see [[DEMOGRAPHICS]].
           </li>
           <li>
 Passing the identifier of a [=credential=] to a centralized revocation
-server. The centralized server can correlate the [=credential=] usage across
+server. The centralized server can correlate the [=credential=] use across
 interactions. For example, if a [=credential=] is used for proof of age in
 this manner, the centralized service could know everywhere that
 [=credential=] was presented (all liquor stores, bars, adult stores, lottery
@@ -5604,14 +5604,14 @@ any specific long-lived [=subject=] identifier.
 
         <p>
 It is understood that these mitigation techniques are not always practical
-or even compatible with necessary usage. Sometimes correlation is a
+or even compatible with necessary use. Sometimes correlation is a
 requirement.
         </p>
         <p>
-For example, in some prescription drug monitoring programs, usage monitoring is
+For example, in some prescription drug monitoring programs, monitoring of use is
 a requirement. Enforcement entities need to be able to confirm that individuals
 are not cheating the system to get multiple prescriptions for controlled
-substances. This statutory or regulatory need to correlate usage overrides
+substances. This statutory or regulatory need to correlate use overrides
 individual privacy concerns.
         </p>
 
@@ -5624,7 +5624,7 @@ long as each of those services uses the correlation in the expected manner.
         </p>
 
         <p>
-Privacy violations of [=verifiable credential=] usage occur when unintended or
+Privacy violations of [=verifiable credential=] use occur when unintended or
 unexpected correlation arises from the presentation of those
 [=verifiable credentials=].
         </p>
@@ -6460,7 +6460,7 @@ of the [=validation=] of [=verifiable credentials=] or
 [=verifiable presentations=], readers might be curious about how the
 information in this data model is expected to be utilized by [=verifiers=]
 during the process of [=validation=]. This section captures a selection of
-conversations held by the Working Group related to the expected usage of the
+conversations held by the Working Group related to the expected use of the
 properties in this specification by [=verifiers=].
       </p>
 
@@ -7071,7 +7071,7 @@ include additional type values in the array. Many verifiers will request a
 value could make it more difficult for verifiers to inform the holder which
 [=verifiable credential=] they require. When a [=verifiable credential=]
 has multiple subtypes, listing all of them in the `type`
-property is sensible. The usage of the `type` property in a
+property is sensible. The use of the `type` property in a
 [[JSON-LD11]] representation of a [=verifiable credential=] enables to enforce
 the semantics of the [=verifiable credential=] because the machine is able to
 check the semantics. With [[JSON-LD11]], the technology is not only describing the
@@ -7474,7 +7474,7 @@ Add section on media type precision and interpretation.
         </li>
         <li>
 Ensure that `dateTimeStamp` is used for time values. Provide further guidance
-on proper usage of time values and timezones.
+on proper use of time values and timezones.
         </li>
         <li>
 Make `validFrom` optional.
@@ -7572,7 +7572,7 @@ Add this revision history section.
         <li>
 Update previous normative references that pointed to RFC3339 for date-time
 details to now normatively reference the date-time details described in
-XMLSCHEMA11-2 which more accurately reflects the usage in examples and
+XMLSCHEMA11-2 which more accurately reflects the use in examples and
 libraries.
         </li>
 


### PR DESCRIPTION
This P.R. addresses issue #1555 

Just checking, I should only be changing the base index.html right? 

Also, as I was going through this I noticed the spec still has 32 uses of the word usage. I believe in the examples.

For example: "Usage of the credentialSubject property"

Should we also be changing these to Use?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/wip-abramson/vc-data-model/pull/1561.html" title="Last updated on Oct 3, 2024, 4:04 PM UTC (d656c37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1561/062e4b3...wip-abramson:d656c37.html" title="Last updated on Oct 3, 2024, 4:04 PM UTC (d656c37)">Diff</a>