### PR TITLE
Remove ProblemDetail integer error codes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4752,12 +4752,6 @@ properties:
 The `type` [=property=] MUST be present and its value MUST be a [=URL=]
 identifying the type of problem.
           </dd>
-          <dt>code</dt>
-          <dd>
-The `code` [=property=] is OPTIONAL. If present, its value MUST be an integer
-that identifies the type of the problem. Integer codes are useful in systems
-that only provide integer return values.
-          </dd>
           <dt>title</dt>
           <dd>
 The `title` [=property=] MUST be present and its value SHOULD provide a short
@@ -4771,21 +4765,18 @@ longer human-readable string for the problem.
         </dl>
 
         <p>
-The following problem description types and codes are defined by this
-specification:
+The following problem description types are defined by this specification:
         </p>
 
         <dl>
           <dt id="PARSING_ERROR">
 https://www.w3.org/TR/vc-data-model#PARSING_ERROR
-(-64)
           </dt>
           <dd>
 There was an error while parsing input.
           </dd>
           <dt id="CRYPTOGRAPHIC_SECURITY_ERROR">
 https://www.w3.org/TR/vc-data-model#CRYPTOGRAPHIC_SECURITY_ERROR
-(-65)
           </dt>
           <dd>
 The securing mechanism for the document has detected a
@@ -4795,7 +4786,6 @@ potential tampering detected. See Section
           </dd>
           <dt id="MALFORMED_VALUE_ERROR">
 https://www.w3.org/TR/vc-data-model#MALFORMED_VALUE_ERROR
-(-66)
           </dt>
           <dd>
 The value associated with a particular [=property=] is malformed. The
@@ -4805,7 +4795,6 @@ in the [=ProblemDetails=] object. See Section
           </dd>
           <dt id="RANGE_ERROR">
 https://www.w3.org/TR/vc-data-model#RANGE_ERROR
-(-67)
           </dt>
           <dd>
 A provided value is outside of the expected range of an associated value,
@@ -4816,7 +4805,7 @@ of the array.
 
         <p>
 Implementations MAY extend the [=ProblemDetails=] object by specifying
-additional types, codes, or properties. See the
+additional types or properties. See the
 <a data-cite="RFC9457#name-extension-members">Extension Member</a> section
 in [[RFC9457]] for further guidance on using this mechanism.
         </p>


### PR DESCRIPTION
This PR is an attempt to address issue #1559 by removing integer error codes in the ProblemDetails objects.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1562.html" title="Last updated on Sep 15, 2024, 11:02 PM UTC (a794cc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1562/ae63dda...a794cc5.html" title="Last updated on Sep 15, 2024, 11:02 PM UTC (a794cc5)">Diff</a>