### PR TITLE
Require digest verification for related resources.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3192,10 +3192,11 @@ SHOULD NOT be included as an object in the `relatedResource` array.
 
         <p>
 A [=conforming verifier implementation=] that makes use of a resource based on
-the `id` of an object inside a [=conforming document=] with a corresponding
-cryptographic digest MUST check the digest against the retrieved resource. If
-the digest of the retrieved resource does not match the one provided by the
-[=issuer=], the [=conforming verifier implementation=] MUST produce an error.
+the `id` of a `relatedResource` object inside a [=conforming document=] with a
+corresponding cryptographic digest appearing in a `relatedResource` object value
+MUST compute the digest of the retrieved resource. If the digest provided by the
+[=issuer=] does not match the digest computed for the retrieved resource, the
+[=conforming verifier implementation=] MUST produce an error.
         </p>
 
         <p>

--- a/index.html
+++ b/index.html
@@ -3191,12 +3191,13 @@ SHOULD NOT be included as an object in the `relatedResource` array.
         </p>
 
         <p>
-Specification authors that write algorithms that fetch a resource based on the
-`id` of an object inside a [=conforming document=] need to consider whether
-that resource's content is vital to the validity of that document. If it is, the
-specification MUST produce a validation error unless the resource matches the
-expected media type and cryptographic digest.
+A [=conforming verifier implementation=] that makes use of a resource based on
+the `id` of an object inside a [=conforming document=] with a corresponding
+cryptographic digest MUST check the digest against the retrieved resource. If
+the digest of the retrieved resource does not match the one provided by the
+[=issuer=], the [=conforming verifier implementation=] MUST produce an error.
         </p>
+
         <p>
 Implementers are urged to consult appropriate sources, such as the
 <a href="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf">


### PR DESCRIPTION
This PR is an attempt to address https://github.com/w3c/vc-data-integrity/issues/272 by requiring digest verification for related resources.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1567.html" title="Last updated on Oct 14, 2024, 8:41 PM UTC (a565f43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1567/062e4b3...a565f43.html" title="Last updated on Oct 14, 2024, 8:41 PM UTC (a565f43)">Diff</a>