### PR TITLE
Update lifecycle example link to vc overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -535,7 +535,7 @@ Subject-Holder Relationships</a> section in the [[[VC-IMP-GUIDE]]].
 
         <p>
 For a deeper exploration of the [=verifiable credentials=] ecosystem and
-a concrete lifecycle example, please refer to [[[VC-USE-CASES]]] [[?VC-USE-CASES]].
+a concrete lifecycle example, please refer to [[[VC-OVERVIEW]]] [[?VC-OVERVIEW]].
         </p>
       </section>
 


### PR DESCRIPTION
With #1476 the link is updated to the use cases document. 

It would be added to the use cases document by this PR https://github.com/w3c/vc-use-cases/pull/154 but it is now in the overview document. https://github.com/w3c/vc-overview

It would be nice to update this link to the vc overview document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ricklambrechts/w3c-vc-data-model/pull/1573.html" title="Last updated on Nov 26, 2024, 7:53 PM UTC (25f84dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1573/3fbda62...ricklambrechts:25f84dc.html" title="Last updated on Nov 26, 2024, 7:53 PM UTC (25f84dc)">Diff</a>