### PR TITLE
Reword self-asserted VC in VP text to remove MUST.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2667,10 +2667,9 @@ All of the normative requirements defined for [=verifiable credentials=]
 apply to self-asserted [=verifiable credentials=].
           </p>
           <p>
-When a self-asserted [=verifiable credential=] is secured using the same
-mechanism as the [=verifiable presentation=], the value of the
-`issuer` [=property=] of the [=verifiable credential=]
-MUST be identical to the `holder` [=property=] of the
+A [=verifiable credential=] in a [=verifiable presentation=] is considered
+self-asserted when the value of the `issuer` [=property=] of the
+[=verifiable credential=] is identical to the `holder` [=property=] of the
 [=verifiable presentation=].
           </p>
           <p>

--- a/index.html
+++ b/index.html
@@ -2669,8 +2669,8 @@ apply to self-asserted [=verifiable credentials=].
           <p>
 A [=verifiable credential=] in a [=verifiable presentation=] is considered
 self-asserted when the value of the `issuer` [=property=] of the
-[=verifiable credential=] is identical to the `holder` [=property=] of the
-[=verifiable presentation=].
+[=verifiable credential=] is identical to the value of the `holder`
+[=property=] of the [=verifiable presentation=].
           </p>
           <p>
 The example below shows a [=verifiable presentation=] that embeds a


### PR DESCRIPTION
The original statement was found to be untestable. This new text provides explanatory text instead.

NOTE: the goal of this change is to avoid this text being "at risk" while keeping the intention of the text.

@jandrieu I believe this was originally your text, so please let us know if you're OK with this change.

Thanks!
🎩


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1580.html" title="Last updated on Jan 14, 2025, 2:22 PM UTC (79ddaf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1580/a78384a...79ddaf1.html" title="Last updated on Jan 14, 2025, 2:22 PM UTC (79ddaf1)">Diff</a>