### PR TITLE
Fix JsonSchema of the Verifiable Credential

### DIFF
--- a/schema/verifiable-credential/verifiable-credential-schema.json
+++ b/schema/verifiable-credential/verifiable-credential-schema.json
@@ -51,7 +51,6 @@
         }
       },
       "required": [
-        "id",
         "type"
       ],
       "additionalProperties": true
@@ -154,17 +153,9 @@
       "required": [
         "type",
         "proofPurpose",
-        "verificationMethod",
-        "created"
+        "verificationMethod"
       ],
       "additionalProperties": true
-    },
-    "proofChain": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/proof"
-      },
-      "minItems": 1
     }
   },
   "properties": {
@@ -316,9 +307,6 @@
           "minItems": 1
         }
       ]
-    },
-    "proofChain": {
-      "$ref": "#/$defs/proofChain"
     }
   },
   "required": [


### PR DESCRIPTION
A couple of fix to the json schema resource of the VC. Addresses #1577

- remove required `id` property on the credentialStatus object:
this field is optional in the spec (BitstringStatusList)

- remove required `created` property on the proof object:
this is field is optional in the spec (DataIntegrity)

- remove `proofChain` property:
AFAIK this isn't defined anywhere and should be represented by the proof attribute