### PR TITLE
Removed the "MUST" for error conditions to be in sync with CID and DI

### DIFF
--- a/index.html
+++ b/index.html
@@ -4779,12 +4779,12 @@ identifying the type of problem.
           </dd>
           <dt>title</dt>
           <dd>
-The `title` [=property=] MUST be present and its value SHOULD provide a short
+The `title` [=property=] SHOULD provide a short
 but specific human-readable string for the problem.
           </dd>
           <dt>detail</dt>
           <dd>
-The `detail` [=property=] MUST be present and its value SHOULD provide a
+The `detail` [=property=] SHOULD provide a
 longer human-readable string for the problem.
           </dd>
         </dl>


### PR DESCRIPTION
See discussion in https://github.com/w3c/vc-data-integrity/pull/327 : the handling/reporting of errors should be consistent with the DI and CID specifications.

(See also https://github.com/w3c/cid/pull/140).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1587.html" title="Last updated on Jan 20, 2025, 7:23 AM UTC (167fce0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1587/a18b601...167fce0.html" title="Last updated on Jan 20, 2025, 7:23 AM UTC (167fce0)">Diff</a>