### PR TITLE
Added the standard errata management

### DIFF
--- a/errata.html
+++ b/errata.html
@@ -57,7 +57,7 @@
     <main>
       <!-- The data-erratalabel should include one label that filters the errata -->
       <section data-nolabel>
-        <h1>Open Errata on the “Verifiable Credentials Data Model v2.0</h1>
+        <h1>Open Errata on the “Verifiable Credentials Data Model v2.0”</h1>
         <dl>
           <dt>Latest Published Version:</dt>
           <dd><a href="https://www.w3.org/TR/vc-data-model-2.0/">https://www.w3.org/TR/vc-data-model-2.0/</a></dd>

--- a/errata.html
+++ b/errata.html
@@ -6,7 +6,7 @@
   -->
   <head data-githubrepo="w3c/vc-data-model">
     <meta charset="UTF-8">
-    <title>Open Errata for the Verifiable Credentials Working Group</title>
+    <title>Open Errata for the Verifiable Credentials Data Model v2.0</title>
     <link rel="stylesheet" type="text/css" href="https://w3c.github.io/display_errata/assets/errata.css"/>
     <script src="https://www.w3.org/scripts/jquery/1.11/jquery.min.js"></script>
     <script src="https://w3c.github.io/display_errata/assets/moment.min.js" type="text/javascript"></script>
@@ -24,7 +24,7 @@
     <header>
       <p class="banner"><a accesskey="W" href="/"><img width="72" height="48" alt="W3C" src="https://www.w3.org/Icons/w3c_home" /></a> </p>
       <br />
-      <h1 class="title">Open Errata for the Verifiable Credentials Working Group</h1>
+      <h1 class="title">Open Errata for the Verifiable Credentials Data Model v2.0</h1>
       <dl>
         <dt>Latest errata update:</dt>
         <dd><span id="date"></span></dd>
@@ -38,15 +38,15 @@
         <h1>How to Submit an Erratum?</h1>
         <p>Errata are introduced and stored in the <a href="https://github.com/w3c/vc-data-model/issues/">issue list of the group‘s GitHub repository</a>. The workflow to add a new erratum is as follows:</p>
         <ul>
-           <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>ErratumRaised</code>”. It is o.k. for an erratum to have several labels. In some, exceptional, cases, i.e., when the erratum is very general, it is also acceptable not to have a reference to a document.</li>
-           <li>Issues labeled as “<code>Editorial</code>” are displayed separately, to make it easier to differentiate editorial errata from substantive ones.</li>
-          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>ErratumRaised</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
-          <li>If the community rejects the issue as an erratum, the issue should be closed.</li>
-          <li>Each errata may be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
-          <li>ALL substantive errata are generally expected to have corresponding test(s) (such as a pull request in <a href='https://github.com/web-platform-tests/wpt'>web-platform-tests</a>), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
-      </ul>
+          <li>An issue is raised for a possible erratum. The label of the issue SHOULD be set to “<code>PossibleErratum</code>”. One erratum might have several labels.</li>
+          <li>The community discusses the issue. If it is accepted as a genuine erratum, the label “<code>Errata</code>” is added to the entry and the “<code>PossibleErratum</code>” label should be removed. Additionally, a new comment on the issue MAY be added, beginning with the word "Summary:" (if such a summary is useful based on the discussion).</li>
+          <li>Issues labeled as “<code>Errata</code>” are displayed below.</li>
+          <li>If the community rejects the issue as an erratum, the issue should be closed (but they will not be removed from the listing below, to ensure a historical record).</li>
+          <li>Each errata may also be labelled as “<code>Editorial</code>”; editorial errata are listed separately from the substantive ones.</li>
+          <li>ALL substantive errata are generally expected to have corresponding test(s), either in the form of new tests or modifications to existing tests, or must include the rationale for why test updates are not required for the erratum.</li>
+        </ul>
 
-        <p>This report contains a reference to all open issues with the label <code>Errata</code>, displayed in the sections below. Each section collects the issues for a specific document, with a separate section for the issues not assigned to any.</p>
+        <p>This report contains a reference to all open issues with the label <code>Errata</code>.</p>
 
         <p>If you have problems following this process, but you want nevertheless to report an error, you can also contact the staff contact of the Working Group, <a href="mailto:ivan@w3.org">ivan</a>.</p>
       </section>
@@ -57,15 +57,15 @@
     <main>
       <!-- The data-erratalabel should include one label that filters the errata -->
       <section data-nolabel>
-        <h1>Open Errata on the “Verifiable Credentials Data Model 1.0” Recommendation</h1>
+        <h1>Open Errata on the “Verifiable Credentials Data Model v2.0</h1>
         <dl>
           <dt>Latest Published Version:</dt>
-          <dd><a href="https://www.w3.org/TR/vc-data-model/">https://www.w3.org/TR/vc-data-model/</a></dd>
+          <dd><a href="https://www.w3.org/TR/vc-data-model-2.0/">https://www.w3.org/TR/vc-data-model-2.0/</a></dd>
           <dt>Editor’s draft:</dt>
           <dd><a href="https://w3c.github.io/vc-data-model/">https://w3c.github.io/vc-data-model/</a></dd>
           <dt>Latest Publication Date:</dt>
-          <dd>19 November 2019</dd>
-      </dl>
+          <dd>15 May 2025</dd>
+        </dl>
         <section id="first">
           <h2>Substantive Issues</h2>
         </section>
@@ -77,7 +77,14 @@
 
     <footer>
       <address><a href="mailto:ivan@w3.org" class=''>ivan</a>, &lt;ivan@w3.org&gt;, (W3C)</address>
-      <p class="copyright"><a href="/Consortium/Legal/ipr-notice#Copyright" rel="Copyright">Copyright</a> © 2019 <a href="/"><abbr title="World Wide Web Consortium">W3C</abbr></a> <sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.org/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>, <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.</p>
+      <p class="copyright">
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © <span class="todo">2025</span>
+        World Wide Web Consortium.
+        W3C® <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>, and
+        <a href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document">permissive document license</a>
+        rules apply.
+      </p>
     </footer>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         crEnd: "2025-01-19",
         prEnd: "2025-4-17",
         implementationReportURI: "https://w3c.github.io/vc-data-model-2.0-test-suite/",
-        //errata: "https://w3c.github.io/vc-data-model/errata.html",
+        errata: "https://w3c.github.io/vc-data-model/errata.html",
         previousMaturity: "REC",
         previousPublishDate: "2022-03-03",
 
@@ -172,7 +172,6 @@
         xref: ["URL", "I18N-GLOSSARY", "INFRA", "CID"],
         lint: { "informative-dfn": false },
         maxTocLevel: 3,
-        errata: "https://w3c.github.io/vc-data-model/errata.html",
         inlineCSS: true
       };
     </script>

--- a/index.html
+++ b/index.html
@@ -172,6 +172,7 @@
         xref: ["URL", "I18N-GLOSSARY", "INFRA", "CID"],
         lint: { "informative-dfn": false },
         maxTocLevel: 3,
+        errata: "https://w3c.github.io/vc-data-model/errata.html",
         inlineCSS: true
       };
     </script>


### PR DESCRIPTION
I have reused the errata management used for DID which, in turn, originates from the standard W3C practice these days.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1597.html" title="Last updated on Apr 25, 2025, 7:29 AM UTC (852561b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1597/db8fa5b...852561b.html" title="Last updated on Apr 25, 2025, 7:29 AM UTC (852561b)">Diff</a>