### PR TITLE
Add reference to confidence method and render method

### DIFF
--- a/index.html
+++ b/index.html
@@ -3929,7 +3929,7 @@ on usage, can refer to the [[[?VC-CONFIDENCE-METHOD]]] specification.
 A property used for specifying one or more methods to render a credential into a
 visual, auditory, haptic, or other format. The associated vocabulary URL MUST be
 `https://www.w3.org/2018/credentials#renderMethod`. Implementers that are 
-interested in learning more about render method, including examples on usage, can 
+interested in learning more about render method, including examples of usage, can 
 refer to the [[[?VC-RENDER-METHOD]]] specification.
               </td>
             </tr>


### PR DESCRIPTION
Attempt to address issue #1480 by adding a reference to confidence method and render method.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/ewoogit/vc-data-model/pull/1620.html" title="Last updated on Mar 20, 2026, 1:28 PM UTC (33fd59f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1620/1e016bf...ewoogit:33fd59f.html" title="Last updated on Mar 20, 2026, 1:28 PM UTC (33fd59f)">Diff</a>