### PR TITLE
Clarify that SD-JWT-VC is incompatible with W3C VCs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,6 +98,13 @@
             authors: ['Daniel Buchner', 'Brent Zundel', 'Martin Riedel', 'Kim Hamilton Duffy'],
             status: 'DIF Ratified Specification',
             publisher: 'Decentralized Identity Foundation'
+          },
+          'SD-JWT-VC': {
+            title: 'SD-JWT-based Verifiable Digital Credentials',
+            href: 'https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/',
+            authors: ['Oliver Terbu', 'Daniel Fett', 'Brian Campbell'],
+            status: 'Internet-Draft',
+            publisher: 'Internet Engineering Task Force'
           }
         },
         doJsonLd: true,
@@ -4013,7 +4020,9 @@ and it uses at least one securing mechanism, as described by their
 respective requirements in this specification. While some communities might call
 some digital credential formats that are not [=conforming documents=]
 "verifiable credentials", doing so does NOT make that digital credential
-compliant to this specification.
+compliant to this specification. For example, despite the use of the letters
+"VC" in the SD-JWT-VC [[?SD-JWT-VC]] specification, that specification
+explicitly states that it is incompatible with W3C Verifiable Credentials.
         </p>
 
       </section>


### PR DESCRIPTION
This PR attempts to address issue #1593 by clarifying that the SD-JWT-VC specification is incompatible with W3C VCs by adding text to that effect.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1622.html" title="Last updated on Mar 20, 2026, 12:49 PM UTC (d682765)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1622/1e016bf...d682765.html" title="Last updated on Mar 20, 2026, 12:49 PM UTC (d682765)">Diff</a>