### PR TITLE
Update URL definition to clarify dereferencing

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,7 +749,7 @@ a digital signature associated with a [=verifiable credential=].
         </dd>
         <dt><dfn data-lt="URL|URLs">URL</dfn></dt>
         <dd>
-A Uniform Resource Locator, as defined by the [[[URL]]]. URLs can be
+A Uniform Resource Locator, as defined by the [[[URL]]]. Some URLs may be
 dereferenced to result in a resource, such as a document. The rules
 for dereferencing, or fetching, a URL are defined by the URL [=url/scheme=].
 This specification does not use the term URI or IRI because those terms have

--- a/index.html
+++ b/index.html
@@ -749,7 +749,7 @@ a digital signature associated with a [=verifiable credential=].
         </dd>
         <dt><dfn data-lt="URL|URLs">URL</dfn></dt>
         <dd>
-A Uniform Resource Locator, as defined by the [[[URL]]]. Some URLs may be
+A Uniform Resource Locator, as defined by the [[[URL]]]. Some URLs can be
 dereferenced to result in a resource, such as a document. The rules
 for dereferencing, or fetching, a URL are defined by the URL [=url/scheme=].
 This specification does not use the term URI or IRI because those terms have


### PR DESCRIPTION
The URL definition stated, incorrectly, that URLs can be dereferenced. Unfortunately, that is not true under the WhatWG definition, including treats all URIs as URLs, such that a URN in the WhatWG context *is* a URL, despite the fact that you cannot dereference it.

This should be a simple clarification, which might mean it is merely editorial. However, looking at the edit out of context, it is redefining a normative definition. However, I do think it is a security error to have incompatible definitions between the `id` property and the `url` definition.

Addresses #1624


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1625.html" title="Last updated on Mar 22, 2026, 6:12 PM UTC (07c1544)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1625/324e220...07c1544.html" title="Last updated on Mar 22, 2026, 6:12 PM UTC (07c1544)">Diff</a>