### PR TITLE
Fix citation `href` value for ETSI doc.

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
           },
           "ETSI-TRUST-LISTS": {
             title: "Electronic Signatures and Infrastructures (ESI); Trusted Lists",
-            href: ["https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf"],
+            href: "https://www.etsi.org/deliver/etsi_ts/119600_119699/119612/02.01.01_60/ts_119612v020101p.pdf",
             authors: ["ETSI"],
             status: "ETSI Standard TS 119 612 V2.1.1 (2015-07)",
             publisher: "ETSI"


### PR DESCRIPTION
The `href` value MUST be a string. The array value breaks  downstream tooling like the JSON-LD output for SEO (likely among others).

The broken syntax came in a couple years ago in this commit:
https://github.com/w3c/vc-data-model/commit/c7c967c372385db797333ae65915e9c2c277491d#diff-1511ae6a0ec41a07cc1be69eda506b90a16e7209fed37371407584eb71f1a64fR47

Fixing this should fix the JSON-LD (which currently fails). I've no idea how we handle bugs in published specs...but that's what we have here.

Thanks!
🎩


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1626.html" title="Last updated on Apr 7, 2026, 7:54 PM UTC (c82318e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1626/dd06826...c82318e.html" title="Last updated on Apr 7, 2026, 7:54 PM UTC (c82318e)">Diff</a>