### PR TITLE
Deprecate `digestSri`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 **/.vscode
 **/package-lock.json
 out.html
+
+vocab/credentials/v2/vocabulary.html
+vocab/credentials/v2/vocabulary.jsonld
+vocab/credentials/v2/vocabulary.ttl

--- a/index.html
+++ b/index.html
@@ -3143,12 +3143,19 @@ IANA Media Types</a> registry.
                   </td>
                 </tr>
                 <tr>
-                  <td>`digestSRI`</td>
+                  <td>`digestSRI` (deprecated)</td>
                   <td>
 One or more cryptographic digests, as defined by the `hash-expression` ABNF
 grammar defined in the [[[SRI]]] specification,
 <a data-cite="SRI#the-integrity-attribute">Section 3.5: The `integrity`
 attribute</a>.
+<div class="note" title="digestSRI is deprecated">
+Document authors are warned that `digestSRI` is deprecated and will likely be
+removed in the next version of this specification. Authors are urged to use
+`digestMultibase` instead because it supports a greater variety of cryptographic
+hash formats, compresses well when transformed to binary formats such as
+CBOR-LD, and has a more flexible extensibility model than `digestSRI`.
+</div>
                   </td>
                 </tr>
                 <tr>

--- a/vocab/credentials/v2/template.html
+++ b/vocab/credentials/v2/template.html
@@ -237,8 +237,8 @@
         <h2>Deprecated classes</h2>
       </section>
 
-      <section id="deprecated_property_definitions" class="term_definitions">
-        <h2>Deprecated properties</h2>
+      <section id="deprecated_datatype_definitions" class="term_definitions">
+        <h2>Deprecated datatypes</h2>
       </section>
 
       <section id="deprecated_individual_definitions" class="term_definitions">
@@ -252,36 +252,36 @@
         <summary>Overview diagram of the vocabulary (without the deprecated items).</summary>
         <p>
           The diagram uses boxes, ellipses, and connecting lines with different "styles" (border color, end
-          marker, line type) to differentiate their semantic meaning; these styles identify 
+          marker, line type) to differentiate their semantic meaning; these styles identify
           Property, Class, or Datatype, via the shapes used for the graph nodes, and Superclass, Domain Of,
-          Range, or Contains, via the styles of the connecting lines. 
-          These style names are used in the explanation text in what follows. 
+          Range, or Contains, via the styles of the connecting lines.
+          These style names are used in the explanation text in what follows.
         </p>
-        <p>  
-          In the middle of the diagram there is a column of labeled boxes, all styled as Property. 
-          The labels, from top to bottom, are: "credentialSchema", "credentialStatus", "credentialSubject", 
+        <p>
+          In the middle of the diagram there is a column of labeled boxes, all styled as Property.
+          The labels, from top to bottom, are: "credentialSchema", "credentialStatus", "credentialSubject",
           "issuer", "evidence", "refreshService", "renderMethod", "confidenceMethod", "termsOfUse", "validFrom",
-          "validUntil", and "holder". 
-          On the left side of this column, there are five labeled ellipses, styled as Class. 
+          "validUntil", and "holder".
+          On the left side of this column, there are five labeled ellipses, styled as Class.
           These are, from top to bottom, "VerifiableCredential", "JsonSchemaCredential",
-          "EnvelopedVerifiableCredential", "VerifiableCredentialGraph", and "VerifiablePresentation". 
+          "EnvelopedVerifiableCredential", "VerifiableCredentialGraph", and "VerifiablePresentation".
           There is also a small, unlabeled circle, which serves as an intersection point for connector
           lines, with two pointing in, and four pointing out.
         </p>
         <p>
           The "VerifiableCredential" ellipse is connected to the "credentialSchema", "credentialStatus",
-          "credentialSubject", "issuer", "relatedResource", "evidence", "refreshService", "renderMethod", 
-          and "confidenceMethod" boxes, through connecting lines styled as Domain Of. 
+          "credentialSubject", "issuer", "relatedResource", "evidence", "refreshService", "renderMethod",
+          and "confidenceMethod" boxes, through connecting lines styled as Domain Of.
           It is also connected to the crossing point circle with a similar connecting line,
           styled as Domain Of.
-          The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" and 
-          "verifiableCredential" boxes, with a similar connecting line styled as Domain Of. 
-          The crossing point circle is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a 
+          The "VerifiablePresentation" ellipse is connected to the crossing point circle, as well as the "holder" and
+          "verifiableCredential" boxes, with a similar connecting line styled as Domain Of.
+          The crossing point circle is connected to the "termsOfUse", "validFrom", and "validUntil" boxes with a
           connecting line styled as Domain Of.
           The "verifiableCredential" box is connected to the "VerifiableCredentialGraph" ellipse with a connecting
-          line styled as Range. 
-          The "JsonSchemaCredential" ellipse is connected to the "VerifiableCredential" ellipse with a 
-          connecting line styled as Superclass. 
+          line styled as Range.
+          The "JsonSchemaCredential" ellipse is connected to the "VerifiableCredential" ellipse with a
+          connecting line styled as Superclass.
           Finally, the "VerifiableCredentialGraph" ellipse is connected to the "VerifiableCredential"
           and "EnvelopedVerifiableCredential" ellipses with connector lines styled as Contains.
         </p>
@@ -290,19 +290,19 @@
           "CredentialStatus", "CredentialEvidence", "RefreshService", "RenderMethod", "ConfidenceMethod", and "TermsOfUse".
           The Property boxes labeled as "credentialSchema", "credentialStatus", "credentialEvidence,
           "refreshService", "renderMethod", "confidenceMethod", and "termsOfUse" are respectively
-          connected to those Class ellipses, with connecting lines styled as Range. 
+          connected to those Class ellipses, with connecting lines styled as Range.
         </p>
         <p>
           The "CredentialSchema" ellipse is connected to one more ellipse, on the far right
           side of the diagram, styled as Class and labeled as "JsonSchema", with a connecting line
-          styled as Superclass. 
-          This "JsonSchema" ellipse is also connected to a Property box labeled as "jsonSchema", 
+          styled as Superclass.
+          This "JsonSchema" ellipse is also connected to a Property box labeled as "jsonSchema",
           through a connector line styled as Domain Of, and to a Datatype shape
-          labeled as "rdf:JSON", through a connecting line styled as Range. 
+          labeled as "rdf:JSON", through a connecting line styled as Range.
         </p>
         <p>
-          Finally, on the lower far right side of the diagram, there is a separate Property box labeled as 
-          "digestSRI", connected to a Datatype shape labeled as "sriString", with a connecting line 
+          Finally, on the lower far right side of the diagram, there is a separate Property box labeled as
+          "digestSRI", connected to a Datatype shape labeled as "sriString", with a connecting line
           styled as Range.
         </p>
       </details>

--- a/vocab/credentials/v2/vocabulary.yml
+++ b/vocab/credentials/v2/vocabulary.yml
@@ -201,6 +201,7 @@ datatype:
     label: Datatype for digest SRI values
     upper_value: xsd:string
     defined_by: https://www.w3.org/TR/vc-data-model-2.0/#the-sristring-datatype
+    deprecated: true
     see_also:
       - label: Subresource Integrity Metadata
         url:  https://www.w3.org/TR/SRI/#the-integrity-attribute


### PR DESCRIPTION
Addresses issue #1628 by deprecating `digestSri`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/pull/1629.html" title="Last updated on May 12, 2026, 3:53 AM UTC (d1f6da4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-data-model/1629/2b8a84f...d1f6da4.html" title="Last updated on May 12, 2026, 3:53 AM UTC (d1f6da4)">Diff</a>