### PR TITLE
Migrate Security/Privacy Considerations to Threat Model

### DIFF
--- a/threat-model/index.html
+++ b/threat-model/index.html
@@ -27,7 +27,29 @@
       }],
       noRecTrack: "true",
       maxTocLevel: 4,
-      xref: ["VC-DATA-MODEL-2.0", "CID", "DID", "VC-DATA-INTEGRITY"],
+      xref: ["VC-DATA-MODEL-2.0", "CID", "DID", "VC-DATA-INTEGRITY",
+        "VC-DI-BBS"],
+      localBiblio: {
+        "NIST-SP-800-57-Part-1": {
+          title: "Recommendation for Key Management: Part 1 – General",
+          authors: ["Elaine Barker"],
+          date: "May 2020",
+          publisher: "National Institute of Standards and Technology",
+          href: "https://doi.org/10.6028/NIST.SP.800-57pt1r5"
+        },
+        "NIST-SP-800-63A": {
+          title: "Digital Identity Guidelines: Identity Proofing and " +
+            "Enrollment",
+          authors: [
+            "David Temoshok", "Diana Proud-Madruga", "Yee-Yin Choong",
+            "Ryan Galluzzo", "Sarbari Gupta", "Connie LaSalle",
+            "Naomi Lefkovitz", "Andrew Regenscheid"
+          ],
+          date: "2025",
+          publisher: "National Institute of Standards and Technology",
+          href: "https://doi.org/10.6028/NIST.SP.800-63a-4"
+        }
+      },
       preProcess: [window.ThreatModel.render],
       postProcess: [(config, document) => {
         config.thisVersion =

--- a/threat-model/index.html
+++ b/threat-model/index.html
@@ -130,6 +130,14 @@ the specification depends upon.
       </li>
     </ul>
 
+    <p>
+Each threat in this model is examined in isolation. However, good, scalable
+solutions always require balance, and almost any decision comes with trade offs.
+Readers are expected to take all relevant threats, advice, and mitigations into
+consideration to balance them appropriately to optimize for their solution's
+widest target audience.
+    </p>
+
     <section id="threat-model-description">
       <h3>Description</h3>
       <p>

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -15,7 +15,7 @@
 categories:
   - name: Target Threats
     id: threat-model-target-threats
-    threats: [T1]
+    threats: [T1, T25]
   - name: Implementation Threats
     id: threat-model-implementation-threats
     threats: [T2, T8, T12, T18, T19, T20, T24]
@@ -80,3 +80,4 @@ files:
   - t22-device-theft-and-impersonation.yaml
   - t23-unauthorized-post-presentation-use.yaml
   - t24-inappropriate-use.yaml
+  - t25-identity-proofing-failure.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7]
+    threats: [T3, T6, T7, T9]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4]
@@ -64,3 +64,4 @@ files:
   - t6-untrustworthy-user-agent-software.yaml
   - t7-excessive-data-disclosure.yaml
   - t8-signature-based-correlation.yaml
+  - t9-metadata-based-correlation.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8, T12]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9, T11, T14, T15]
+    threats: [T3, T6, T7, T9, T11, T14, T15, T16]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10, T13]
@@ -71,3 +71,4 @@ files:
   - t13-credential-aggregation.yaml
   - t14-correlation-via-patterns-of-use.yaml
   - t15-disclosure-to-malicious-verifier.yaml
+  - t16-data-theft.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -18,7 +18,7 @@ categories:
     threats: [T1]
   - name: Implementation Threats
     id: threat-model-implementation-threats
-    threats: [T2, T8, T12]
+    threats: [T2, T8, T12, T18]
   - name: Deployment Threats
     id: threat-model-deployment-threats
     threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17]
@@ -73,3 +73,4 @@ files:
   - t15-disclosure-to-malicious-verifier.yaml
   - t16-data-theft.yaml
   - t17-issuer-side-correlation.yaml
+  - t18-signing-key-compromise.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -18,7 +18,7 @@ categories:
     threats: [T1]
   - name: Implementation Threats
     id: threat-model-implementation-threats
-    threats: [T2]
+    threats: [T2, T8]
   - name: Deployment Threats
     id: threat-model-deployment-threats
     threats: [T3, T6, T7]
@@ -63,3 +63,4 @@ files:
   - t5-cryptographic-suite-obsolescence.yaml
   - t6-untrustworthy-user-agent-software.yaml
   - t7-excessive-data-disclosure.yaml
+  - t8-signature-based-correlation.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8, T12]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9, T11, T14]
+    threats: [T3, T6, T7, T9, T11, T14, T15]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10, T13]
@@ -70,3 +70,4 @@ files:
   - t12-correlation-via-status-lookup.yaml
   - t13-credential-aggregation.yaml
   - t14-correlation-via-patterns-of-use.yaml
+  - t15-disclosure-to-malicious-verifier.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -24,7 +24,7 @@ categories:
     threats: [T3, T6, T7, T9, T11]
   - name: External Threats
     id: threat-model-external-threats
-    threats: [T4, T10]
+    threats: [T4, T10, T13]
   - name: Dependency Threats
     id: threat-model-dependency-threats
     threats: [T5]
@@ -68,3 +68,4 @@ files:
   - t10-device-tracking-and-fingerprinting.yaml
   - t11-bearer-credential-reuse.yaml
   - t12-correlation-via-status-lookup.yaml
+  - t13-credential-aggregation.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -24,7 +24,7 @@ categories:
     threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17, T21, T22]
   - name: External Threats
     id: threat-model-external-threats
-    threats: [T4, T10, T13]
+    threats: [T4, T10, T13, T23]
   - name: Dependency Threats
     id: threat-model-dependency-threats
     threats: [T5]
@@ -78,3 +78,4 @@ files:
   - t20-presentation-exchange-attacks.yaml
   - t21-inappropriate-validity-periods.yaml
   - t22-device-theft-and-impersonation.yaml
+  - t23-unauthorized-post-presentation-use.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6]
+    threats: [T3, T6, T7]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4]
@@ -62,3 +62,4 @@ files:
   - t4-storage-provider-data-mining.yaml
   - t5-cryptographic-suite-obsolescence.yaml
   - t6-untrustworthy-user-agent-software.yaml
+  - t7-excessive-data-disclosure.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8, T12, T18, T19, T20]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17, T21]
+    threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17, T21, T22]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10, T13]
@@ -77,3 +77,4 @@ files:
   - t19-unprotected-external-resources.yaml
   - t20-presentation-exchange-attacks.yaml
   - t21-inappropriate-validity-periods.yaml
+  - t22-device-theft-and-impersonation.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8, T12]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9, T11]
+    threats: [T3, T6, T7, T9, T11, T14]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10, T13]
@@ -69,3 +69,4 @@ files:
   - t11-bearer-credential-reuse.yaml
   - t12-correlation-via-status-lookup.yaml
   - t13-credential-aggregation.yaml
+  - t14-correlation-via-patterns-of-use.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -18,7 +18,7 @@ categories:
     threats: [T1]
   - name: Implementation Threats
     id: threat-model-implementation-threats
-    threats: [T2, T8, T12, T18, T19]
+    threats: [T2, T8, T12, T18, T19, T20]
   - name: Deployment Threats
     id: threat-model-deployment-threats
     threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17]
@@ -75,3 +75,4 @@ files:
   - t17-issuer-side-correlation.yaml
   - t18-signing-key-compromise.yaml
   - t19-unprotected-external-resources.yaml
+  - t20-presentation-exchange-attacks.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3]
+    threats: [T3, T6]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4]
@@ -61,3 +61,4 @@ files:
   - t3-identifier-based-correlation.yaml
   - t4-storage-provider-data-mining.yaml
   - t5-cryptographic-suite-obsolescence.yaml
+  - t6-untrustworthy-user-agent-software.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -18,7 +18,7 @@ categories:
     threats: [T1]
   - name: Implementation Threats
     id: threat-model-implementation-threats
-    threats: [T2, T8, T12, T18, T19, T20]
+    threats: [T2, T8, T12, T18, T19, T20, T24]
   - name: Deployment Threats
     id: threat-model-deployment-threats
     threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17, T21, T22]
@@ -79,3 +79,4 @@ files:
   - t21-inappropriate-validity-periods.yaml
   - t22-device-theft-and-impersonation.yaml
   - t23-unauthorized-post-presentation-use.yaml
+  - t24-inappropriate-use.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -18,7 +18,7 @@ categories:
     threats: [T1]
   - name: Implementation Threats
     id: threat-model-implementation-threats
-    threats: [T2, T8, T12, T18]
+    threats: [T2, T8, T12, T18, T19]
   - name: Deployment Threats
     id: threat-model-deployment-threats
     threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17]
@@ -74,3 +74,4 @@ files:
   - t16-data-theft.yaml
   - t17-issuer-side-correlation.yaml
   - t18-signing-key-compromise.yaml
+  - t19-unprotected-external-resources.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8, T12]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9, T11, T14, T15, T16]
+    threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10, T13]
@@ -72,3 +72,4 @@ files:
   - t14-correlation-via-patterns-of-use.yaml
   - t15-disclosure-to-malicious-verifier.yaml
   - t16-data-theft.yaml
+  - t17-issuer-side-correlation.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -24,7 +24,7 @@ categories:
     threats: [T3, T6, T7, T9]
   - name: External Threats
     id: threat-model-external-threats
-    threats: [T4]
+    threats: [T4, T10]
   - name: Dependency Threats
     id: threat-model-dependency-threats
     threats: [T5]
@@ -65,3 +65,4 @@ files:
   - t7-excessive-data-disclosure.yaml
   - t8-signature-based-correlation.yaml
   - t9-metadata-based-correlation.yaml
+  - t10-device-tracking-and-fingerprinting.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9]
+    threats: [T3, T6, T7, T9, T11]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10]
@@ -66,3 +66,4 @@ files:
   - t8-signature-based-correlation.yaml
   - t9-metadata-based-correlation.yaml
   - t10-device-tracking-and-fingerprinting.yaml
+  - t11-bearer-credential-reuse.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -18,7 +18,7 @@ categories:
     threats: [T1]
   - name: Implementation Threats
     id: threat-model-implementation-threats
-    threats: [T2, T8]
+    threats: [T2, T8, T12]
   - name: Deployment Threats
     id: threat-model-deployment-threats
     threats: [T3, T6, T7, T9, T11]
@@ -67,3 +67,4 @@ files:
   - t9-metadata-based-correlation.yaml
   - t10-device-tracking-and-fingerprinting.yaml
   - t11-bearer-credential-reuse.yaml
+  - t12-correlation-via-status-lookup.yaml

--- a/threat-model/threats/outline.yaml
+++ b/threat-model/threats/outline.yaml
@@ -21,7 +21,7 @@ categories:
     threats: [T2, T8, T12, T18, T19, T20]
   - name: Deployment Threats
     id: threat-model-deployment-threats
-    threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17]
+    threats: [T3, T6, T7, T9, T11, T14, T15, T16, T17, T21]
   - name: External Threats
     id: threat-model-external-threats
     threats: [T4, T10, T13]
@@ -76,3 +76,4 @@ files:
   - t18-signing-key-compromise.yaml
   - t19-unprotected-external-resources.yaml
   - t20-presentation-exchange-attacks.yaml
+  - t21-inappropriate-validity-periods.yaml

--- a/threat-model/threats/t1-credential-content-tampering.yaml
+++ b/threat-model/threats/t1-credential-content-tampering.yaml
@@ -39,5 +39,10 @@ response:
       credential with no proof contains nothing to verify. [=E3|Verifiers=]
       address this through policy. They reject any [=verifiable credential=]
       that does not carry the securing mechanism their policy requires, and
-      they treat unsecured [=credentials=] as unauthenticated statements made by the presenting holder, rather than
-      as authenticated statements made by the [=E1|issuer=].
+      they treat unsecured [=credentials=] as unauthenticated statements made
+      by the presenting holder, rather than as authenticated statements made by
+      the [=E1|issuer=]. The specification allows [=credentials=] to be created
+      without proofs, which are useful for intermediate storage or self-asserted
+      information; such [=credentials=] are not [=verifiable=] because their
+      authorship is unknown or cannot be trusted, and a [=E3|verifier=] does not
+      rely on them as though an [=E1|issuer=] had authored them.

--- a/threat-model/threats/t10-device-tracking-and-fingerprinting.yaml
+++ b/threat-model/threats/t10-device-tracking-and-fingerprinting.yaml
@@ -1,0 +1,43 @@
+id: T10
+name: Device Tracking and Fingerprinting
+elements: [E2, E3, P8, P11, F4, C2]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  Mechanisms external to [=verifiable credentials=] track and correlate
+  individuals on the Internet, including Internet protocol address tracking, web
+  browser fingerprinting, evercookies, advertising network trackers, mobile
+  network position information, and Global Positioning System interfaces. Using
+  [=verifiable credentials=] alongside these technologies can reveal new
+  correlatable information; for example, a birthdate combined with a device's
+  location can strongly correlate an individual across multiple websites.
+  Fetching an external resource associated with a credential, such as a linked
+  image or a revocation list, also signals activity to the server hosting it. A
+  [=E2|holder's=] wallet fetching such a resource reveals the holder's activity,
+  and a [=E3|verifier=] fetching a status list signals to the [=E1|issuer=] that
+  it has received a specific credential. These tracking technologies exist
+  outside the data model, so this risk arises from the operating environment
+  rather than from the specification.
+response:
+  - id: R1
+    name: Oblivious Retrieval of External Resources
+    type: Reduce
+    description: >-
+      Implementers fetch external resources associated with a
+      [=verifiable credential=] or [=verifiable presentation=] using a
+      privacy-preserving transport such as Oblivious HTTP [[?RFC9458]], which
+      lets a client make requests to an origin server without that server being
+      able to link the requests to the client or identify them as coming from a
+      single client. This reduces the chance that a [=E2|holder=] is tracked
+      when a wallet fetches linked content, and the chance that a
+      [=E3|verifier=] signals to an [=E1|issuer=] that it has received a
+      specific credential.
+  - id: R2
+    name: Prevent Combination with Tracking Technologies
+    type: Reduce
+    description: >-
+      Privacy-respecting systems aim to prevent the combination of other
+      tracking technologies with [=verifiable credentials=]. In some cases,
+      tracking technologies are disabled on devices that transmit
+      [=verifiable credentials=] on behalf of a [=E2|holder=].

--- a/threat-model/threats/t11-bearer-credential-reuse.yaml
+++ b/threat-model/threats/t11-bearer-credential-reuse.yaml
@@ -1,0 +1,36 @@
+id: T11
+name: Bearer Credential Reuse and Correlation
+elements: [E1, E2, E3, P2, F3]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  A [=bearer credential=] entitles whoever holds it to a resource without
+  requiring the [=E2|holder=] to identify themselves, by omitting the
+  [=subject=] identifier normally expressed with the <code>id</code>
+  [=property=]. This privacy-enhancing design can still enable correlation.
+  Repeated use of the same [=bearer credential=] across multiple sites lets
+  those sites collude to track the [=holder=], and information that appears
+  non-identifying on its own, such as a birthdate and a postal code carried in
+  the same bearer credential, can statistically identify an individual. Whether
+  this threat is present depends on how an [=E1|issuer=] designs the bearer
+  credential and how the [=E2|holder=] uses it.
+response:
+  - id: R1
+    name: Single-Use, Non-Identifying Bearer Credentials
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] of [=bearer credentials=] design them to be single-use
+      where possible, to avoid carrying personally identifying information, and
+      to avoid being unduly correlatable. [=E3|Verifiers=] avoid requesting
+      [=bearer credentials=] known to carry information that can be used to
+      illicitly correlate the [=holder=].
+  - id: R2
+    name: Warn Holders of Correlation Risk
+    type: Reduce
+    description: >-
+      Software for [=E2|holders=] warns the holder when it detects that a
+      [=bearer credential=] containing sensitive information has been issued or
+      requested, or that a correlation risk is posed by the combination of two
+      or more [=bearer credentials=] across one or more sessions. Detecting
+      every correlation risk is not possible, but many are detectable.

--- a/threat-model/threats/t12-correlation-via-status-lookup.yaml
+++ b/threat-model/threats/t12-correlation-via-status-lookup.yaml
@@ -1,0 +1,43 @@
+id: T12
+name: Correlation via Status and Revocation Lookup
+elements: [E1, E3, P5, P11, F4, S1]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  When a [=E3|verifier=] [=P11|checks the status=] of a [=verifiable
+  credential=], the act of looking up status information can leak that an
+  interaction is taking place. A revocation or status mechanism that is unique
+  per [=credential=], or that requires submitting a [=credential's=] identifier
+  to a centralized query interface, tells the [=E1|issuer=] operating
+  [=S1|status list storage=] which credential is being checked and, by
+  inference, that a specific [=E3|verifier=] is likely interacting with the
+  [=E2|holder=]. This enables an [=E1|issuer=] to learn everywhere a credential
+  is presented and enables [=issuers=] and [=verifiers=] to collude to correlate
+  the holder. Even a bulk, privacy-preserving status list leaks information when
+  the [=E1|issuer=] [=P5|updates the status list=] frequently: a [=E3|verifier=]
+  refetches it often to stay current, and that pattern of retrieval reveals the
+  verifier's interest in that particular status list and, by extension, in the
+  population of [=subjects=] the list covers. Whether this threat is present
+  depends on the status mechanism an [=E1|issuer=] deploys and how often it is
+  updated.
+response:
+  - id: R1
+    name: Privacy-Preserving Status Mechanisms
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] avoid status mechanisms, such as per-credential revocation
+      lists, that reveal which [=credential=] is being checked during
+      [=P11|verification=]. Status mechanisms that do not depend on submitting a
+      unique [=credential=] identifier to a query interface, such as a
+      privacy-preserving status list retrieved in bulk, avoid signaling
+      individual lookups. Serving status information from a globally distributed
+      service further reduces the ability to correlate lookups.
+  - id: R2
+    name: Warn and Reject on Privacy-Harming Status Checks
+    type: Reduce
+    description: >-
+      Software for [=E2|holders=] warns when a [=credential=] carries status
+      information that could lead to a privacy violation during verification.
+      [=E3|Verifiers=] consider rejecting [=credentials=] whose status checks
+      produce privacy violations or enable substandard privacy practices.

--- a/threat-model/threats/t13-credential-aggregation.yaml
+++ b/threat-model/threats/t13-credential-aggregation.yaml
@@ -1,0 +1,38 @@
+id: T13
+name: Credential and Data Aggregation
+elements: [E2, E3, F3, P9]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  Holding two pieces of information about the same [=subject=] often reveals
+  more than the two pieces considered separately, even when they arrive through
+  different channels or sessions. When a [=E3|verifier=] receives, for example,
+  a [=bearer credential=] carrying an email address and another stating the
+  [=E2|holder=] is over a certain age, it gains a unique identifier joined to an
+  attribute and can begin building a profile that grows as more information
+  leaks over time. Aggregation is also performed by multiple sites acting in
+  collusion. Preventing aggregation is a difficult problem: long-lived
+  identifiers and browser-tracking techniques defeat even modern cryptographic
+  protections, so the effective mitigations are largely policy-driven. This risk
+  arises from the broader operating environment rather than from the data model
+  itself.
+response:
+  - id: R1
+    name: Express and Honor Anti-Aggregation Intent
+    type: Reduce
+    description: >-
+      A [=E2|holder=] who wishes to avoid the aggregation of their information
+      expresses this in the [=verifiable presentations=] they transmit, and
+      relies on the [=holders=] and [=E3|verifiers=] to whom they transmit those
+      presentations to honor it. Because the effective controls are largely
+      policy-driven rather than technological, all participants in the ecosystem
+      remain aware of the risks of data aggregation.
+  - id: R2
+    name: Accept Residual Aggregation Risk
+    type: Accept
+    description: >-
+      The existence of long-lived identifiers and external tracking techniques
+      means aggregation cannot be fully prevented by technological means. This
+      residual risk is acknowledged and accepted as outside the scope of the
+      data model.

--- a/threat-model/threats/t14-correlation-via-patterns-of-use.yaml
+++ b/threat-model/threats/t14-correlation-via-patterns-of-use.yaml
@@ -1,0 +1,42 @@
+id: T14
+name: Correlation via Patterns of Use
+elements: [E2, E3, P8, F3, P9]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  Even when individual disclosures are minimized, the pattern in which
+  [=verifiable credentials=] are presented can lead to de-anonymization. When
+  the same [=verifiable credential=] is presented to the same [=E3|verifier=]
+  more than once, the verifier can infer it is dealing with the same individual.
+  When the same credential is presented to different [=E3|verifiers=] who
+  collude, or a third party has access to transaction records from both, an
+  observer can infer the same person controls both accounts. A [=subject=]
+  identifier that is stable across [=presentations=] links them even when the
+  credentials differ, and underlying information such as a postal code, age, and
+  gender can be matched against an existing profile. In some settings
+  correlation is a deliberate requirement, such as prescription monitoring, and
+  in others it is intended, such as logging in with a common persona; the threat
+  is the unintended or unexpected correlation that arises from presentation.
+  Whether it is present depends on how [=holders=] and [=E1|issuers=] design and
+  use credentials.
+response:
+  - id: R1
+    name: Single-Use Credentials and Fresh Identifiers
+    type: Reduce
+    description: >-
+      Software for [=E2|holders=] provides a globally unique [=subject=]
+      identifier for a given [=verifiable credential=] and does not reuse that
+      credential, so a credential itself cannot be used to track the holder.
+      Preferring single-use [=verifiable credentials=] wherever possible also
+      assures [=E3|verifiers=] that the data is fresh and leaves attackers
+      nothing to steal.
+  - id: R2
+    name: Avoid Long-Lived Correlating Identifiers
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] avoid associating personally identifiable information with
+      any long-lived [=subject=] identifier, and avoid issuing [=credentials=]
+      whose reuse enables them to correlate patterns of use. These techniques
+      are not always practical or compatible with a required use, so some
+      correlation remains unavoidable.

--- a/threat-model/threats/t15-disclosure-to-malicious-verifier.yaml
+++ b/threat-model/threats/t15-disclosure-to-malicious-verifier.yaml
@@ -1,0 +1,29 @@
+id: T15
+name: Disclosure to a Malicious or Deceptive Verifier
+elements: [E2, E3, P8, F3]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Spoofing
+description: >-
+  When a [=E2|holder=] chooses to share information with a [=E3|verifier=], the
+  verifier can be acting in bad faith and request information that could harm
+  the holder. For example, a [=E3|verifier=] might ask for a bank account
+  number, which could then be combined with other information to defraud the
+  [=E2|holder=] or their bank. The data model describes the structure of a
+  [=verifiable presentation=] but does not by itself prevent a holder from
+  disclosing sensitive values to the wrong party, so this threat arises from the
+  interaction rather than from the specification.
+response:
+  - id: R1
+    name: Tokenize Sensitive Values
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] tokenize as much information as possible so that
+      accidentally transmitting a [=credential=] to the wrong [=E3|verifier=] is
+      not catastrophic. For example, instead of a bank account number, a bank
+      issues a [=verifiable credential=] containing a balance-checking token
+      that lets a [=verifier=] confirm a balance is above a threshold without
+      learning the account number or the exact balance, and the value of the
+      token is bounded by a short validity period. Even if the [=holder=] shares
+      the token with the wrong party, the attacker cannot recover the underlying
+      sensitive value.

--- a/threat-model/threats/t16-data-theft.yaml
+++ b/threat-model/threats/t16-data-theft.yaml
@@ -1,0 +1,40 @@
+id: T16
+name: Data Theft and Credential Honeypots
+elements: [E1, E2, E3, S1, S2, C1, C2, C3]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  The data expressed in [=verifiable credentials=] and [=verifiable
+  presentations=] is valuable because it contains authentic statements made by
+  trusted third parties or individuals. Storing and making this data accessible
+  can create honeypots of sensitive data that attract malicious actors seeking
+  to acquire and trade it for financial gain. An [=E1|issuer=] that retains more
+  data than necessary, a [=E2|holder=] that stores credentials on a poorly
+  protected device, or a [=E3|verifier=] that retains data beyond a
+  transaction's needs each increases the value and likelihood of a large-scale
+  theft. Whether this threat materializes depends on retention and protection
+  choices made across the ecosystem.
+response:
+  - id: R1
+    name: Minimize Retention
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] retain the minimum data necessary to issue [=credentials=]
+      and to manage their status and revocation, and avoid creating publicly
+      accessible credentials that include personally identifiable information.
+      [=E3|Verifiers=] ask only for data necessary for a particular transaction
+      and retain no data beyond its needs. Regulators reconsider audit
+      requirements that insist on long-term retention of personally identifiable
+      information, favoring privacy-preserving alternatives such as logging that
+      information was checked.
+  - id: R2
+    name: Encrypt and Control Access to Stored Data
+    type: Reduce
+    description: >-
+      Software implementers safeguard [=verifiable credentials=] with robust
+      consent and access-control measures so they remain inaccessible to
+      unauthorized entities. [=E2|Holders=] use implementations that encrypt
+      data in transit and at rest, protect cryptographic secrets so they cannot
+      be easily extracted from hardware, store and manipulate data on devices
+      they control, and grant access only to explicitly authorized parties.

--- a/threat-model/threats/t17-issuer-side-correlation.yaml
+++ b/threat-model/threats/t17-issuer-side-correlation.yaml
@@ -1,0 +1,40 @@
+id: T17
+name: Issuer-Side Correlation and Privacy Subversion
+elements: [E1, E2, P2, P3, P4, F2]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  Many privacy protections depend on active support from the [=E1|issuer=], and
+  on the issuer not deliberately subverting them. An [=E1|issuer=] that makes
+  its [=verifiable credentials=] short-lived with automatic renewal can
+  correlate a [=E2|holder's=] behavior by learning each time a credential is
+  renewed, even when the holder uses the credential without the issuer's direct
+  knowledge. An issuer can also undermine a protection it appears to offer; for
+  example, signing with a scheme that protects against signature-based
+  correlation while minting a unique key for each issued [=credential=], which
+  lets the issuer track [=presentations=] even though a [=E3|verifier=] cannot.
+  Finally, the identifiers and claim types an issuer chooses can leak data, such
+  as a driver's license revealing the issuer's jurisdiction and the
+  [=subject's=] residence. This threat depends on issuer behavior and is not
+  something the data model can prevent on its own.
+response:
+  - id: R1
+    name: Avoid Correlating Issuance Practices
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] avoid issuance practices that let them correlate patterns
+      of use, such as very short validity periods combined with automatic
+      renewal, and avoid minting a unique key per [=credential=] when using a
+      signature scheme intended to prevent signature-based correlation. Software
+      for [=E2|holders=] warns the holder when it repeatedly uses credentials
+      with short lifespans that could enable behavior correlation.
+  - id: R2
+    name: Mask Leaky Metadata
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] limit the data they leak through identifiers and claim
+      types, for example by using a shared [=issuer=] identifier at a state or
+      national level rather than one that reveals a smaller municipality.
+      [=E3|Verifiers=] use [=holder=] attestation mechanisms that prove an
+      [=issuer=] belongs to a trusted set without disclosing the exact issuer.

--- a/threat-model/threats/t18-signing-key-compromise.yaml
+++ b/threat-model/threats/t18-signing-key-compromise.yaml
@@ -1,0 +1,36 @@
+id: T18
+name: Signing Key Compromise and Mismanagement
+elements: [E1, P3, P10, S1, C1]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Spoofing
+description: >-
+  The authenticity and integrity guarantees of a [=verifiable credential=]
+  depend on the quality and protection of the private signing keys used to
+  secure it. A compromised private signing key lets an attacker forge
+  [=credentials=] that a [=P10|verify=] process reports as authentic. Poor key
+  management makes compromise more likely: reusing a private signing key for
+  more than one purpose, such as for both encryption and signing; keeping a key
+  in service for an over-long cryptoperiod; and using [=verification material=]
+  without first confirming its validity. This threat concerns how keys are
+  handled rather than whether the underlying algorithm is sound, which is
+  addressed by [[[#t5-cryptographic-suite-obsolescence]]].
+response:
+  - id: R1
+    name: Key Separation and Bounded Cryptoperiods
+    type: Reduce
+    description: >-
+      Operators follow established key-management guidance such as
+      [[NIST-SP-800-57-Part-1]]: a private signing key is used for a single
+      purpose and not, for example, for both signing and encryption, and private
+      signing keys and public verification keys are given limited cryptoperiods.
+      Bounding the cryptoperiod limits the window in which a compromised key can
+      be exploited.
+  - id: R2
+    name: Compromise Response and Material Validation
+    type: Reduce
+    description: >-
+      Operators put protective measures, harm-reduction steps, and revocation
+      procedures in place to deal with potential private key compromise, as
+      described in [[NIST-SP-800-57-Part-1]]. Before relying on any
+      [=verification material=], a [=P10|verify=] process confirms its validity.

--- a/threat-model/threats/t19-unprotected-external-resources.yaml
+++ b/threat-model/threats/t19-unprotected-external-resources.yaml
@@ -1,0 +1,39 @@
+id: T19
+name: Tampering with Unprotected External Resources
+elements: [P2, P10, P12, F2, C3]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Tampering
+description: >-
+  A [=verifiable credential=] often contains URLs to data that resides outside
+  the credential, such as images, JSON-LD extension contexts, JSON Schemas, and
+  other machine-readable data. Because this linked content lives outside the
+  protection of the [=securing mechanism=], it is not protected against
+  tampering. An attacker who modifies an external resource whose content affects
+  how a credential is processed can introduce vulnerabilities into a consumer's
+  application, even though the credential's own [=P10|verification=] still
+  succeeds. The specification leaves the choice of whether and how to protect
+  external resources to implementers.
+response:
+  - id: R1
+    name: Related Resource Integrity Protection
+    type: Reduce
+    description: >-
+      For external resources whose content changes could introduce security
+      vulnerabilities, implementers use the integrity-protection mechanism for
+      related resources defined by this specification, which binds a digest of
+      each external resource into the protected credential so that tampering is
+      detected. The mechanism is not needed for external resources that do not
+      affect the credential's security.
+  - id: R2
+    name: Use Known-Good Cached Values
+    type: Reduce
+    description: >-
+      For external references whose content is fixed and permanently cacheable,
+      such as JSON-LD context files and JSON Schemas, consumers resolve them
+      from a local store of known-good values rather than fetching them from the
+      network at processing time. Pinning these resources to vetted, immutable
+      copies removes the opportunity for an attacker to alter them and also
+      avoids the network request that would otherwise leak activity,
+      complementing the protections in
+      [[[#t10-device-tracking-and-fingerprinting]]].

--- a/threat-model/threats/t20-presentation-exchange-attacks.yaml
+++ b/threat-model/threats/t20-presentation-exchange-attacks.yaml
@@ -1,0 +1,47 @@
+id: T20
+name: Presentation Exchange Attacks (MITM, Replay, and Spoofing)
+elements: [E2, E3, P8, F3, P10, P12]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Spoofing
+description: >-
+  The data model does not by itself prevent man-in-the-middle, replay, and
+  spoofing attacks on the [=F3|exchange of a presentation=]. In a
+  man-in-the-middle attack, a [=E3|verifier=] cannot be sure it is the intended
+  recipient of a [=verifiable presentation=] rather than the target of an
+  adversary relaying it. In a replay attack, the same [=verifiable
+  presentation=] is reused, for example when multiple individuals present the
+  same credential representing an event ticket, undermining the ticket's
+  purpose. In a spoofing attack, the [=E3|verifier=] has no built-in way to
+  confirm that the [=E2|holder=] presenting the [=claims=] is authorized to do
+  so. Both online and offline exchanges can be susceptible, and an unsecured
+  protocol is susceptible to all three.
+response:
+  - id: R1
+    name: Bind the Presentation to Its Audience
+    type: Reduce
+    description: >-
+      To counter man-in-the-middle attacks, [=E3|verifiers=] use a
+      [=securing mechanism=] that lets a [=verifiable presentation=] specify its
+      intended audience or domain, as [[[VC-DATA-INTEGRITY]]] does, so a
+      presentation relayed to an unintended recipient is not accepted.
+      Approaches that tie the request for a presentation to the response further
+      secure the protocol.
+  - id: R2
+    name: Enforce Freshness to Prevent Replay
+    type: Reduce
+    description: >-
+      To counter replay attacks, [=E3|verifiers=] require [=E2|holders=] to
+      include additional measures in a [=verifiable presentation=], such as a
+      challenge supplied by the verifier whose uniqueness the verifier enforces,
+      or a validity period that limits the window during which the presentation
+      is accepted.
+  - id: R3
+    name: Bind the Presentation to the Holder
+    type: Reduce
+    description: >-
+      To counter spoofing, implementers explore methods that establish the
+      [=E2|holder's=] authority to present the [=claims=], such as binding
+      [=verifiable credentials=] to strong authentication mechanisms or using
+      additional properties in [=verifiable presentations=] that enable proof of
+      control.

--- a/threat-model/threats/t21-inappropriate-validity-periods.yaml
+++ b/threat-model/threats/t21-inappropriate-validity-periods.yaml
@@ -1,0 +1,27 @@
+id: T21
+name: Inappropriate Validity Periods
+elements: [E1, P2, P3, P10, P12]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Tampering
+description: >-
+  When a [=verifiable credential=] carries highly dynamic information, the
+  choice of validity period affects security. A validity period that extends
+  beyond the time the information is intended to be used leaves a window in
+  which a malicious actor can rely on stale information that no longer reflects
+  reality. A validity period shorter than the information's useful lifetime
+  places a burden on [=E2|holders=] and [=E3|verifiers=] through frequent
+  reissuance and checking. Setting a validity period that does not match the
+  volatility of the underlying information is therefore a source of risk. This
+  threat depends on choices an [=E1|issuer=] makes when it [=P2|assembles=] a
+  credential.
+response:
+  - id: R1
+    name: Match Validity Period to Information Lifetime
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] set the validity period of a [=verifiable credential=] to
+      match the use case and the expected lifetime of the information it
+      contains, so that highly dynamic information is not treated as current for
+      longer than it remains accurate, while stable information does not impose
+      unnecessary reissuance on [=E2|holders=] and [=E3|verifiers=].

--- a/threat-model/threats/t22-device-theft-and-impersonation.yaml
+++ b/threat-model/threats/t22-device-theft-and-impersonation.yaml
@@ -1,0 +1,34 @@
+id: T22
+name: Device Theft and Impersonation
+elements: [E2, P6, S2, P8, C2]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Spoofing
+description: >-
+  Storing [=verifiable credentials=] on a device poses a risk if the device is
+  lost or stolen. An attacker who gains possession of the device can gain
+  unauthorized access to systems that rely on the victim's [=verifiable
+  credentials=], impersonating the [=E2|holder=]. Impersonation also takes other
+  forms, including an [=entity=] attempting to disavow its own actions. This
+  threat arises from physical control of the [=C2|holder system=] rather than
+  from the data model itself.
+response:
+  - id: R1
+    name: Authentication and Hardware Protection
+    type: Reduce
+    description: >-
+      [=E2|Holders=] mitigate device theft by enabling screen-unlock protection
+      on the device such as a password, PIN, pattern, or biometric; by requiring
+      password, biometric, or multi-factor authentication for the
+      [=credential repository=] and when accessing cryptographic keys; and by
+      using a separate hardware-based signature device. These measures are
+      combined for stronger protection.
+  - id: R2
+    name: Non-Repudiation Mechanisms
+    type: Reduce
+    description: >-
+      Beyond preventing impersonation, implementers deploy non-repudiation
+      mechanisms that tie an [=entity=] to its actions, reinforcing
+      accountability and deterring an entity from disavowing them. These include
+      [=securing mechanisms=], proofs of possession, and authentication schemes
+      built into the surrounding protocols.

--- a/threat-model/threats/t23-unauthorized-post-presentation-use.yaml
+++ b/threat-model/threats/t23-unauthorized-post-presentation-use.yaml
@@ -1,0 +1,37 @@
+id: T23
+name: Unauthorized Post-Presentation Use of Data
+elements: [E2, E3, F3, P12]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Repudiation
+description: >-
+  After a [=E2|holder=] shares a [=verifiable presentation=] with a
+  [=E3|verifier=] for a stated purpose, the verifier can use that data beyond
+  the purpose the holder consented to. Consider a [=E2|holder=] who shares a
+  presentation to establish age and residency; if the [=E3|verifier=] then uses
+  the data without proper consent, such as selling it to a data broker, that is
+  an unauthorized use that violates the holder's expectation of privacy. A
+  [=E1|issuer=] can express, through a <code>termsOfUse</code> [=property=], how
+  and when a [=credential=] is permitted to be used, and use outside that scope
+  is unauthorized. The data model does not currently provide a way for a
+  [=E2|holder=] to enforce authorized use after [=presentation=], so this threat
+  is acknowledged as an area for further study.
+response:
+  - id: R1
+    name: Express Terms of Use
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] use a <code>termsOfUse</code> [=property=] to state the
+      scopes and purposes for which a [=credential=] is permitted to be used,
+      giving [=E3|verifiers=] and downstream parties a clear signal of what
+      constitutes authorized use and a basis on which unauthorized use can be
+      identified.
+  - id: R2
+    name: Accept Residual Enforcement Gap
+    type: Accept
+    description: >-
+      How a [=E2|holder=] can assert and enforce authorized use of their data
+      after [=presentation=] requires further study. Until such mechanisms
+      exist, the residual risk that a [=E3|verifier=] uses disclosed data
+      contrary to the holder's consent is acknowledged and accepted as outside
+      what the data model controls.

--- a/threat-model/threats/t24-inappropriate-use.yaml
+++ b/threat-model/threats/t24-inappropriate-use.yaml
@@ -1,0 +1,26 @@
+id: T24
+name: Inappropriate or Out-of-Context Credential Use
+elements: [E3, P10, P12]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Tampering
+description: >-
+  A valid cryptographic signature and a successful status check show that a
+  [=verifiable credential=] is authentic and unrevoked, but they do not show
+  that the credential is appropriate for the context in which it is being used.
+  A [=E3|verifier=] that treats verification as sufficient can accept a
+  credential whose source and nature do not fit the purpose at hand. For
+  example, a self-asserted [=credential=] carrying medical data can verify
+  correctly yet lack the authority required where a certified medical diagnosis
+  is needed. Not all [=credentials=] are interchangeable across contexts, and
+  relying on one outside its appropriate context is a validation failure.
+response:
+  - id: R1
+    name: Validate Fitness for Purpose
+    type: Reduce
+    description: >-
+      Beyond verifying a [=credential=], [=E3|verifiers=] [=P12|validate=] the
+      relevant [=claims=], weighing the source and nature of each [=claim=]
+      against the purpose for which the [=E2|holder=] presents the credential.
+      Verifiers assess whether the credential's authority is adequate for the
+      specific context of their intended application before relying on it.

--- a/threat-model/threats/t25-identity-proofing-failure.yaml
+++ b/threat-model/threats/t25-identity-proofing-failure.yaml
@@ -1,0 +1,42 @@
+id: T25
+name: Identity Proofing Failure at Issuance
+elements: [E1, E2, P1, F1, P2, P3]
+tags: [security]
+taxonomyName: STRIDE
+taxonomyClass: Spoofing
+description: >-
+  Before issuing a [=verifiable credential=], an [=E1|issuer=] carries out a
+  [=P1|establish confidence=] process to gain confidence in the identity or
+  attributes of a [=subject=]. When that process fails, the [=E1|issuer=] can
+  identify the individual incorrectly and issue a credential to the wrong
+  person. An attacker who presents another person's information during
+  [=F1|establish confidence in subject=], or who otherwise defeats weak
+  proofing, receives an authentic credential that names the victim as its
+  [=subject=]. Because the credential is genuinely issued and correctly
+  secured, every downstream [=P10|verification=] succeeds, and the attacker can
+  use it to impersonate the victim, effectively enlisting the [=E1|issuer=] as
+  an unwitting participant in identity theft. The strength of the proofing
+  process is a choice the [=E1|issuer=] makes and is not something the data
+  model can enforce on its own.
+response:
+  - id: R1
+    name: Rigorous Identity Proofing
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] establish confidence in a [=subject=] using an
+      identity-proofing process whose rigor matches the risk of the
+      [=credential=] being issued, following an established framework such as
+      the Identity Assurance Levels (IAL) defined in [[NIST-SP-800-63A]]. Higher
+      assurance levels call for stronger evidence and verification of the
+      claimed identity, reducing the chance that a credential is issued to
+      someone other than the person it names.
+  - id: R2
+    name: Match Assurance Level to Credential Risk
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] select the identity assurance level appropriate to how a
+      [=credential=] will be relied upon, and [=E3|verifiers=] take the
+      assurance level of the [=P1|establish confidence=] process into account
+      when they [=P12|validate=] a credential, rather than treating a successful
+      cryptographic [=P10|verification=] as evidence that the [=subject=] was
+      correctly identified at issuance.

--- a/threat-model/threats/t6-untrustworthy-user-agent-software.yaml
+++ b/threat-model/threats/t6-untrustworthy-user-agent-software.yaml
@@ -1,0 +1,41 @@
+id: T6
+name: Untrustworthy User-Agent Software
+elements: [E1, E2, E3, P7, P8, P9, C2]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  Each role in the ecosystem relies on software acting as its
+  <a href="https://www.w3.org/TR/UAAG20/#def-user-agent">user agent</a>: an
+  [=E1|issuer's=] issuance software, a [=E3|verifier's=] verification software,
+  and above all a [=E2|holder's=] digital wallet. A [=E2|holder=] trusts their
+  wallet to disclose information only when they consent to releasing it. When
+  that software operates against the user's interest, it betrays this trust, for
+  example by uploading a [=holder's=] personal information to a data broker, or
+  by disclosing more than the [=holder=] authorized while it
+  [=P8|generates a presentation=] or [=P7|engages in a workflow=]. A related
+  case arises when a single piece of software acts as a user agent to more than
+  one role at once, such as a website serving one [=E3|verifier=] and many
+  [=E2|holders=]; it cannot always act in the best interest of every party
+  simultaneously, and acts against some [=holders=] without their awareness.
+  Whether this threat is present depends on which software an entity chooses to
+  operate on its behalf, so it arises from deployment rather than from the data
+  model itself.
+response:
+  - id: R1
+    name: Trustworthy Software and Clear Consent
+    type: Reduce
+    description: >-
+      Implementers create software that operates in the user's best interests
+      and obtains the user's consent before disclosing information. When a piece
+      of software acts on behalf of more than one role, it makes clear in whose
+      interest it is operating, for example through a published use policy, so
+      the [=E2|holder=] understands the trust boundary they are relying on.
+  - id: R2
+    name: Auditing and User Oversight
+    type: Reduce
+    description: >-
+      Implementers include auditing features that let users, or trusted third
+      parties acting for them, verify that the software is operating in
+      alignment with their interests. Software that violates this expectation
+      loses user trust and is replaced with a more trustworthy alternative.

--- a/threat-model/threats/t7-excessive-data-disclosure.yaml
+++ b/threat-model/threats/t7-excessive-data-disclosure.yaml
@@ -1,0 +1,43 @@
+id: T7
+name: Excessive Data Disclosure
+elements: [E1, E2, E3, P2, P8, P9, F3]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  A [=verifiable credential=] can carry more personally identifiable
+  information than an interaction requires. An [=E1|issuer=] that
+  [=P2|assembles=] a credential containing specific data, such as a full date
+  of birth, a home address, or a driver's identification number, exposes the
+  [=subject=] to disclosure of that data whenever the credential is used, even
+  when the [=E3|verifier=] needs only a narrow fact such as whether the subject
+  is over a certain age. A [=E3|verifier=] that requests more than the minimum
+  necessary compounds the exposure and takes on liability for handling
+  sensitive data it does not need. Even data that appears innocuous, such as a
+  birthdate combined with a postal code, has strong de-anonymization power once
+  disclosed. This threat arises from choices made when credentials are designed
+  and when verifiers frame their requests, rather than from the data model
+  itself.
+response:
+  - id: R1
+    name: Abstract Claims and Selective Disclosure
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] limit the information in a [=verifiable credential=] to the
+      smallest set required for its intended purposes. One approach expresses an
+      abstract [=property=], such as <code>ageOver</code>, that answers a
+      [=E3|verifier's=] question without revealing the underlying sensitive
+      value such as a birthdate. Another approach atomizes the information or
+      uses a securing mechanism that supports [=selective disclosure=], so the
+      [=E2|holder=] discloses only the individual properties an interaction
+      requires.
+  - id: R2
+    name: Verifier Data Minimization
+    type: Reduce
+    description: >-
+      [=E3|Verifiers=] request only the information strictly necessary for a
+      specific transaction. This reduces the verifier's liability for handling
+      sensitive data and enhances the [=subject's=] and [=E2|holder's=] privacy.
+      Software for [=E2|holders=] discloses what a [=verifier=] is requesting so
+      the [=holder=] can decline to share information that is unnecessary, and
+      gives the [=holder=] access to a log of what was shared.

--- a/threat-model/threats/t8-signature-based-correlation.yaml
+++ b/threat-model/threats/t8-signature-based-correlation.yaml
@@ -1,0 +1,32 @@
+id: T8
+name: Signature-Based Correlation
+elements: [E1, E3, P8, F3, P10]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  The values that make up a [=securing mechanism=] on a [=verifiable
+  credential=] can themselves be correlating, independent of the claims they
+  protect. When the binary value of a digital signature, the timestamp
+  associated with its creation, or cryptographic material such as a public key
+  identifier remains the same across multiple sessions or domains, a
+  [=E3|verifier=] that receives the credential more than once, or two
+  [=E3|verifiers=] acting in collusion, can link those presentations to the same
+  [=E2|holder=] even when no correlating identifier appears in the payload. This
+  threat depends on the [=securing mechanism=] an [=E1|issuer=] chooses when it
+  [=P8|generates=] and secures a credential.
+response:
+  - id: R1
+    name: Unlinkable Disclosure
+    type: Reduce
+    description: >-
+      When strong anti-correlation properties are required, [=E1|issuers=]
+      produce [=verifiable credentials=] whose signature values and metadata are
+      regenerated for each [=verifiable presentation=], using a securing
+      mechanism that supports unlinkable disclosure such as [[[?VC-DI-BBS]]].
+      [=E3|Verifiers=] prefer [=verifiable presentations=] that use such
+      technology to enhance privacy for [=holders=] and [=subjects=]. Unlinkable
+      signatures do not remove correlation that comes from other information in
+      the credential, which is addressed by
+      [[[#t3-identifier-based-correlation]]] and
+      [[[#t7-excessive-data-disclosure]]].

--- a/threat-model/threats/t9-metadata-based-correlation.yaml
+++ b/threat-model/threats/t9-metadata-based-correlation.yaml
@@ -1,0 +1,27 @@
+id: T9
+name: Metadata-Based Correlation
+elements: [E1, E2, E3, P2, F3]
+tags: [privacy]
+taxonomyName: STRIDE
+taxonomyClass: Information Disclosure
+description: >-
+  The choice of extensions, types, and technology profiles used in a
+  [=verifiable credential=] can act as a correlating fingerprint when relatively
+  few [=E1|issuers=] use a specific combination. Cryptographic methods unique to
+  a particular nation-state, revocation formats specific to a jurisdiction, or
+  [=credential=] types employed only by a locality narrow the set of people a
+  given [=E2|holder=] could be, reducing the pseudonymity the holder expects
+  when selectively disclosing information to a [=E3|verifier=]. This threat
+  arises from choices an [=E1|issuer=] makes when it [=P2|assembles=] a
+  credential intended for pseudonymous use.
+response:
+  - id: R1
+    name: Prefer Widely Adopted Profiles
+    type: Reduce
+    description: >-
+      [=E1|Issuers=] issuing [=verifiable credentials=] intended for
+      pseudonymous use limit the extension types, [=credential=] types, and
+      technology profiles that could reduce a [=holder's=] pseudonymity. Choices
+      with global adoption are the most privacy-preserving, followed by those in
+      national use; choices with only local use offer the least pseudonymity
+      because they narrow the holder's anonymity set the most.


### PR DESCRIPTION
Attempt to address PR #1637 by refactoring the security and privacy considerations sections in the VCDM into the threat model. While the language had to be reworked a bit (some are threats, some are responses) to fit nicely into the way to do threat models, all the basic content should be the same (nothing really new, just re-stating what we've stated for many years now in the language of threat models).

This PR builds on top of PR #1638, which established the base threat model and data flow diagram. This PR purposefully does not delete any content from the VCDM. We will do that if this PR gets merged.